### PR TITLE
[autofix] Syntax error in dynobench.py line 6: invalid syntax

### DIFF
--- a/hooks/dynobench.py
+++ b/hooks/dynobench.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent))
-import pithch pitch
 import argparse
 import json
 import os


### PR DESCRIPTION
## Autofix: Syntax error in dynobench.py line 6: invalid syntax

**Category:** syntax-error
**Severity:** medium

### Evidence
```json
{
  "file": "hooks/dynobench.py",
  "line": 6,
  "message": "invalid syntax",
  "text": "import pithch pitch"
}
```

Auto-generated by the dynos-work proactive scanner.