### PR TITLE
[autofix] Unused imports in dynopostmortem.py: apply_improvement

### DIFF
--- a/hooks/dynopostmortem.py
+++ b/hooks/dynopostmortem.py
@@ -376,7 +376,6 @@ def _render_markdown(pm: dict) -> str:
 # Auto-improvement engine (delegated to dynopostmortem_improve)
 # ---------------------------------------------------------------------------
 from dynopostmortem_improve import (  # noqa: E402
-    apply_improvement,
     cmd_approve,
     cmd_improve,
     cmd_list_pending,


### PR DESCRIPTION
## Autofix: Unused imports in dynopostmortem.py: apply_improvement

**Category:** dead-code
**Severity:** low

### Evidence
```json
{
  "file": "hooks/dynopostmortem.py",
  "unused_imports": [
    "apply_improvement"
  ]
}
```

Auto-generated by the dynos-work proactive scanner.