### PR TITLE
[autofix][dead-code][low] Unused imports in dynopostmortem.py: apply_improvement

### DIFF
--- a/hooks/dynopostmortem.py
+++ b/hooks/dynopostmortem.py
@@ -390,7 +390,6 @@ def _render_markdown(pm: dict) -> str:
 # Auto-improvement engine (delegated to dynopostmortem_improve)
 # ---------------------------------------------------------------------------
 from dynopostmortem_improve import (  # noqa: E402
-    apply_improvement,
     cmd_approve,
     cmd_improve,
     cmd_list_pending,

--- a/tests/test_policy_json.py
+++ b/tests/test_policy_json.py
@@ -521,7 +521,7 @@ class TestPostmortemWritesToModelPolicyJson(unittest.TestCase):
     def test_adjust_model_policy_writes_model_policy_json(self) -> None:
         """adjust_model_policy action writes entries to model-policy.json with source postmortem_recommendation."""
         from dynoslib import _persistent_project_dir, write_json
-        from dynopostmortem import apply_improvement
+        from dynopostmortem_improve import apply_improvement
 
         persistent = _persistent_project_dir(self.root)
         # Initialize empty policy.json
@@ -552,7 +552,7 @@ class TestPostmortemWritesToModelPolicyJson(unittest.TestCase):
     def test_adjust_model_policy_preserves_explicit_policy_entries(self) -> None:
         """Postmortem recommendations do not overwrite existing explicit_policy entries."""
         from dynoslib import _persistent_project_dir, write_json
-        from dynopostmortem import apply_improvement
+        from dynopostmortem_improve import apply_improvement
 
         persistent = _persistent_project_dir(self.root)
         write_json(persistent / "policy.json", {})


### PR DESCRIPTION
## What's wrong

Unused imports in dynopostmortem.py: apply_improvement

**Where:** `hooks/dynopostmortem.py`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynopostmortem.py   | 1 -
 tests/test_policy_json.py | 4 ++--
 2 files changed, 2 insertions(+), 3 deletions(-)
```

## Evidence

```json
{
  "file": "hooks/dynopostmortem.py",
  "unused_imports": [
    "apply_improvement"
  ]
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*