### PR TITLE
feat(start): unify Founder + Standard into single Foundry pipeline

### DIFF
--- a/skills/founder/SKILL.md
+++ b/skills/founder/SKILL.md
@@ -1,47 +1,37 @@
 ---
 name: founder
-description: "High-level autonomous system architect. Takes a minimal prompt and interrogates the user to define a production-grade Reward Function. It then uses MCTS and Dreaming to design, bootstrap, and launch a full self-healing implementation."
+description: "Foundry Strategic Dreaming Service. Provides the MCTS (Monte Carlo Tree Search) and Sandbox Simulation logic used by the 'start' skill to vet architectural design options before human approval."
 ---
 
-# dynos-work: Founder (The Strategic Core)
+# dynos-work: Founder (The Dreaming Engine)
 
-The "Unified Policy" for your autonomous software factory. It transforms a 10-word vision into a 1.0-Quality production system.
+The **Founder** is the strategic "Imagination" of the Foundry. It doesn't just write code; it simulates reality to prove which architectural path has the highest ROI.
 
-## What you do
+## **Service 1 — Strategic Interrogation (Insight Generation)**
 
-### Step 1 -- Strategic Discovery (The Interrogator)
+When called by `skills/start/SKILL.md` during discovery:
+1.  **Trajectory Search**: Use the **State Signature ($)** to retrieve the top 3 successful trajectories from `trajectories.json`.
+2.  **Gaps Search**: Identify the "High Entropy" (uncertain) parts of the prompt based on past failures in similar domains.
+3.  **Insight Output**: Provide the `start` skill with 3-5 targeted questions that will uncover hidden complexity.
 
-Stop! Do not start coding. 
-1. **Ambiguity Scan:** Identify the 3-5 most "Surprising" (High Entropy) parts of the prompt.
-2. **Q&A Loop:** Use `AskUserQuestion` to interview the user. Focus on:
-   - **Performance vs. Cost** (The Reward Function).
-   - **Security Thresholds** (The Risk Level).
-   - **Primary Use-Case** (The Goal).
+## **Service 2 — MCTS Architecture Playouts (Dreaming)**
 
-### Step 2 -- Pattern-Matched Bootstrapping (Experience Replay)
+When called to vet a **High-Risk Design Option**:
+1.  **The Sandbox**: Initialize a simulation environment at `/tmp/dynos-dream-{id}/`.
+2.  **Playout**: Draft the core implementation for the design option (e.g., "Architecture A: NoSQL").
+3.  **Autonomous Audit**: Run an Opus-level Security and Performance audit on the drafted code within the sandbox.
+4.  **Reward Attribution**: Calculate the **Discovery Reward** (How well did this architecture meet the implicit goals in simulation?).
 
-Based on the interview, scan the **Gold Standard Library** in `dynos_patterns.md`:
-1. **Architecture Selection:** Pick the most "Optimal" stack (e.g., Next.js, Postgres, Docker).
-2. **Dreaming (Scaffolding):**
-   - Create a **Simulation Sandbox** at `/tmp/dynos-bootstrap-{id}`.
-   - Generate the **Database Schema**, **Auth Layer**, and **API Interfaces** in one "Dream" passthrough.
-   - Run a **Security Audit** on the bootstrap code before presenting it.
+## **Service 3 — The Design Certificate**
 
-### Step 3 -- MCTS Feature Mapping (Product Backlog)
+For every vetted option, output a **Design Certificate** to be presented in the `start` skill's design-decisions gate:
+*   **Result**: PASS/FAIL.
+*   **Performance Metrics**: Instruction density, cyclomatic complexity, and dependency breadth.
+*   **Security Score**: Number of findings generated in the sandbox.
+*   **Recommendation**: "Elite", "Standard", or "High Risk."
 
-1. **Tree Search:** Use **MCTS** to "Look Ahead" into the project's future. 
-   - Propose a **Pruned Backlog** of 5-8 major features.
-   - For each feature, simulate a "Mini-Plan" and pick the one with the highest **Market Value/Token Cost** ratio.
-2. **Skeletal Graph:** Write the **Execution Graph Skeleton** to `.dynos/task-{id}/execution-graph-skeleton.json`.
+## **Hard Rules**
 
