### PR TITLE
[autofix][dead-code][low] Unused imports in dynoslib_core.py: validate_chain

### DIFF
--- a/hooks/dynoslib_core.py
+++ b/hooks/dynoslib_core.py
@@ -278,7 +278,7 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
         raise ValueError(f"Illegal stage transition: {current_stage} -> {next_stage}")
     # ---- Receipt-based transition gates (unmissable) ----
     if not force:
-        from dynoslib_receipts import read_receipt, validate_chain
+        from dynoslib_receipts import read_receipt
         gate_errors: list[str] = []
 
         # EXECUTION requires plan-validated receipt


### PR DESCRIPTION
## What's wrong

Unused imports in dynoslib_core.py: validate_chain

**Where:** `hooks/dynoslib_core.py`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoslib_core.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Evidence

```json
{
  "file": "hooks/dynoslib_core.py",
  "unused_imports": [
    "validate_chain"
  ]
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*