### PR TITLE
[feat] PR #10 — compliance category in security-auditor

### DIFF
--- a/agents/_shared/audit-report.md
+++ b/agents/_shared/audit-report.md
@@ -12,6 +12,7 @@ All auditors write their report as a JSON file to `.dynos/task-{id}/audit-report
   "findings": [
     {
       "id": "string — prefix-NNN (e.g. 'sec-001')",
+      "category": "string — finding category (e.g. 'security', 'compliance'). Optional for backwards compatibility; defaults to the auditor's primary category if omitted",
       "description": "string — what is wrong",
       "location": "string — file:line",
       "severity": "critical | major | minor",
@@ -42,7 +43,7 @@ All auditors write their report as a JSON file to `.dynos/task-{id}/audit-report
 
 Auditor-specific notes:
 - `spec-completion-auditor`: `requirement_coverage` is mandatory and must cover every numbered criterion. Finding IDs use prefix `sc-`. Severity is always `critical`.
-- `security-auditor`: `severity` meanings: `critical` = direct exploitability, `major` = significant risk, `minor` = defense-in-depth. Finding IDs use prefix `sec-`.
+- `security-auditor`: `severity` meanings: `critical` = direct exploitability, `major` = significant risk, `minor` = defense-in-depth. Finding IDs use prefix `sec-` (category `security`) or `comp-` (category `compliance`).
 - `code-quality-auditor`: Distinguish blocking from warning in the `blocking` field. Finding IDs use prefix `cq-`.
 - `ui-auditor`: Every UI state must have specific file evidence. Finding IDs use prefix `ui-`.
 - `db-schema-auditor`: `severity` meanings: `critical` = data loss risk or broken referential integrity, `major` = missing index or N+1, `minor` = naming or minor optimization. Finding IDs use prefix `db-`.

--- a/agents/repair-coordinator.md
+++ b/agents/repair-coordinator.md
@@ -41,6 +41,7 @@ You are the Repair Coordinator. You receive audit findings and produce a precise
 - Test coverage findings → `testing-executor`
 - Structural/refactor findings → `refactor-executor`
 - ML/model findings → `ml-executor`
+- Compliance findings (category `compliance`, prefix `comp-`) → route by affected file type: dependency manifests and license issues → `integration-executor`; missing privacy features (data export, account deletion) → `backend-executor`
 
 ## Instruction quality
 

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,12 +1,12 @@
 ---
 name: security-auditor
-description: "Internal dynos-work agent. Adversarial security review of all changed code. Runs on every task. Always blocks completion. Read-only."
+description: "Internal dynos-work agent. Adversarial security review and compliance audit of all changed code. Runs on every task. Always blocks completion. Read-only."
 model: opus
 ---
 
 # dynos-work Security Auditor
 
-You are the Security Auditor. You think adversarially. Your job is to find every way the implementation can be abused, leaked, injected, escalated, or broken. You are read-only.
+You are the Security Auditor. You think adversarially. Your job is to find every way the implementation can be abused, leaked, injected, escalated, or broken — and to verify supply-chain and compliance posture. You are read-only.
 
 **You run on every task, every audit cycle. You always have blocking authority.**
 
@@ -17,6 +17,8 @@ You are the Security Auditor. You think adversarially. Your job is to find every
 - `.dynos/task-{id}/evidence/`
 
 ## What you inspect systematically
+
+### Category: security
 
 **Secrets & Config:** Hardcoded secrets, tokens, API keys, passwords. Secrets logged or in error messages.
 
@@ -30,13 +32,50 @@ You are the Security Auditor. You think adversarially. Your job is to find every
 
 **For AI/Agent features:** User input not passed directly to LLM system prompts. Agent outputs not used to construct shell commands.
 
+### Category: compliance
+
+When the diff touches dependency manifests, lock files, or code that handles user data, run the compliance hook and incorporate its results. Compliance findings use the `comp-` prefix.
+
+**Step 1 — Run the deterministic compliance hook:**
+
+```bash
+python3 "${PLUGIN_HOOKS}/compliance_check.py" --root . --task-dir .dynos/task-{id} --changed-files {comma-separated changed files}
+```
+
+The hook auto-detects project ecosystems (npm, Python, Go, Rust, Ruby, Java, PHP, Dart, Swift, Elixir) and runs checks appropriate to each. It outputs JSON with four sections: `license_findings`, `sbom`, `provenance`, `privacy`.
+
+**Step 2 — Evaluate the hook output and generate findings:**
+
+**(a) License check — GPL/AGPL deps in proprietary projects:**
+If `license_findings` is non-empty, emit one finding per flagged package. Each copyleft dependency in a proprietary project is a compliance risk.
+- Severity: `major` (GPL/AGPL in proprietary = distribution risk). Escalate to `critical` if the dep is AGPL (network-use triggers copyleft).
+- Blocking: `true`
+
+**(b) SBOM generation:**
+If `sbom.generated` is `false` and the project has dependency manifests, emit a `minor` non-blocking finding noting that no SBOM tool (`syft` or `cyclonedx-bom`) is available. If generated, record the SBOM path in `evidence_checked`.
+
+**(c) Dependency provenance via Sigstore:**
+If `provenance.checked` is `true`, review each ecosystem result. For any ecosystem where provenance verification failed, emit a `minor` finding. If `provenance.checked` is `false` (cosign not installed), emit a `minor` non-blocking advisory.
+
+**(d) Privacy-relevant code checks:**
+If `privacy.handles_pii` is `true` and `privacy.missing` is non-empty, emit one finding per missing privacy feature:
+- Missing `data_export`: `major`, blocking — users have a right to their data (GDPR Art. 20, CCPA).
+- Missing `account_deletion`: `major`, blocking — users have a right to erasure (GDPR Art. 17, CCPA).
+- Missing `consent_management`: `minor`, non-blocking — advisory.
+
+**Step 3 — If the hook cannot run** (e.g., no dependency changes detected, or all ecosystems are unsupported), skip compliance checks and note this in the report. Do not emit false findings.
+
 ## Output
 
 Write report to `.dynos/task-{id}/audit-reports/security-{timestamp}.json`.
 
 Write your report following the canonical schema defined in `agents/_shared/audit-report.md`.
 
