### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'require_receipts' in dynoslib_receipts.py

### DIFF
--- a/hooks/dynoslib_receipts.py
+++ b/hooks/dynoslib_receipts.py
@@ -145,14 +145,6 @@ def require_receipt(task_dir: Path, step_name: str) -> dict:
     return receipt
 
 
-def require_receipts(task_dir: Path, step_names: list[str]) -> dict[str, dict]:
-    """Validate multiple receipts exist. Returns all receipts or raises on first missing."""
-    results = {}
-    for name in step_names:
-        results[name] = require_receipt(task_dir, name)
-    return results
-
-
 def validate_chain(task_dir: Path) -> list[str]:
     """Validate the entire receipt chain for a task. Returns list of gaps.
 


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'require_receipts' in dynoslib_receipts.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoslib_receipts.py | 8 --------
 1 file changed, 8 deletions(-)
```

## Evidence

```json
{
  "function": "require_receipts",
  "defined_in": [
    "dynoslib_receipts.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*