### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'receipt_plan_routing' in dynoslib_receipts.py

### DIFF
--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -292,7 +292,6 @@ All receipts at `.dynos/task-{id}/receipts/{step-name}.json`.
 
 | Receipt | Written by | Gates which transition |
 |---|---|---|
-| `plan-routing` | `receipt_plan_routing()` | Advisory |
 | `planner-discovery` | `receipt_planner_spawn("discovery")` | Advisory |
 | `planner-spec` | `receipt_planner_spawn("spec")` | Advisory |
 | `spec-validated` | `receipt_spec_validated()` | Advisory |

--- a/hooks/dynoslib_receipts.py
+++ b/hooks/dynoslib_receipts.py
@@ -233,24 +233,6 @@ def hash_file(path: Path) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def receipt_plan_routing(
-    task_dir: Path,
-    agent_name: str | None,
-    agent_path: str | None,
-    route_mode: str,
-    agent_file_hash: str | None = None,
-) -> Path:
-    """Write receipt proving plan-skill routing was resolved."""
-    return write_receipt(
-        task_dir,
-        "plan-routing",
-        agent_name=agent_name,
-        agent_path=agent_path,
-        route_mode=route_mode,
-        agent_content_hash=agent_file_hash,
-    )
-
-
 def receipt_spec_validated(
     task_dir: Path,
     criteria_count: int,


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'receipt_plan_routing' in dynoslib_receipts.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
docs/pipeline-reference.md |  1 -
 hooks/dynoslib_receipts.py | 18 ------------------
 2 files changed, 19 deletions(-)
```

## Evidence

```json
{
  "function": "receipt_plan_routing",
  "defined_in": [
    "dynoslib_receipts.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*