### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'global_policy_path' in dynoglobal.py

### DIFF
--- a/hooks/dynoglobal.py
+++ b/hooks/dynoglobal.py
@@ -68,10 +68,6 @@ def registry_path() -> Path:
     return global_home() / "registry.json"
 
 
-def global_policy_path() -> Path:
-    return global_home() / "policy" / "global-policy.json"
-
-
 def patterns_dir() -> Path:
     return global_home() / "patterns"
 


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'global_policy_path' in dynoglobal.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoglobal.py | 4 ----
 1 file changed, 4 deletions(-)
```

## Evidence

```json
{
  "function": "global_policy_path",
  "defined_in": [
    "dynoglobal.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*