-### Step 4 -- Launch & Coordinate (The Macro-Policy)
-
-1. **Self-Healing Hand-off:** 
-   - Spawn the **Hierarchical Planner** (Master/Worker) for detailed specs.
-   - Trigger the **Optimized Scheduler** for parallel implementation.
-2. **The "Shadow" Guard:** As the Founder, monitor the whole lifecycle. If an auditor finds a "Critical" bug, you must re-intervene (The Self-Correction Loop).
-
-## Hard Rules
-- **No Boilerplate without Logic:** Every file created during bootstrapping must have working, verifiable code. No "TODO" comments.
-- **Security-First Bootstrapping:** Auth and DB layers must pass an Opus-level Security Audit as a prerequisite for any further coding.
-- **The "Dream" Threshold:** If the bootstrap code fails the sandbox audit, retry **one alternate architecture** branch from the MCTS tree before asking the user for help.
+- **Supportive, Not Bypassing**: The Founder never bypasses the Spec Review. It provides the **evidence** the user needs to approve the spec.
+- **Evidence-First**: Never recommend an architecture in the design phase unless a sandbox playout has been completed.
+- **RL-Guided**: Every simulation must be seeded with the "winning" actions from past trajectories to ensure continuous improvement.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,25 +1,17 @@
 ---
 name: start
-description: "High-level autonomous entry point. Supports 'Founder Mode' for minimal prompts (MCTS/Dreaming/Curiosity bootstrap) and standard 'Discovery' for detailed specs. Manages all human-in-the-loop gates before execution."
+description: "Unified Foundry entry point. Combines 'Founder Mode' strategic dreaming (MCTS/RL-informed) with rigorous 'Standard Mode' spec and plan gates. Every task goes through the full pipeline. Human approval is mandatory at Spec Review and Plan Review with no skip paths."
 ---
 
-# dynos-work: Start
+# dynos-work: Unified Foundry Start
 
 You are the entry point for dynos-work. You own all human-in-the-loop gates before execution. When done, the task is ready for `/dynos-work:execute`.
 
-## Phase 0 -- Founder Mode (Strategic Bootstrap)
+There is **one pipeline** for all tasks. There are no shortcuts. The Founder's dreaming power is embedded inside the standard discovery flow to give you **better choices**—not to skip your approval.
 
-If the user's **raw input** is minimal (typically < 50 words or a high-level vision):
+---
 
