### PR TITLE
[autofix] Potentially unreferenced function 'set_project_active' in dynoglobal.py

### DIFF
--- a/hooks/dynoglobal.py
+++ b/hooks/dynoglobal.py
@@ -182,11 +182,6 @@ def unregister_project(root: Path) -> dict:
     return reg
 
 
-def set_project_active(root: Path) -> dict:
-    """Mark project as active and update last_active_at."""
-    return set_project_status(root, "active")
-
-
 def set_project_status(root: Path, status: str) -> dict:
     """Set project status. Must be one of: active, paused, archived."""
     if status not in _VALID_STATUSES:

--- a/tests/test_dynoglobal.py
+++ b/tests/test_dynoglobal.py
@@ -138,12 +138,12 @@ class TestRegistryCRUD:
         set_project_status(proj, "active")  # no error
 
     def test_set_active_updates_last_active_at(self, tmp_path):
-        from dynoglobal import register_project, set_project_active, list_projects
+        from dynoglobal import register_project, set_project_status, list_projects
 
         proj = _make_project(tmp_path, "proj-a")
         register_project(proj)
         before = list_projects()[0]["last_active_at"]
-        set_project_active(proj)
+        set_project_status(proj, "active")
         after = list_projects()[0]["last_active_at"]
         assert after >= before
 


### PR DESCRIPTION
## Autofix: Potentially unreferenced function 'set_project_active' in dynoglobal.py

**Category:** dead-code
**Severity:** low

### Evidence
```json
{
  "function": "set_project_active",
  "defined_in": [
    "dynoglobal.py"
  ],
  "occurrence_count": 1
}
```

Auto-generated by the dynos-work proactive scanner.