### PR TITLE
[autofix] Unused imports in dynosdream.py: re

### DIFF
--- a/hooks/dynosdream.py
+++ b/hooks/dynosdream.py
@@ -7,7 +7,6 @@ import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__)
 import argparse
 import json
 import random
-import re
 import shutil
 import tempfile
 from pathlib import Path


### PR DESCRIPTION
## Autofix: Unused imports in dynosdream.py: re

**Category:** dead-code
**Severity:** low

### Evidence
```json
{
  "file": "hooks/dynosdream.py",
  "unused_imports": [
    "re"
  ]
}
```

Auto-generated by the dynos-work proactive scanner.