### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'receipt_audit_routing' in dynoslib_receipts.p

### DIFF
--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -302,7 +302,7 @@ All receipts at `.dynos/task-{id}/receipts/{step-name}.json`.
 | `tdd-tests` | `receipt_tdd_tests()` | Advisory |
 | **`executor-routing`** | `receipt_executor_routing()` | **→ CHECKPOINT_AUDIT** |
 | `executor-{seg-id}` | `receipt_executor_done()` | `validate_chain()` |
-| `audit-routing` | `receipt_audit_routing()` | `validate_chain()` |
+| `audit-routing` | `write_receipt()` | `validate_chain()` |
 | `audit-{auditor}` | `receipt_audit_done()` | `validate_chain()` at DONE |
 | **`retrospective`** | `receipt_retrospective()` | **→ DONE** |
 | **`post-completion`** | `receipt_post_completion()` | **→ DONE** |

--- a/hooks/dynoslib_receipts.py
+++ b/hooks/dynoslib_receipts.py
@@ -325,18 +325,6 @@ def receipt_executor_done(
     )
 
 
-def receipt_audit_routing(
-    task_dir: Path,
-    auditors: list[dict],
-) -> Path:
-    """Write receipt proving all auditor routing decisions were made."""
-    return write_receipt(
-        task_dir,
-        "audit-routing",
-        auditors=auditors,
-    )
-
-
 def receipt_audit_done(
     task_dir: Path,
     auditor_name: str,


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'receipt_audit_routing' in dynoslib_receipts.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the dynos-work autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
docs/pipeline-reference.md |  1 -
 hooks/dynoslib_receipts.py | 12 ------------
 2 files changed, 13 deletions(-)
```

## Evidence

```json
{
  "function": "receipt_audit_routing",
  "defined_in": [
    "dynoslib_receipts.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [dynos-work](https://github.com/dynos-fit/dynos-work) proactive scanner.*