-**Severity:** `critical` = direct exploitability. `major` = significant risk. `minor` = defense-in-depth.
+**Every finding must include a `category` field** — either `"security"` or `"compliance"`.
+
+**Severity (security):** `critical` = direct exploitability. `major` = significant risk. `minor` = defense-in-depth.
+
+**Severity (compliance):** `critical` = AGPL dep in proprietary project. `major` = GPL dep or missing privacy feature. `minor` = advisory (no SBOM tool, no provenance).
 
 ## Hard rules
 
@@ -44,4 +83,5 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Critical findings always block completion
 - Do not modify any files
 - Focus on actual vulnerabilities, not best-practice suggestions
+- Compliance findings are based on deterministic hook output — do not hallucinate license or dependency data
 - Always write your report

--- a/hooks/compliance_check.py
+++ b/hooks/compliance_check.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Deterministic compliance checks for the security-auditor.
+
+Runs as a hook — invoked by the security-auditor agent via Bash.
+
+Usage:
+    python3 hooks/compliance_check.py --root <project-root> --task-dir <.dynos/task-id>
+
+Checks:
+  (a) License scan — flag GPL/AGPL deps in proprietary projects
+  (b) SBOM generation — invoke cyclonedx-bom or syft if available
+  (c) Dependency provenance — verify Sigstore attestations where available
+  (d) Privacy-relevant code — detect missing data export / account deletion endpoints
+
+Outputs JSON to stdout. The security-auditor merges these into its report.
+
+Works for ANY project type — detects ecosystem from lock/manifest files.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Ecosystem detection
+# ---------------------------------------------------------------------------
+
+# Map of manifest/lock files to ecosystem name.  Checked in order — first hit
+# wins, but we collect ALL ecosystems present.
+ECOSYSTEM_MARKERS: dict[str, str] = {
+    "package-lock.json": "npm",
+    "yarn.lock": "npm",
+    "pnpm-lock.yaml": "npm",
+    "package.json": "npm",
+    "Pipfile.lock": "python",
+    "poetry.lock": "python",
+    "requirements.txt": "python",
+    "setup.py": "python",
+    "setup.cfg": "python",
+    "pyproject.toml": "python",
+    "Gemfile.lock": "ruby",
+    "Gemfile": "ruby",
+    "go.sum": "go",
+    "go.mod": "go",
+    "Cargo.lock": "rust",
+    "Cargo.toml": "rust",
+    "composer.lock": "php",
+    "composer.json": "php",
+    "build.gradle": "java",
+    "build.gradle.kts": "java",
+    "pom.xml": "java",
+    "pubspec.lock": "dart",
+    "pubspec.yaml": "dart",
+    "Package.resolved": "swift",
+    "Package.swift": "swift",
+    "mix.lock": "elixir",
+}
+
+# Licenses that are copyleft — problematic in proprietary projects.
+COPYLEFT_LICENSES = {
+    "GPL-2.0",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "AGPL-1.0",
+    "AGPL-3.0",
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
+    "LGPL-2.0",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    "LGPL-2.1",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-3.0",
+    "LGPL-3.0-only",
+    "LGPL-3.0-or-later",
+    "SSPL-1.0",
+    "EUPL-1.1",
+    "EUPL-1.2",
+    "OSL-3.0",
+    "CPAL-1.0",
+    "CPL-1.0",
+    "CC-BY-SA-4.0",
+}
+
+
+def detect_ecosystems(root: Path) -> list[str]:
+    """Return deduplicated list of ecosystems present in the project."""
+    seen: set[str] = set()
+    for marker, eco in ECOSYSTEM_MARKERS.items():
+        if (root / marker).exists():
+            seen.add(eco)
+    return sorted(seen)
+
+
+# ---------------------------------------------------------------------------
+# (a) License check
+# ---------------------------------------------------------------------------
+
+def _run_cmd(cmd: list[str], cwd: str | None = None, timeout: int = 120) -> tuple[int, str, str]:
+    """Run a command, return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return -1, "", f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -2, "", f"timeout after {timeout}s: {' '.join(cmd)}"
+
+
+def _check_npm_licenses(root: Path) -> list[dict[str, Any]]:
+    """Check npm deps for copyleft licenses using license-checker if available."""
+    findings: list[dict[str, Any]] = []
+    # Try license-checker (npx)
+    rc, stdout, _ = _run_cmd(
+        ["npx", "--yes", "license-checker", "--json", "--production"],
+        cwd=str(root),
+        timeout=120,
+    )
+    if rc == 0 and stdout.strip():
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return findings
+        for pkg, info in data.items():
+            licenses_raw = info.get("licenses", "")
+            if isinstance(licenses_raw, list):
+                licenses_raw = " AND ".join(licenses_raw)
+            for copyleft in COPYLEFT_LICENSES:
+                if copyleft.lower() in licenses_raw.lower():
+                    findings.append({
+                        "package": pkg,
+                        "license": licenses_raw,
+                        "ecosystem": "npm",
+                        "manifest": "package.json",
+                    })
+                    break
+    return findings
+
+
+def _check_python_licenses(root: Path) -> list[dict[str, Any]]:
+    """Check Python deps for copyleft licenses using pip-licenses if available."""
+    findings: list[dict[str, Any]] = []
+    rc, stdout, _ = _run_cmd(
+        [sys.executable, "-m", "piplicenses", "--format=json", "--with-system"],
+        cwd=str(root),
+        timeout=60,
+    )
+    if rc != 0:
+        # fallback: try pip-licenses directly
+        rc, stdout, _ = _run_cmd(
+            ["pip-licenses", "--format=json", "--with-system"],
+            cwd=str(root),
+            timeout=60,
+        )
+    if rc == 0 and stdout.strip():
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return findings
+        for entry in data:
+            license_name = entry.get("License", "")
+            for copyleft in COPYLEFT_LICENSES:
+                if copyleft.lower() in license_name.lower():
+                    findings.append({
+                        "package": f"{entry.get('Name', '?')}=={entry.get('Version', '?')}",
+                        "license": license_name,
+                        "ecosystem": "python",
+                        "manifest": _find_python_manifest(root),
+                    })
+                    break
+    return findings
+
+
+def _find_python_manifest(root: Path) -> str:
+    """Return the most likely Python manifest file name."""
+    for name in ("pyproject.toml", "Pipfile.lock", "poetry.lock", "requirements.txt", "setup.py"):
+        if (root / name).exists():
+            return name
+    return "requirements.txt"
+
+
+def _check_go_licenses(root: Path) -> list[dict[str, Any]]:
+    """Check Go deps for copyleft licenses using go-licenses if available."""
+    findings: list[dict[str, Any]] = []
+    rc, stdout, _ = _run_cmd(
+        ["go-licenses", "report", "./...", "--template", "{{range .}}{{.Name}},{{.LicenseFile}},{{.LicenseName}}\n{{end}}"],
+        cwd=str(root),
+        timeout=120,
+    )
+    if rc == 0 and stdout.strip():
+        for line in stdout.strip().splitlines():
+            parts = line.split(",")
+            if len(parts) >= 3:
+                pkg, _, license_name = parts[0], parts[1], parts[2]
+                for copyleft in COPYLEFT_LICENSES:
+                    if copyleft.lower() in license_name.lower():
+                        findings.append({
+                            "package": pkg,
+                            "license": license_name,
+                            "ecosystem": "go",
+                            "manifest": "go.mod",
+                        })
+                        break
+    return findings
+
+
+LICENSE_CHECKERS: dict[str, Any] = {
+    "npm": _check_npm_licenses,
+    "python": _check_python_licenses,
+    "go": _check_go_licenses,
+}
+
+
+def check_licenses(root: Path, ecosystems: list[str]) -> list[dict[str, Any]]:
+    """Run license checks for all detected ecosystems."""
+    all_findings: list[dict[str, Any]] = []
+    for eco in ecosystems:
+        checker = LICENSE_CHECKERS.get(eco)
+        if checker:
+            all_findings.extend(checker(root))
+    return all_findings
+
+
+# ---------------------------------------------------------------------------
+# (b) SBOM generation
+# ---------------------------------------------------------------------------
+
+def generate_sbom(root: Path, task_dir: Path, ecosystems: list[str]) -> dict[str, Any]:
+    """Generate SBOM using cyclonedx or syft. Returns status dict."""
+    sbom_path = task_dir / "sbom.json"
+
+    # Try syft first (supports all ecosystems)
+    rc, stdout, stderr = _run_cmd(
+        ["syft", str(root), "-o", "cyclonedx-json"],
+        cwd=str(root),
+        timeout=300,
+    )
+    if rc == 0 and stdout.strip():
+        sbom_path.write_text(stdout)
+        return {"generated": True, "tool": "syft", "path": str(sbom_path), "format": "cyclonedx-json"}
+
+    # Try cyclonedx-bom for Python projects
+    if "python" in ecosystems:
+        rc, stdout, stderr = _run_cmd(
+            [sys.executable, "-m", "cyclonedx_bom", "--format", "json", "-o", str(sbom_path)],
+            cwd=str(root),
+            timeout=120,
+        )
+        if rc == 0 and sbom_path.exists():
+            return {"generated": True, "tool": "cyclonedx-bom", "path": str(sbom_path), "format": "cyclonedx-json"}
+
+    # Try cyclonedx for npm
+    if "npm" in ecosystems:
+        rc, stdout, stderr = _run_cmd(
+            ["npx", "--yes", "@cyclonedx/cyclonedx-npm", "--output-file", str(sbom_path)],
+            cwd=str(root),
+            timeout=120,
+        )
+        if rc == 0 and sbom_path.exists():
+            return {"generated": True, "tool": "cyclonedx-npm", "path": str(sbom_path), "format": "cyclonedx-json"}
+
+    return {"generated": False, "tool": None, "path": None, "format": None,
+            "reason": "neither syft nor cyclonedx-bom/npm available"}
+
+
+# ---------------------------------------------------------------------------
+# (c) Dependency provenance via Sigstore
+# ---------------------------------------------------------------------------
+
+def check_provenance(root: Path, ecosystems: list[str]) -> dict[str, Any]:
+    """Check dependency provenance via cosign/Sigstore where available."""
+    # cosign must be installed
+    rc, _, _ = _run_cmd(["cosign", "version"])
+    if rc != 0:
+        return {"checked": False, "reason": "cosign not installed"}
+
+    results: list[dict[str, Any]] = []
+
+    # For npm: check npm audit signatures
+    if "npm" in ecosystems and (root / "package-lock.json").exists():
+        rc, stdout, stderr = _run_cmd(
+            ["npm", "audit", "signatures"],
+            cwd=str(root),
+            timeout=120,
+        )
+        results.append({
+            "ecosystem": "npm",
+            "method": "npm audit signatures",
+            "passed": rc == 0,
+            "detail": stdout.strip()[:500] if rc == 0 else stderr.strip()[:500],
+        })
+
+    # For Python: check attestations on PyPI (best-effort via pip)
+    if "python" in ecosystems:
+        rc, stdout, _ = _run_cmd(
+            [sys.executable, "-m", "pip", "install", "--dry-run", "--require-hashes",
+             "--no-deps", "--report", "-", "-r", "requirements.txt"],
+            cwd=str(root),
+            timeout=60,
+        )
+        results.append({
+            "ecosystem": "python",
+            "method": "pip --require-hashes (dry-run)",
+            "passed": rc == 0,
+            "detail": "hash verification passed" if rc == 0 else "hash verification unavailable or failed",
+        })
+
+    return {"checked": True, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# (d) Privacy-relevant code checks
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate privacy-relevant functionality.
+PRIVACY_PATTERNS: dict[str, list[str]] = {
+    "data_export": [
+        r"export[_-]?data",
+        r"download[_-]?data",
+        r"data[_-]?export",
+        r"gdpr[_-]?export",
+        r"user[_-]?data[_-]?download",
+        r"takeout",
+        r"data[_-]?portability",
+    ],
+    "account_deletion": [
+        r"delete[_-]?account",
+        r"account[_-]?delet",
+        r"remove[_-]?account",
+        r"close[_-]?account",
+        r"gdpr[_-]?delet",
+        r"right[_-]?to[_-]?erasure",
+        r"data[_-]?erasure",
+    ],
+    "consent_management": [
+        r"cookie[_-]?consent",
+        r"consent[_-]?manag",
+        r"privacy[_-]?preference",
+        r"opt[_-]?out",
+        r"data[_-]?processing[_-]?consent",
+    ],
+}
+
+# Indicators that the project handles user data (PII).
+PII_INDICATORS = [
+    r"user[_-]?email",
+    r"password[_-]?hash",
+    r"personal[_-]?data",
+    r"first[_-]?name.*last[_-]?name",
+    r"date[_-]?of[_-]?birth",
+    r"social[_-]?security",
+    r"phone[_-]?number",
+    r"credit[_-]?card",
+    r"address.*street",
+    r"user[_-]?profile",
+    r"session[_-]?token",
+    r"auth[_-]?token",
+]
+
+# File extensions to scan for privacy patterns.
+CODE_EXTENSIONS = {
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".rb", ".java",
+    ".kt", ".swift", ".cs", ".php", ".ex", ".exs", ".erl", ".dart",
+    ".vue", ".svelte",
+}
+
+
+def _scan_files_for_patterns(root: Path, patterns: list[str], changed_files: list[str] | None = None) -> bool:
+    """Return True if any pattern matches in project source files."""
+    targets = []
+    if changed_files:
+        targets = [root / f for f in changed_files if Path(f).suffix in CODE_EXTENSIONS]
+    if not targets:
+        # Scan up to 500 files to keep it bounded
+        count = 0
+        for f in root.rglob("*"):
+            if f.suffix in CODE_EXTENSIONS and ".dynos" not in f.parts and "node_modules" not in f.parts and ".git" not in f.parts:
+                targets.append(f)
+                count += 1
+                if count >= 500:
+                    break
+
+    compiled = [re.compile(p, re.IGNORECASE) for p in patterns]
+    for fpath in targets:
+        try:
+            content = fpath.read_text(errors="ignore")
+        except (OSError, PermissionError):
+            continue
+        for pat in compiled:
+            if pat.search(content):
+                return True
+    return False
+
+
+def check_privacy(root: Path, changed_files: list[str] | None = None) -> dict[str, Any]:
+    """Check for missing privacy-relevant code when project handles PII."""
+    # First, determine if project handles user data
+    handles_pii = _scan_files_for_patterns(root, PII_INDICATORS, changed_files)
+    if not handles_pii:
+        return {"handles_pii": False, "missing": [], "note": "no PII indicators detected — privacy checks skipped"}
+
+    missing: list[str] = []
+    for category, patterns in PRIVACY_PATTERNS.items():
+        found = _scan_files_for_patterns(root, patterns)
+        if not found:
+            missing.append(category)
+
+    return {
+        "handles_pii": True,
+        "missing": missing,
+        "note": f"project handles PII; missing privacy features: {', '.join(missing)}" if missing else "all privacy features detected",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compliance checks for security-auditor")
+    parser.add_argument("--root", required=True, help="Project root directory")
+    parser.add_argument("--task-dir", required=True, help="Task directory (.dynos/task-{id})")
+    parser.add_argument("--changed-files", help="Comma-separated list of changed files")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    task_dir = Path(args.task_dir).resolve()
+    changed_files = args.changed_files.split(",") if args.changed_files else None
+
+    ecosystems = detect_ecosystems(root)
+
+    result: dict[str, Any] = {
+        "ecosystems_detected": ecosystems,
+        "license_findings": check_licenses(root, ecosystems),
+        "sbom": generate_sbom(root, task_dir, ecosystems),
+        "provenance": check_provenance(root, ecosystems),
+        "privacy": check_privacy(root, changed_files),
+    }
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compliance_check.py
+++ b/tests/test_compliance_check.py
@@ -1,0 +1,504 @@
+"""Tests for hooks/compliance_check.py.
+
+Validates:
+  - Ecosystem detection across all supported project types
+  - License check finding generation
+  - SBOM generation status handling
+  - Provenance check status handling
+  - Privacy-relevant code detection (PII detection, missing features)
+  - CLI invocation and JSON output shape
+  - Compliance findings follow the canonical audit report schema
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Ensure hooks/ is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+import compliance_check
+
+
+# ---------------------------------------------------------------------------
+# Ecosystem detection
+# ---------------------------------------------------------------------------
+
+class TestDetectEcosystems:
+    def test_npm_from_package_json(self, tmp_path: Path):
+        (tmp_path / "package.json").write_text("{}")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["npm"]
+
+    def test_python_from_pyproject(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["python"]
+
+    def test_go_from_go_mod(self, tmp_path: Path):
+        (tmp_path / "go.mod").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["go"]
+
+    def test_rust_from_cargo_toml(self, tmp_path: Path):
+        (tmp_path / "Cargo.toml").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["rust"]
+
+    def test_ruby_from_gemfile(self, tmp_path: Path):
+        (tmp_path / "Gemfile").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["ruby"]
+
+    def test_java_from_pom_xml(self, tmp_path: Path):
+        (tmp_path / "pom.xml").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["java"]
+
+    def test_php_from_composer_json(self, tmp_path: Path):
+        (tmp_path / "composer.json").write_text("{}")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["php"]
+
+    def test_dart_from_pubspec(self, tmp_path: Path):
+        (tmp_path / "pubspec.yaml").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["dart"]
+
+    def test_swift_from_package_swift(self, tmp_path: Path):
+        (tmp_path / "Package.swift").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["swift"]
+
+    def test_elixir_from_mix_lock(self, tmp_path: Path):
+        (tmp_path / "mix.lock").write_text("")
+        assert compliance_check.detect_ecosystems(tmp_path) == ["elixir"]
+
+    def test_multiple_ecosystems(self, tmp_path: Path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "pyproject.toml").write_text("")
+        result = compliance_check.detect_ecosystems(tmp_path)
+        assert "npm" in result
+        assert "python" in result
+
+    def test_empty_project(self, tmp_path: Path):
+        assert compliance_check.detect_ecosystems(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# License check
+# ---------------------------------------------------------------------------
+
+class TestCheckLicenses:
+    def test_no_ecosystems_returns_empty(self, tmp_path: Path):
+        assert compliance_check.check_licenses(tmp_path, []) == []
+
+    def test_unsupported_ecosystem_returns_empty(self, tmp_path: Path):
+        assert compliance_check.check_licenses(tmp_path, ["rust"]) == []
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_copyleft_detected(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (0, json.dumps({
+            "some-pkg@1.0.0": {"licenses": "GPL-3.0", "repository": "https://example.com"},
+            "safe-pkg@2.0.0": {"licenses": "MIT", "repository": "https://example.com"},
+        }), "")
+        findings = compliance_check.check_licenses(tmp_path, ["npm"])
+        assert len(findings) == 1
+        assert findings[0]["package"] == "some-pkg@1.0.0"
+        assert findings[0]["license"] == "GPL-3.0"
+        assert findings[0]["ecosystem"] == "npm"
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_agpl_detected(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (0, json.dumps({
+            "agpl-pkg@1.0.0": {"licenses": "AGPL-3.0-only", "repository": ""},
+        }), "")
+        findings = compliance_check.check_licenses(tmp_path, ["npm"])
+        assert len(findings) == 1
+        assert "AGPL" in findings[0]["license"]
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_mit_not_flagged(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (0, json.dumps({
+            "safe@1.0.0": {"licenses": "MIT", "repository": ""},
+        }), "")
+        assert compliance_check.check_licenses(tmp_path, ["npm"]) == []
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_checker_failure_returns_empty(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (1, "", "error")
+        assert compliance_check.check_licenses(tmp_path, ["npm"]) == []
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_python_copyleft_detected(self, mock_run, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("some-pkg==1.0")
+        mock_run.return_value = (0, json.dumps([
+            {"Name": "some-pkg", "Version": "1.0", "License": "GPL-2.0-or-later"},
+            {"Name": "safe-pkg", "Version": "2.0", "License": "MIT"},
+        ]), "")
+        findings = compliance_check.check_licenses(tmp_path, ["python"])
+        assert len(findings) == 1
+        assert findings[0]["package"] == "some-pkg==1.0"
+        assert findings[0]["ecosystem"] == "python"
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_python_checker_fallback(self, mock_run, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("")
+        # First call (piplicenses module) fails, second (pip-licenses binary) succeeds
+        mock_run.side_effect = [
+            (1, "", "not found"),
+            (0, json.dumps([{"Name": "gpl-pkg", "Version": "1.0", "License": "GPL-3.0"}]), ""),
+        ]
+        findings = compliance_check.check_licenses(tmp_path, ["python"])
+        assert len(findings) == 1
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_license_list_format(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (0, json.dumps({
+            "dual-pkg@1.0.0": {"licenses": ["MIT", "GPL-3.0"], "repository": ""},
+        }), "")
+        findings = compliance_check.check_licenses(tmp_path, ["npm"])
+        assert len(findings) == 1
+        assert "GPL-3.0" in findings[0]["license"]
+
+
+# ---------------------------------------------------------------------------
+# SBOM generation
+# ---------------------------------------------------------------------------
+
+class TestGenerateSbom:
+    @mock.patch("compliance_check._run_cmd")
+    def test_syft_success(self, mock_run, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        mock_run.return_value = (0, '{"bomFormat": "CycloneDX"}', "")
+        result = compliance_check.generate_sbom(tmp_path, task_dir, ["npm"])
+        assert result["generated"] is True
+        assert result["tool"] == "syft"
+        assert result["format"] == "cyclonedx-json"
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_syft_failure_falls_back_to_cyclonedx_python(self, mock_run, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        sbom_path = task_dir / "sbom.json"
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "syft":
+                return (1, "", "not found")
+            # cyclonedx-bom creates the file
+            sbom_path.write_text('{"bomFormat": "CycloneDX"}')
+            return (0, "", "")
+
+        mock_run.side_effect = side_effect
+        result = compliance_check.generate_sbom(tmp_path, task_dir, ["python"])
+        assert result["generated"] is True
+        assert result["tool"] == "cyclonedx-bom"
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_no_tools_available(self, mock_run, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        mock_run.return_value = (1, "", "not found")
+        result = compliance_check.generate_sbom(tmp_path, task_dir, ["npm"])
+        assert result["generated"] is False
+        assert "neither" in result["reason"]
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_syft_failure_falls_back_to_cyclonedx_npm(self, mock_run, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        sbom_path = task_dir / "sbom.json"
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "syft":
+                return (1, "", "not found")
+            if "cyclonedx-npm" in str(cmd):
+                sbom_path.write_text('{"bomFormat": "CycloneDX"}')
+                return (0, "", "")
+            return (1, "", "not found")
+
+        mock_run.side_effect = side_effect
+        result = compliance_check.generate_sbom(tmp_path, task_dir, ["npm"])
+        assert result["generated"] is True
+        assert result["tool"] == "cyclonedx-npm"
+
+
+# ---------------------------------------------------------------------------
+# Provenance check
+# ---------------------------------------------------------------------------
+
+class TestCheckProvenance:
+    @mock.patch("compliance_check._run_cmd")
+    def test_cosign_not_installed(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (-1, "", "command not found: cosign")
+        result = compliance_check.check_provenance(tmp_path, ["npm"])
+        assert result["checked"] is False
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_signatures_pass(self, mock_run, tmp_path: Path):
+        (tmp_path / "package-lock.json").write_text("{}")
+        mock_run.side_effect = [
+            (0, "cosign v2.0.0", ""),  # cosign version
+            (0, "audited 50 packages", ""),  # npm audit signatures
+        ]
+        result = compliance_check.check_provenance(tmp_path, ["npm"])
+        assert result["checked"] is True
+        assert len(result["results"]) == 1
+        assert result["results"][0]["passed"] is True
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_npm_signatures_fail(self, mock_run, tmp_path: Path):
+        (tmp_path / "package-lock.json").write_text("{}")
+        mock_run.side_effect = [
+            (0, "cosign v2.0.0", ""),
+            (1, "", "invalid signatures found"),
+        ]
+        result = compliance_check.check_provenance(tmp_path, ["npm"])
+        assert result["checked"] is True
+        assert result["results"][0]["passed"] is False
+
+    @mock.patch("compliance_check._run_cmd")
+    def test_no_lock_file_skips_npm(self, mock_run, tmp_path: Path):
+        mock_run.return_value = (0, "cosign v2.0.0", "")
+        result = compliance_check.check_provenance(tmp_path, ["npm"])
+        assert result["checked"] is True
+        assert len(result["results"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Privacy checks
+# ---------------------------------------------------------------------------
+
+class TestCheckPrivacy:
+    def test_no_pii_skips(self, tmp_path: Path):
+        (tmp_path / "main.py").write_text("print('hello')")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is False
+        assert result["missing"] == []
+
+    def test_pii_with_all_features(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        (tmp_path / "export.py").write_text("def export_data(user_id): pass")
+        (tmp_path / "account.py").write_text("def delete_account(user_id): pass")
+        (tmp_path / "consent.py").write_text("def cookie_consent(): pass")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is True
+        assert result["missing"] == []
+
+    def test_pii_missing_export(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        (tmp_path / "account.py").write_text("def delete_account(user_id): pass")
+        (tmp_path / "consent.py").write_text("def cookie_consent(): pass")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is True
+        assert "data_export" in result["missing"]
+
+    def test_pii_missing_deletion(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        (tmp_path / "export.py").write_text("def data_export(user_id): pass")
+        (tmp_path / "consent.py").write_text("def cookie_consent(): pass")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is True
+        assert "account_deletion" in result["missing"]
+
+    def test_pii_missing_consent(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        (tmp_path / "export.py").write_text("def data_export(user_id): pass")
+        (tmp_path / "account.py").write_text("def delete_account(user_id): pass")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is True
+        assert "consent_management" in result["missing"]
+
+    def test_pii_all_missing(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is True
+        assert len(result["missing"]) == 3
+
+    def test_changed_files_filter(self, tmp_path: Path):
+        (tmp_path / "models.py").write_text("user_email = db.Column(String)")
+        result = compliance_check.check_privacy(tmp_path, changed_files=["models.py"])
+        assert result["handles_pii"] is True
+
+    def test_ignores_node_modules(self, tmp_path: Path):
+        nm = tmp_path / "node_modules" / "pkg"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("var user_email = 'test';")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is False
+
+    def test_ignores_dynos_dir(self, tmp_path: Path):
+        dynos = tmp_path / ".dynos" / "task-1"
+        dynos.mkdir(parents=True)
+        (dynos / "spec.py").write_text("user_email = 'test'")
+        result = compliance_check.check_privacy(tmp_path)
+        assert result["handles_pii"] is False
+
+
+# ---------------------------------------------------------------------------
+# _run_cmd edge cases
+# ---------------------------------------------------------------------------
+
+class TestRunCmd:
+    def test_command_not_found(self):
+        rc, stdout, stderr = compliance_check._run_cmd(["nonexistent_cmd_12345"])
+        assert rc == -1
+        assert "command not found" in stderr
+
+    def test_timeout(self):
+        rc, stdout, stderr = compliance_check._run_cmd(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            timeout=1,
+        )
+        assert rc == -2
+        assert "timeout" in stderr
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_json_output_shape(self, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        (tmp_path / "main.py").write_text("print('hello')")
+
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve().parent.parent / "hooks" / "compliance_check.py"),
+             "--root", str(tmp_path), "--task-dir", str(task_dir)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "ecosystems_detected" in data
+        assert "license_findings" in data
+        assert "sbom" in data
+        assert "provenance" in data
+        assert "privacy" in data
+
+    def test_with_changed_files(self, tmp_path: Path):
+        task_dir = tmp_path / ".dynos" / "task-1"
+        task_dir.mkdir(parents=True)
+        (tmp_path / "main.py").write_text("print('hello')")
+
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve().parent.parent / "hooks" / "compliance_check.py"),
+             "--root", str(tmp_path), "--task-dir", str(task_dir),
+             "--changed-files", "main.py,other.py"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data["ecosystems_detected"], list)
+
+
+# ---------------------------------------------------------------------------
+# Finding schema compatibility
+# ---------------------------------------------------------------------------
+
+class TestFindingSchemaCompat:
+    """Verify that compliance findings can use the canonical audit report schema."""
+
+    def test_compliance_finding_shape(self):
+        """A compliance finding has all required fields from audit-report.md."""
+        finding = {
+            "id": "comp-001",
+            "category": "compliance",
+            "description": "GPL-3.0 dependency 'some-pkg@1.0.0' in proprietary project",
+            "location": "package.json:1",
+            "severity": "major",
+            "blocking": True,
+        }
+        assert finding["id"].startswith("comp-")
+        assert finding["category"] == "compliance"
+        assert finding["severity"] in ("critical", "major", "minor")
+        assert isinstance(finding["blocking"], bool)
+
+    def test_security_finding_backwards_compat(self):
+        """Existing security findings remain valid — category is optional."""
+        finding = {
+            "id": "sec-001",
+            "description": "Hardcoded secret in config.py",
+            "location": "config.py:10",
+            "severity": "critical",
+            "blocking": True,
+        }
+        # No category field — backwards compatible
+        assert "category" not in finding
+        assert finding["id"].startswith("sec-")
+
+    def test_security_finding_with_category(self):
+        """Security findings can optionally include category."""
+        finding = {
+            "id": "sec-002",
+            "category": "security",
+            "description": "SQL injection in query builder",
+            "location": "db.py:42",
+            "severity": "critical",
+            "blocking": True,
+        }
+        assert finding["category"] == "security"
+
+    def test_repair_task_shape_for_compliance(self):
+        """Compliance repair tasks match the repair_tasks schema."""
+        repair_task = {
+            "finding_id": "comp-002",
+            "description": "Add data export endpoint for user data (GDPR Art. 20)",
+            "assigned_executor": "backend-executor",
+            "affected_files": ["src/api/routes.py"],
+        }
+        assert repair_task["finding_id"].startswith("comp-")
+        assert repair_task["assigned_executor"] in (
+            "backend-executor", "integration-executor", "ui-executor",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Copyleft license set
+# ---------------------------------------------------------------------------
+
+class TestCopyleftSet:
+    def test_gpl_variants_covered(self):
+        for v in ("GPL-2.0", "GPL-2.0-only", "GPL-2.0-or-later",
+                   "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later"):
+            assert v in compliance_check.COPYLEFT_LICENSES
+
+    def test_agpl_variants_covered(self):
+        for v in ("AGPL-1.0", "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later"):
+            assert v in compliance_check.COPYLEFT_LICENSES
+
+    def test_lgpl_variants_covered(self):
+        for v in ("LGPL-2.0", "LGPL-2.1", "LGPL-3.0"):
+            assert v in compliance_check.COPYLEFT_LICENSES
+
+    def test_mit_not_copyleft(self):
+        assert "MIT" not in compliance_check.COPYLEFT_LICENSES
+
+    def test_apache_not_copyleft(self):
+        assert "Apache-2.0" not in compliance_check.COPYLEFT_LICENSES
+
+    def test_bsd_not_copyleft(self):
+        assert "BSD-3-Clause" not in compliance_check.COPYLEFT_LICENSES
+
+
+# ---------------------------------------------------------------------------
+# Ecosystem marker coverage
+# ---------------------------------------------------------------------------
+
+class TestEcosystemMarkers:
+    """Ensure we support the project types mentioned in the PR spec."""
+
+    @pytest.mark.parametrize("marker,eco", [
+        ("package.json", "npm"),
+        ("pyproject.toml", "python"),
+        ("go.mod", "go"),
+        ("Cargo.toml", "rust"),
+        ("Gemfile", "ruby"),
+        ("pom.xml", "java"),
+        ("composer.json", "php"),
+        ("pubspec.yaml", "dart"),
+        ("Package.swift", "swift"),
+        ("mix.lock", "elixir"),
+    ])
+    def test_marker_maps_to_ecosystem(self, marker: str, eco: str):
+        assert compliance_check.ECOSYSTEM_MARKERS[marker] == eco


### PR DESCRIPTION
## Summary

- Extends `agents/security-auditor.md` with a new **compliance** category covering: (a) GPL/AGPL license flagging, (b) SBOM generation via cyclonedx-bom/syft, (c) dependency provenance via Sigstore, (d) missing privacy-relevant code detection (data export, account deletion)
- Adds `hooks/compliance_check.py` — deterministic compliance checks that auto-detect 10 ecosystems (npm, Python, Go, Rust, Ruby, Java, PHP, Dart, Swift, Elixir) from manifest/lock files
- Adds `category` field to the canonical audit report schema (`agents/_shared/audit-report.md`) with backwards-compatible optional semantics
- Updates `agents/repair-coordinator.md` with routing rules for `comp-` prefix compliance findings

## Verification checklist

- [x] Existing security findings produce the same output shape (`category` is optional — backwards compatible)
- [x] New compliance findings use the canonical JSON schema with `comp-` prefix and `category: "compliance"`
- [x] Repair-coordinator handles compliance findings without structural changes (routing rule addition only)
- [x] Works for ANY project type — ecosystem auto-detection from manifest files, not hardcoded to Python/JS
- [x] No Python code in SKILL.md — all deterministic checks in `hooks/compliance_check.py`
- [x] No new slash commands or agent files — extends the existing security-auditor
- [x] Full test suite passes: 736 passed (62 new + 674 existing), 10 pre-existing failures on main unrelated to this PR

## Test plan

- [x] Run `pytest tests/test_compliance_check.py -v` — 62 tests covering all 4 compliance checks, ecosystem detection, CLI integration, schema compatibility
- [x] Run full `pytest tests/` — verify no regressions (736 passed, same 10 pre-existing failures as main)
- [ ] Manual: verify compliance hook runs correctly on a project with npm/Python deps
- [ ] Manual: verify security-auditor produces valid report with both `sec-` and `comp-` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)