-1. **Trigger the Founder Skill (`skills/founder/SKILL.md`)**: Skip standard discovery and hand off the task to the **Founder (The Strategist).**
-2. **Goal:** The Founder will perform the **Strategic Interrogation**, architecture selection (from Gold Standards), and **Dreaming (Scaffolding)** in the sandbox.
-3. **Transition:** After the Founder completes the bootstrap, it returns the generated `spec.md` and `plan.md`. Move directly to **Step 6: Plan Review**.
-
-## Standard Mode (Discovery + Design)
-
-If the user's raw input is detailed, proceed with the standard pipeline below.
-
-### Step 1 — Initialize
+## Step 1 — Initialize
 
 1. Generate a task ID in the format `task-YYYYMMDD-NNN` (use today's date, increment NNN if directory exists)
 2. Create the task directory: `.dynos/task-{id}/`
@@ -49,15 +41,23 @@ Started: {ISO timestamp}
 ```
 6. Print:
 ```
-dynos-work: Task initialized
-ID: task-20260327-001
+dynos-work: Foundry Task Initialized
+ID: task-YYYYMMDD-NNN
 ```
 
-### Step 2 — Discovery + Design + Classification (single planner spawn)
+---
 
-**Spawn the Planner subagent** (dynos-work:planning) with instruction: "Phase: Discovery + Design + Classification (combined). Read `raw-input.md`. Perform all three phases in one pass:
+## Step 2 — RL-Informed Discovery + Design + Classification
 
-1. **Discovery:** Generate up to 5 targeted questions that would meaningfully improve understanding of the spec — gaps, ambiguities, trade-offs, unstated constraints. Do not ask obvious or trivial questions.
+**Before spawning the Planner**, run the **Decision Transformer pre-check** (in background):
+1. Spawn the **state-encoder** agent to produce a State Signature ($) for the current codebase module.
+2. Search `.dynos/trajectories.json` for the 3 most similar successful past trajectories.
+3. Extract known **failure points and winning patterns** from those trajectories.
+4. Pass this context into the Planner spawn as additional instruction.
+
+**Spawn the Planner subagent** (dynos-work:planning) with instruction: "Phase: Discovery + Design + Classification (combined). Read `raw-input.md`. Also read the attached trajectory context (failure points and winning patterns from similar past tasks). Perform all three phases in one pass:
+
+1. **Discovery:** Generate up to 5 targeted questions that would meaningfully improve understanding of the spec — gaps, ambiguities, trade-offs, unstated constraints. **RL-Informed:** Priority questions must target high-entropy areas identified from past trajectory failures in similar domains. Do not ask obvious or trivial questions.
 2. **Design Options:** Break the task into subtasks. Rate each: complexity (easy/medium/hard) and value (low/medium/high/critical). For any subtask rated hard complexity OR critical value, generate 2-3 design options with pros and cons. Decide easy/medium subtasks autonomously.
 3. **Classification:** Classify the task (type, domains, risk_level).
 
@@ -67,7 +67,25 @@ Return a structured response with three sections: Questions (numbered list), Des
 
 Write `.dynos/task-{id}/discovery-notes.md` with Q&A.
 
-**If hard/critical design options were returned**, present them to the user **one at a time** using **AskUserQuestion**. If no critical/hard subtasks, note autonomous decisions.
+**If hard/critical design options were returned**, run the **Founder Dreaming step** for each option:
+1. Spawn the **Founder (skills/founder/SKILL.md)** in Simulation mode for each high-risk design option.
+2. The Founder creates a sandbox at `/tmp/dynos-dream-{id}/`, drafts the core implementation, and runs an autonomous Opus-level Security audit.
+3. It returns a **Design Certificate** (PASS/FAIL, Security Score, Performance Metrics, Recommendation).
+
+**Present design options to the user one at a time** using **AskUserQuestion**, including the Design Certificate evidence:
+```
+=== Design Decision: {subtask name} ===
+
+Option A: {description}
+  Simulation Certificate: PASS | Security Score: 0 findings | Recommendation: Elite
+
+Option B: {description}  
+  Simulation Certificate: FAIL | Security Score: 3 findings | Recommendation: High Risk
+
+Which option do you prefer? (A / B / custom)
+```
+
+If no critical/hard subtasks: note autonomous decisions. Do not spawn the Founder for low/medium complexity subtasks.
 
 Write `.dynos/task-{id}/design-decisions.md` with decisions.
 
@@ -75,13 +93,16 @@ Write classification to `manifest.json` under the `classification` key.
 
 Append to log:
 ```
+{timestamp} [DT] state-encoder run — trajectory context attached
 {timestamp} [DONE] discovery + design + classification — notes, decisions, and classification written
 {timestamp} [STAGE] → CLASSIFY_AND_SPEC
 ```
 
 Update `manifest.json` stage to `CLASSIFY_AND_SPEC`.
 
-### Step 3 — Spec Normalization
+---
+
+## Step 3 — Spec Normalization
 
 **Spawn the Planner subagent** with instruction: "Phase: Spec Normalization. Read `raw-input.md`, `discovery-notes.md`, and `design-decisions.md`. Human design choices are binding. Write normalized spec with numbered acceptance criteria to `spec.md`."
 
@@ -95,9 +116,11 @@ Append to log:
 
 Update `manifest.json` stage to `SPEC_REVIEW`.
 
-### Step 4 — Spec Review (you run this, not a subagent)
+---
 
-**This gate always runs. There is no skip path.**
+## Step 4 — Spec Review (you run this, not a subagent)
+
+**THIS GATE ALWAYS RUNS. THERE IS NO SKIP PATH.**
 
 Read `spec.md` and `design-decisions.md`. Present to the user using **AskUserQuestion**:
 
@@ -121,22 +144,27 @@ Does this spec accurately capture what you want built?
 
 Update `manifest.json` stage to `PLANNING`.
 
-### Step 5 — Generate Plan + Execution Graph (PLANNING)
+---
+
+## Step 5 — Generate Plan + Execution Graph (PLANNING)
 
 Append to log:
 ```
 {timestamp} [STAGE] → PLANNING
 ```
 
-1. **Determine Planning Strategy:**
+1. **Determine Planning Strategy (RL-informed):**
+   - Consult the **Model & Skip Policy** table in `dynos_patterns.md` if available.
    - If `risk_level` is `high` or `critical` (from `manifest.json`), OR the `spec.md` contains more than `10` acceptance criteria: **Hierarchical Planning (Master/Worker)**.
    - Otherwise: **Standard Planning (Single-Planner)**.
+
 2. **Hierarchical Flow:**
    - **Spawn Master Planner (Opus):** Phase: "Strategic Implementation Planning (Master)". It writes the skeletal `plan.md` and `execution-graph-skeleton.json`.
    - **Spawn Worker Planners (Sonnet) in parallel:** One for each major segment defined in the skeleton. Phase: "Detailed Segment Planning (Worker)".
    - **Merge Results:** Combine the Strategic Plan with the Detailed Plans into the final `plan.md`. Merge all Worker segment objects into the final `execution-graph.json`.
+
 3. **Standard Flow:**
-   - **Spawn Planner (Opus):** Instruction: "Generate the implementation plan AND execution graph. Read `spec.md` and `design-decisions.md`. Human design choices are binding. Write `plan.md` and `execution-graph.json`."
+   - **Spawn Planner (Opus):** Instruction: "Generate the implementation plan AND execution graph. Read `spec.md` and `design-decisions.md`. Reference Gold Standard patterns from `dynos_patterns.md` if available. Human design choices are binding. Write `plan.md` and `execution-graph.json`."
 
 Wait for completion. Append to log:
 ```
@@ -146,7 +174,11 @@ Wait for completion. Append to log:
 
 Update `manifest.json` stage to `PLAN_REVIEW`.
 
-### Step 6 — Plan Review (you run this, not a subagent)
+---
+
+## Step 6 — Plan Review (you run this, not a subagent)
+
+**THIS GATE ALWAYS RUNS. THERE IS NO SKIP PATH.**
 
 Read `plan.md`. Present to the user using **AskUserQuestion**:
 
@@ -163,7 +195,9 @@ Approve this plan? (yes / no + what to change)
 - If **changes requested**: append `{timestamp} [HUMAN] PLAN_REVIEW — changes requested: {summary}` to log. Spawn Planner again with the feedback. Re-present the updated plan. Repeat until approved.
 - If **rejected**: set `manifest.json` stage to `FAILED`. Append `[FAILED] Plan rejected by user`. Stop.
 
-### Step 7 — Spec Coverage Audit (PLAN_AUDIT)
+---
+
+## Step 7 — Spec Coverage Audit (PLAN_AUDIT)
 
 Update `manifest.json` stage to `PLAN_AUDIT`. Append to log:
 ```
@@ -178,7 +212,9 @@ Wait for completion. Read the report.
 - If all criteria covered: append `{timestamp} [DONE] spec-completion-auditor — all criteria covered` to log. Proceed to Step 8.
 - If gaps found: append `{timestamp} [DECISION] plan gaps found — respawning planner to fill: {list}` to log. Spawn planning agent with instruction: "The plan is missing coverage for: [{uncovered criteria}]. Update `plan.md` and `execution-graph.json` to address them." Re-run the audit. Repeat until all covered.
 
-### Step 8 — Done
+---
+
+## Step 8 — Done
 
 Update `manifest.json` stage to `PRE_EXECUTION_SNAPSHOT`. Append to log:
 ```
@@ -187,14 +223,17 @@ Update `manifest.json` stage to `PRE_EXECUTION_SNAPSHOT`. Append to log:
 
 Print:
 ```
-Ready to execute.
+Foundry Ready to Execute.
 
-Task:  {task_id}
-Spec:  {N} acceptance criteria
-Plan:  approved and audited
+Task:   {task_id}
+Spec:   {N} acceptance criteria (human approved)
+Plan:   approved and audited (mode: {standard|hierarchical})
+Memory: {N} trajectories consulted
 
 Next: /dynos-work:execute
 ```
+
+---
 
 ## What you do NOT do
 
@@ -202,6 +241,18 @@ Next: /dynos-work:execute
 - You do not audit code
 - You do not decide when the task is done
 - You do not skip discovery, spec review, or plan review — ever
+- You do not let the Founder bypass the Spec Review gate — the Founder provides evidence, the human approves
+
+---
+
+## Hard Rules
+
+- **No Stealth Paths**: There is no "Phase 0 shortcut." All tasks follow Steps 1–8.
+- **RL-First**: Discovery questions and design options must be informed by trajectory memory before being presented to the user.
+- **Founder is a Consultant**: The Founder Dreaming step provides simulation certificates. It never skips or replaces Human Gate #2 or #3.
+- **Evidence-Based Decisions**: Design options presented to the user must include Simulation Certificate data for hard/critical subtasks.
+
+---
 
 ## If the user provides incomplete input
 


### PR DESCRIPTION
- Merged Phase 0 (Founder Mode) into the main discovery flow
- Added RL/DT-informed discovery via state-encoder + trajectory search
- Founder now acts as a Dreaming/Simulation consultant for hard/critical design options
- Returns Design Certificates (PASS/FAIL + security score) before user selects architecture
- Enforced mandatory Spec Review and Plan Review gates for all tasks — no skip paths
- Founder no longer bypasses human approval gates