### PR TITLE
[feat] PR #8 — hooks/verify_behavior_preserved.py

### DIFF
--- a/hooks/verify_behavior_preserved.py
+++ b/hooks/verify_behavior_preserved.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Run a project's test suite at two git refs and assert no regression.
+
+Catches refactors that silently change behavior. Pairs naturally with
+`agents/refactor-executor.md`: refactor agents promise "no behavior change",
+but they're prone to regressions that LLM auditors miss. A real test runner
+is the deterministic ground truth.
+
+How it works:
+  1. Create a temporary git worktree at the BEFORE ref.
+  2. Run the test suite there — capture passing test IDs.
+  3. Create a temporary git worktree at the AFTER ref.
+  4. Run the same test suite — capture passing test IDs.
+  5. Diff: any test that passed BEFORE and fails (or is missing) AFTER is a
+     regression.
+  6. Cleanup worktrees.
+  7. Exit 0 if no regressions, 1 if regressions found, 2 if can't run.
+
+Why git worktrees and not `git stash` + `git checkout`:
+  - No risk to the user's working tree (no stash needed).
+  - Safe under interrupt — worktrees are independent dirs.
+  - Cleanup is `git worktree remove` (atomic).
+
+Usage:
+    python3 hooks/verify_behavior_preserved.py --before HEAD~1 --after HEAD
+    python3 hooks/verify_behavior_preserved.py --before main --after my-branch
+    python3 hooks/verify_behavior_preserved.py --before HEAD~5 --after HEAD --command "pytest tests/unit/"
+    python3 hooks/verify_behavior_preserved.py --before HEAD~1 --after HEAD --json
+
+Test framework auto-detection (override with --command):
+  - pytest.ini / pyproject.toml [tool.pytest] / setup.cfg [tool:pytest] -> pytest tests/
+  - package.json with a "test" script -> npm test
+  - Cargo.toml -> cargo test
+  - go.mod -> go test ./...
+
+Exit codes:
+    0 — no regressions (every passing test in BEFORE still passes in AFTER)
+    1 — at least one regression (test passed before, fails or missing after)
+    2 — could not run (bad refs, no test framework, worktree failure)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Worktree management
+# ---------------------------------------------------------------------------
+
+class WorktreeFailure(Exception):
+    """Raised when a worktree operation fails — caller should report exit 2."""
+
+
+def create_worktree(repo: Path, ref: str, dest: Path) -> None:
+    """Create a detached worktree at `dest` checked out at `ref`.
+
+    Detached so the worktree doesn't claim the branch — the original repo
+    keeps full control of branches and HEAD.
+    """
+    r = subprocess.run(
+        ["git", "worktree", "add", "--detach", str(dest), ref],
+        cwd=repo, capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise WorktreeFailure(
+            f"worktree add failed for ref {ref!r}: {r.stderr.strip()}"
+        )
+
+
+def remove_worktree(repo: Path, dest: Path) -> None:
+    """Remove the worktree (best-effort — log but don't raise on cleanup failure)."""
+    if not dest.exists():
+        return
+    r = subprocess.run(
+        ["git", "worktree", "remove", "--force", str(dest)],
+        cwd=repo, capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        # Manual cleanup if git itself can't
+        try:
+            shutil.rmtree(dest, ignore_errors=True)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test framework detection
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TestFramework:
+    name: str               # "pytest", "npm", "cargo", "go"
+    command: list[str]      # argv
+    parser: str             # which parser to use on output
+
+
+def detect_framework(worktree: Path) -> TestFramework | None:
+    """Look at the worktree contents to guess the right test runner."""
+    if (worktree / "pytest.ini").exists():
+        return TestFramework("pytest", ["pytest", "tests/", "-v", "--tb=no"], "pytest")
+    pyproject = worktree / "pyproject.toml"
+    if pyproject.exists():
+        text = pyproject.read_text()
+        if "[tool.pytest" in text or '"pytest"' in text or "'pytest'" in text:
+            return TestFramework("pytest", ["pytest", "tests/", "-v", "--tb=no"], "pytest")
+    if (worktree / "setup.cfg").exists():
+        text = (worktree / "setup.cfg").read_text()
+        if "[tool:pytest]" in text:
+            return TestFramework("pytest", ["pytest", "tests/", "-v", "--tb=no"], "pytest")
+    # Default: if there's a tests/ dir of .py files, assume pytest is intended.
+    if (worktree / "tests").exists() and any(
+        (worktree / "tests").rglob("test_*.py")
+    ):
+        return TestFramework("pytest", ["pytest", "tests/", "-v", "--tb=no"], "pytest")
+    pkg = worktree / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text())
+            if "scripts" in data and "test" in data["scripts"]:
+                return TestFramework("npm", ["npm", "test", "--silent"], "generic")
+        except json.JSONDecodeError:
+            pass
+    if (worktree / "Cargo.toml").exists():
+        return TestFramework("cargo", ["cargo", "test", "--quiet"], "generic")
+    if (worktree / "go.mod").exists():
+        return TestFramework("go", ["go", "test", "./..."], "generic")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Run + parse
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RunResult:
+    ref: str
+    framework: str
+    passing: set[str]       # test IDs that passed
+    failing: set[str]       # test IDs that failed
+    skipped: set[str]       # test IDs that were skipped
+    error: str | None       # populated if framework couldn't run at all
+
+
+# pytest "PASSED" / "FAILED" lines look like:
+#   tests/test_foo.py::TestBar::test_baz PASSED                        [ 5%]
+#   tests/test_foo.py::TestBar::test_qux FAILED                        [ 6%]
+PYTEST_LINE_RE = re.compile(
+    r"^(?P<id>\S+)\s+(?P<status>PASSED|FAILED|SKIPPED|ERROR|XFAIL|XPASS)",
+    re.MULTILINE,
+)
+
+
+def parse_pytest(stdout: str) -> tuple[set[str], set[str], set[str]]:
+    passing: set[str] = set()
+    failing: set[str] = set()
+    skipped: set[str] = set()
+    for m in PYTEST_LINE_RE.finditer(stdout):
+        test_id, status = m.group("id"), m.group("status")
+        if status in ("PASSED", "XPASS"):
+            passing.add(test_id)
+        elif status in ("FAILED", "ERROR", "XFAIL"):
+            failing.add(test_id)
+        elif status == "SKIPPED":
+            skipped.add(test_id)
+    return passing, failing, skipped
+
+
+def parse_generic(stdout: str, returncode: int) -> tuple[set[str], set[str], set[str]]:
+    """For frameworks where we don't have a per-test ID parser yet, treat the
+    overall return code as a single 'composite' test."""
+    if returncode == 0:
+        return {"<all tests passed>"}, set(), set()
+    return set(), {"<test suite failed>"}, set()
+
+
+def run_at_worktree(
+    worktree: Path, ref: str, command: list[str] | None
+) -> RunResult:
+    if command is None:
+        fw = detect_framework(worktree)
+        if fw is None:
+            return RunResult(
+                ref=ref, framework="unknown",
+                passing=set(), failing=set(), skipped=set(),
+                error="no test framework auto-detected (pass --command)",
+            )
+        cmd = fw.command
+        parser = fw.parser
+        framework_name = fw.name
+    else:
+        cmd = command
+        parser = "pytest" if cmd and cmd[0] == "pytest" else "generic"
+        framework_name = cmd[0] if cmd else "custom"
+
+    try:
+        r = subprocess.run(
+            cmd, cwd=worktree, capture_output=True, text=True, timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return RunResult(
+            ref=ref, framework=framework_name,
+            passing=set(), failing=set(), skipped=set(),
+            error="test run timed out (>600s)",
+        )
+    except FileNotFoundError as e:
+        return RunResult(
+            ref=ref, framework=framework_name,
+            passing=set(), failing=set(), skipped=set(),
+            error=f"test runner not found: {e}",
+        )
+
+    if parser == "pytest":
+        passing, failing, skipped = parse_pytest(r.stdout)
+    else:
+        passing, failing, skipped = parse_generic(r.stdout, r.returncode)
+
+    return RunResult(
+        ref=ref, framework=framework_name,
+        passing=passing, failing=failing, skipped=skipped, error=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diff + report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiffReport:
+    before_ref: str
+    after_ref: str
+    framework: str
+    before_passing: int
+    after_passing: int
+    regressions: list[str]   # passed before, fails/missing after
+    new_passes: list[str]    # not passing before, passing after (informational)
+    no_longer_run: list[str] # passed before, doesn't appear in after results
+
+
+def diff_runs(before: RunResult, after: RunResult) -> DiffReport:
+    regressions = sorted(
+        # Tests that passed BEFORE but now fail
+        (before.passing & after.failing)
+        # Tests that passed BEFORE but no longer appear (deleted? renamed?)
+        | (before.passing - after.passing - after.failing - after.skipped)
+    )
+    # New passes = anything passing after that wasn't passing before. Includes
+    # previously-failing tests that got fixed (a positive signal, worth surfacing).
+    new_passes = sorted(after.passing - before.passing)
+    no_longer_run = sorted(
+        before.passing - after.passing - after.failing - after.skipped
+    )
+    return DiffReport(
+        before_ref=before.ref,
+        after_ref=after.ref,
+        framework=before.framework,
+        before_passing=len(before.passing),
+        after_passing=len(after.passing),
+        regressions=regressions,
+        new_passes=new_passes,
+        no_longer_run=no_longer_run,
+    )
+
+
+def render_human(report: DiffReport, before: RunResult, after: RunResult) -> str:
+    lines = [
+        f"Before ({report.before_ref}): {report.before_passing} passing",
+        f"After  ({report.after_ref}): {report.after_passing} passing",
+        f"Framework: {report.framework}",
+        "",
+    ]
+    if report.regressions:
+        lines.append(f"REGRESSIONS ({len(report.regressions)}):")
+        for r in report.regressions:
+            tag = " (no longer run)" if r in report.no_longer_run else ""
+            lines.append(f"  - {r}{tag}")
+        lines.append("")
+    else:
+        lines.append("No regressions.")
+        lines.append("")
+    if report.new_passes:
+        lines.append(f"New passes ({len(report.new_passes)}):")
+        for r in report.new_passes[:10]:
+            lines.append(f"  + {r}")
+        if len(report.new_passes) > 10:
+            lines.append(f"  ... ({len(report.new_passes) - 10} more)")
+    return "\n".join(lines)
+
+
+def render_json(report: DiffReport) -> str:
+    return json.dumps(asdict(report), indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Run tests at two git refs and assert no regression."
+    )
+    ap.add_argument("--before", required=True,
+                    help="Git ref for the BEFORE state (e.g. HEAD~1, main, abc123)")
+    ap.add_argument("--after", required=True,
+                    help="Git ref for the AFTER state (e.g. HEAD, my-branch)")
+    ap.add_argument("--repo", type=Path, default=Path.cwd(),
+                    help="Repo root (default: cwd)")
+    ap.add_argument("--command", nargs="+",
+                    help="Override test command (e.g. --command pytest tests/unit)")
+    ap.add_argument("--json", action="store_true",
+                    help="Emit JSON instead of human report.")
+    args = ap.parse_args()
+
+    repo = args.repo.resolve()
+    if not (repo / ".git").exists():
+        print(f"not a git repo: {repo}", file=sys.stderr)
+        return 2
+
+    # Validate refs exist before doing expensive worktree work
+    for ref in (args.before, args.after):
+        r = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", ref],
+            cwd=repo, capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            print(f"git ref not found: {ref}", file=sys.stderr)
+            return 2
+
+    # Create temp dirs for both worktrees
+    base_tmp = Path(tempfile.mkdtemp(prefix="dynos-verify-"))
+    before_dir = base_tmp / "before"
+    after_dir = base_tmp / "after"
+
+    try:
+        try:
+            create_worktree(repo, args.before, before_dir)
+            create_worktree(repo, args.after, after_dir)
+        except WorktreeFailure as e:
+            print(f"worktree setup failed: {e}", file=sys.stderr)
+            return 2
+
+        before_run = run_at_worktree(before_dir, args.before, args.command)
+        after_run = run_at_worktree(after_dir, args.after, args.command)
+
+        if before_run.error or after_run.error:
+            err = before_run.error or after_run.error
+            print(f"could not run tests: {err}", file=sys.stderr)
+            return 2
+
+        report = diff_runs(before_run, after_run)
+        if args.json:
+            print(render_json(report))
+        else:
+            print(render_human(report, before_run, after_run))
+
+        return 1 if report.regressions else 0
+    finally:
+        # Always clean up worktrees and temp dir, even on error
+        remove_worktree(repo, before_dir)
+        remove_worktree(repo, after_dir)
+        try:
+            shutil.rmtree(base_tmp, ignore_errors=True)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verify_behavior_preserved.py
+++ b/tests/test_verify_behavior_preserved.py
@@ -1,0 +1,293 @@
+"""Tests for hooks/verify_behavior_preserved.py.
+
+Strategy:
+  - Pure-function tests for parse_pytest, diff_runs, detect_framework,
+    render_human / render_json — these run fast and need no git state.
+  - End-to-end test creates a tiny throwaway git repo with two commits and
+    runs verify against it. Slower but real.
+
+We mock subprocess for the worktree + test-runner integration paths because
+running pytest inside pytest is tricky and slow.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Make hooks/ importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+import verify_behavior_preserved as vbp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_pytest
+# ---------------------------------------------------------------------------
+
+class TestParsePytest:
+    def test_extracts_passing_and_failing(self) -> None:
+        out = textwrap.dedent("""
+            tests/test_a.py::test_one PASSED                                 [ 33%]
+            tests/test_a.py::test_two FAILED                                 [ 66%]
+            tests/test_b.py::TestX::test_three PASSED                        [100%]
+        """)
+        passing, failing, skipped = vbp.parse_pytest(out)
+        assert passing == {"tests/test_a.py::test_one", "tests/test_b.py::TestX::test_three"}
+        assert failing == {"tests/test_a.py::test_two"}
+        assert skipped == set()
+
+    def test_handles_skipped(self) -> None:
+        out = "tests/test_a.py::test_x SKIPPED                              [100%]\n"
+        passing, failing, skipped = vbp.parse_pytest(out)
+        assert skipped == {"tests/test_a.py::test_x"}
+        assert passing == set()
+        assert failing == set()
+
+    def test_xfail_treated_as_failing(self) -> None:
+        out = "tests/test_a.py::test_x XFAIL                                 [100%]\n"
+        passing, failing, _ = vbp.parse_pytest(out)
+        assert failing == {"tests/test_a.py::test_x"}
+
+    def test_empty_output(self) -> None:
+        passing, failing, skipped = vbp.parse_pytest("")
+        assert passing == set() and failing == set() and skipped == set()
+
+
+# ---------------------------------------------------------------------------
+# diff_runs
+# ---------------------------------------------------------------------------
+
+class TestDiffRuns:
+    def _make(self, ref: str, passing: set[str], failing: set[str] = None) -> vbp.RunResult:
+        return vbp.RunResult(
+            ref=ref, framework="pytest",
+            passing=passing, failing=failing or set(), skipped=set(),
+            error=None,
+        )
+
+    def test_no_regressions_when_same_tests_pass(self) -> None:
+        before = self._make("HEAD~1", {"a", "b", "c"})
+        after = self._make("HEAD", {"a", "b", "c"})
+        report = vbp.diff_runs(before, after)
+        assert report.regressions == []
+        assert report.new_passes == []
+
+    def test_test_now_failing_is_regression(self) -> None:
+        before = self._make("HEAD~1", {"a", "b", "c"})
+        after = self._make("HEAD", {"a", "b"}, failing={"c"})
+        report = vbp.diff_runs(before, after)
+        assert "c" in report.regressions
+
+    def test_test_no_longer_present_is_regression(self) -> None:
+        """A test that passed before but doesn't appear in after results — could
+        be deleted, renamed, or filtered out — is still a regression from the
+        contract perspective: that test no longer protects us."""
+        before = self._make("HEAD~1", {"a", "b", "c"})
+        after = self._make("HEAD", {"a", "b"})
+        report = vbp.diff_runs(before, after)
+        assert "c" in report.regressions
+        assert "c" in report.no_longer_run
+
+    def test_new_test_passing_is_informational(self) -> None:
+        before = self._make("HEAD~1", {"a", "b"})
+        after = self._make("HEAD", {"a", "b", "new_test"})
+        report = vbp.diff_runs(before, after)
+        assert report.regressions == []
+        assert "new_test" in report.new_passes
+
+    def test_test_was_failing_now_passing_not_a_regression(self) -> None:
+        before = self._make("HEAD~1", {"a"}, failing={"b"})
+        after = self._make("HEAD", {"a", "b"})
+        report = vbp.diff_runs(before, after)
+        assert report.regressions == []
+        assert "b" in report.new_passes
+
+
+# ---------------------------------------------------------------------------
+# detect_framework
+# ---------------------------------------------------------------------------
+
+class TestDetectFramework:
+    def test_pytest_via_pytest_ini(self, tmp_path: Path) -> None:
+        (tmp_path / "pytest.ini").write_text("[pytest]\n")
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "pytest"
+
+    def test_pytest_via_pyproject_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.pytest.ini_options]\nminversion = \"7.0\"\n"
+        )
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "pytest"
+
+    def test_pytest_via_tests_dir_fallback(self, tmp_path: Path) -> None:
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "test_foo.py").write_text("def test_x(): pass\n")
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "pytest"
+
+    def test_npm_via_package_json(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"test": "jest"}})
+        )
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "npm"
+
+    def test_cargo(self, tmp_path: Path) -> None:
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = \"x\"\n")
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "cargo"
+
+    def test_go(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text("module example.com/foo\n")
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is not None and fw.name == "go"
+
+    def test_no_framework_returns_none(self, tmp_path: Path) -> None:
+        fw = vbp.detect_framework(tmp_path)
+        assert fw is None
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+class TestRendering:
+    def _report(self, regressions: list[str] = None, new_passes: list[str] = None) -> vbp.DiffReport:
+        return vbp.DiffReport(
+            before_ref="HEAD~1", after_ref="HEAD", framework="pytest",
+            before_passing=10, after_passing=10,
+            regressions=regressions or [],
+            new_passes=new_passes or [],
+            no_longer_run=[],
+        )
+
+    def test_human_no_regressions(self) -> None:
+        out = vbp.render_human(self._report(),
+                               vbp.RunResult("HEAD~1", "pytest", set(), set(), set(), None),
+                               vbp.RunResult("HEAD", "pytest", set(), set(), set(), None))
+        assert "No regressions" in out
+
+    def test_human_lists_regressions(self) -> None:
+        out = vbp.render_human(
+            self._report(regressions=["tests/test_a.py::test_x"]),
+            vbp.RunResult("HEAD~1", "pytest", set(), set(), set(), None),
+            vbp.RunResult("HEAD", "pytest", set(), set(), set(), None),
+        )
+        assert "REGRESSIONS" in out
+        assert "tests/test_a.py::test_x" in out
+
+    def test_json_parseable(self) -> None:
+        out = vbp.render_json(self._report(regressions=["x", "y"]))
+        parsed = json.loads(out)
+        assert parsed["regressions"] == ["x", "y"]
+        assert parsed["framework"] == "pytest"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (mocked git + test runner)
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_missing_git_repo_returns_two(self, tmp_path: Path) -> None:
+        # tmp_path has no .git
+        with patch("sys.argv", [
+            "verify_behavior_preserved.py",
+            "--before", "HEAD~1", "--after", "HEAD",
+            "--repo", str(tmp_path),
+        ]):
+            code = vbp.main()
+        assert code == 2
+
+    def test_invalid_ref_returns_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Initialize a real git repo (so .git exists), but reference a missing ref
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
+        (tmp_path / "x").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+        with patch("sys.argv", [
+            "verify_behavior_preserved.py",
+            "--before", "definitely_not_a_ref", "--after", "HEAD",
+            "--repo", str(tmp_path),
+        ]):
+            code = vbp.main()
+        assert code == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: tiny real repo with a regression
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    def _init_repo(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+        return repo
+
+    def _commit_all(self, repo: Path, msg: str) -> None:
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", msg], cwd=repo, check=True)
+
+    def test_no_regression_when_unchanged(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = self._init_repo(tmp_path)
+        (repo / "tests").mkdir()
+        (repo / "tests" / "test_x.py").write_text(
+            "def test_one():\n    assert 1 + 1 == 2\n"
+            "def test_two():\n    assert True\n"
+        )
+        self._commit_all(repo, "init")
+        # Second commit: docs change only, behavior preserved
+        (repo / "README.md").write_text("hello\n")
+        self._commit_all(repo, "docs")
+        with patch("sys.argv", [
+            "verify_behavior_preserved.py",
+            "--before", "HEAD~1", "--after", "HEAD",
+            "--repo", str(repo), "--json",
+        ]):
+            code = vbp.main()
+        out = capsys.readouterr().out
+        report = json.loads(out)
+        assert report["regressions"] == []
+        assert code == 0
+
+    def test_regression_caught(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = self._init_repo(tmp_path)
+        (repo / "tests").mkdir()
+        # First commit: passing test
+        (repo / "tests" / "test_x.py").write_text(
+            "def test_one():\n    assert 1 + 1 == 2\n"
+        )
+        self._commit_all(repo, "init")
+        # Second commit: break the test
+        (repo / "tests" / "test_x.py").write_text(
+            "def test_one():\n    assert 1 + 1 == 3\n"
+        )
+        self._commit_all(repo, "regression!")
+        with patch("sys.argv", [
+            "verify_behavior_preserved.py",
+            "--before", "HEAD~1", "--after", "HEAD",
+            "--repo", str(repo), "--json",
+        ]):
+            code = vbp.main()
+        out = capsys.readouterr().out
+        report = json.loads(out)
+        assert report["regressions"]
+        assert any("test_one" in r for r in report["regressions"])
+        assert code == 1


### PR DESCRIPTION
## Summary

Standalone hook module that runs a project's test suite at two git refs and asserts no regression. Catches refactors that silently change behavior — the deterministic ground truth that LLM auditors miss.

**PR #8** from `docs/foundry-design.md`. Module ships standalone; pairing with `agents/refactor-executor.md` is future work.

## How it works

1. Creates temporary git worktrees at BEFORE and AFTER refs
2. Auto-detects the test framework (pytest / npm / cargo / go)
3. Runs tests in each worktree, captures pass/fail per test ID
4. Diffs: any test passing before that fails/disappears after = regression
5. Cleans up worktrees (even on crash — try/finally)

## Key properties

- **Language-agnostic** — auto-detects from the repo (pytest.ini, package.json, Cargo.toml, go.mod)
- **Safe** — git worktrees, never touches user's working tree or stash
- **Deterministic** — real test runner output, not LLM judgment

## Test plan

- [x] 23 unit + integration tests pass (parse, diff, detect, render, CLI, end-to-end with real git repos)
- [x] Real-world smoke on this repo: `HEAD~1..HEAD` correctly identified regressions from the rename PR
- [x] Full test suite: 651 pass / 10 fail (unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)