### PR TITLE
[autofix][dead-code][low] Potentially unreferenced function 'estimate_token_breakdown' in dynoslib_traject

### DIFF
--- a/hooks/dynoslib_trajectory.py
+++ b/hooks/dynoslib_trajectory.py
@@ -62,20 +62,6 @@ def estimate_token_usage(subagent_spawn_count: int, model_used_by_agent: dict) -
     return max(1, int(subagent_spawn_count or 0)) * TOKEN_ESTIMATES["default"]
 
 
-# Rough input/output ratio by model (input-heavy due to context loading)
-INPUT_OUTPUT_RATIOS: dict[str, float] = {"opus": 0.70, "sonnet": 0.65, "haiku": 0.60, "default": 0.65}
-
-
-def estimate_token_breakdown(total: int, model: str | None = None) -> tuple[int, int]:
-    """Estimate input/output split from a total token count.
-
-    Returns (input_tokens, output_tokens).
-    """
-    ratio = INPUT_OUTPUT_RATIOS.get(model or "default", INPUT_OUTPUT_RATIOS["default"])
-    input_tokens = int(total * ratio)
-    return input_tokens, total - input_tokens
-
-
 def load_token_usage(task_dir: Path) -> dict:
     """Read token-usage.json written by the audit/execute skills during subagent spawns.
 


### PR DESCRIPTION
## What's wrong

Potentially unreferenced function 'estimate_token_breakdown' in dynoslib_trajectory.py

**Where:** `unknown file`
**Severity:** low

## What this PR does

Fixes the issue above. The change was generated by the autofix scanner and verified by running the foundry pipeline (spec -> plan -> execute -> audit).

## Changes

```
hooks/dynoslib_trajectory.py | 14 --------------
 1 file changed, 14 deletions(-)
```

## Evidence

```json
{
  "function": "estimate_token_breakdown",
  "defined_in": [
    "dynoslib_trajectory.py"
  ],
  "occurrence_count": 1
}
```

---
*Auto-generated by [autofix-scanner](https://github.com/dynos-fit/autofix) proactive scanner.*