### PR TITLE
[autofix][dead-code][low] Unused imports in dynoeventbus.py: find_active_tasks

### DIFF
--- a/hooks/dynoeventbus.py
+++ b/hooks/dynoeventbus.py
@@ -232,7 +232,7 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     if "task-completed" in summary:
         try:
             from dynoslib_receipts import receipt_post_completion
-            from dynoslib_core import find_active_tasks, load_json
+            from dynoslib_core import load_json
             # Find the most recently completed task to write the receipt to
             dynos_dir = root / ".dynos"
             task_dirs = sorted(dynos_dir.glob("task-*/manifest.json"), reverse=True)


### PR DESCRIPTION
## What's wrong

Unused imports in dynoeventbus.py: find_active_tasks

**Where:** `hooks/dynoeventbus.py`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoeventbus.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "hooks/dynoeventbus.py",
  "unused_imports": [
    "find_active_tasks"
  ]
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*