### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'receipt_spec_validated' in dynoslib_receipts.

### DIFF
--- a/docs/pipeline-reference.md
+++ b/docs/pipeline-reference.md
@@ -295,7 +295,7 @@ All receipts at `.dynos/task-{id}/receipts/{step-name}.json`.
 | `plan-routing` | `receipt_plan_routing()` | Advisory |
 | `planner-discovery` | `receipt_planner_spawn("discovery")` | Advisory |
 | `planner-spec` | `receipt_planner_spawn("spec")` | Advisory |
-| `spec-validated` | `receipt_spec_validated()` | Advisory |
+| `spec-validated` | `write_receipt(task_dir, "spec-validated", ...)` | Advisory |
 | `planner-plan` | `receipt_planner_spawn("plan")` | Advisory |
 | **`plan-validated`** | `receipt_plan_validated()` | **→ EXECUTION** |
 | `plan-audit-check` | `receipt_plan_audit()` | Advisory |

--- a/hooks/dynoslib_receipts.py
+++ b/hooks/dynoslib_receipts.py
@@ -251,20 +251,6 @@ def receipt_plan_routing(
     )
 
 
-def receipt_spec_validated(
-    task_dir: Path,
-    criteria_count: int,
-    validation_passed: bool = True,
-) -> Path:
-    """Write receipt proving spec passed deterministic validation."""
-    return write_receipt(
-        task_dir,
-        "spec-validated",
-        criteria_count=criteria_count,
-        validation_passed=validation_passed,
-    )
-
-
 def receipt_plan_validated(
     task_dir: Path,
     segment_count: int,


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'receipt_spec_validated' in dynoslib_receipts.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
docs/pipeline-reference.md |  2 +-
 hooks/dynoslib_receipts.py | 14 --------------
 2 files changed, 1 insertion(+), 15 deletions(-)
```

## Evidence

```json
{
  "function": "receipt_spec_validated",
  "defined_in": [
    "dynoslib_receipts.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*