### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'hash_file' in dynoslib_receipts.py

### DIFF
--- a/hooks/dynoslib_receipts.py
+++ b/hooks/dynoslib_receipts.py
@@ -7,7 +7,6 @@ The next step refuses to proceed unless the prior receipt exists.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import sys
 from pathlib import Path
@@ -218,14 +217,6 @@ def validate_chain(task_dir: Path) -> list[str]:
                         gaps.append(f"audit-{name}")
 
     return gaps
-
-
-def hash_file(path: Path) -> str | None:
-    """SHA256 hash of a file's contents. Returns None if file doesn't exist."""
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
-    except (OSError, FileNotFoundError):
-        return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'hash_file' in dynoslib_receipts.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoslib_receipts.py | 8 --------
 1 file changed, 8 deletions(-)
```

## Evidence

```json
{
  "function": "hash_file",
  "defined_in": [
    "dynoslib_receipts.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*