### PR TITLE
[feat] PR #13 — per-agent tool boundaries via frontmatter

### DIFF
--- a/agents/backend-executor.md
+++ b/agents/backend-executor.md
@@ -2,6 +2,7 @@
 name: backend-executor
 description: "Internal dynos-work agent. Implements API routes, services, business logic, and auth. Spawned by /dynos-work:execute for backend execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work Backend Executor

--- a/agents/code-quality-auditor.md
+++ b/agents/code-quality-auditor.md
@@ -2,6 +2,7 @@
 name: code-quality-auditor
 description: "Internal dynos-work agent. Verifies maintainability, correctness, test coverage, and structural integrity. Blocks on significant architecture degradation. Read-only."
 model: sonnet
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work Code Quality Auditor

--- a/agents/db-executor.md
+++ b/agents/db-executor.md
@@ -2,6 +2,7 @@
 name: db-executor
 description: "Internal dynos-work agent. Implements schema changes, migrations, ORM models, and queries. Spawned by /dynos-work:execute for database execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work DB Executor

--- a/agents/db-schema-auditor.md
+++ b/agents/db-schema-auditor.md
@@ -2,6 +2,7 @@
 name: db-schema-auditor
 description: "Internal dynos-work agent. Verifies schema design, migration safety, index strategy, and data integrity. Blocks on DB tasks. Read-only."
 model: opus
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work DB Schema Auditor

--- a/agents/dead-code-auditor.md
+++ b/agents/dead-code-auditor.md
@@ -2,6 +2,7 @@
 name: dead-code-auditor
 description: "Internal dynos-work agent. Detects unused imports, dead exports, unreferenced files, dead functions, and orphaned commented-out code. Runs only at FINAL_AUDIT. Always blocks completion. Read-only."
 model: sonnet
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work Dead Code Auditor

--- a/agents/integration-executor.md
+++ b/agents/integration-executor.md
@@ -2,6 +2,7 @@
 name: integration-executor
 description: "Internal dynos-work agent. Wires components together, connects external APIs, handles plumbing. Spawned by /dynos-work:execute for integration execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work Integration Executor

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -2,6 +2,7 @@
 name: investigator
 description: "Internal dynos-work agent. Deep bug investigation — runtime errors, logic bugs, test failures. Reads relevant files autonomously. Returns structured root cause analysis with evidence and fix recommendation. Read-only."
 model: opus
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work Investigator

--- a/agents/ml-executor.md
+++ b/agents/ml-executor.md
@@ -2,6 +2,7 @@
 name: ml-executor
 description: "Internal dynos-work agent. Implements ML models, training pipelines, inference code, and data processing. Spawned by /dynos-work:execute for ML execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work ML Executor

--- a/agents/planning.md
+++ b/agents/planning.md
@@ -2,6 +2,7 @@
 name: planning
 description: "Internal dynos-work agent. Planner — handles discovery+design+classification, spec normalization, implementation plan + execution graph generation. Spawned by /dynos-work:start."
 model: opus
+tools: [Read, Grep, Glob]
 ---
 
 # dynos-work Planner

--- a/agents/refactor-executor.md
+++ b/agents/refactor-executor.md
@@ -2,6 +2,7 @@
 name: refactor-executor
 description: "Internal dynos-work agent. Restructures code without changing behavior. No new features. Spawned by /dynos-work:execute for refactor execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work Refactor Executor

--- a/agents/repair-coordinator.md
+++ b/agents/repair-coordinator.md
@@ -2,6 +2,7 @@
 name: repair-coordinator
 description: "Internal dynos-work agent. Converts audit findings into precise remediation tasks. Produces repair-log.json with executor assignments and batch groupings."
 model: sonnet
+tools: [Read, Grep, Glob]
 ---
 
 # dynos-work Repair Coordinator

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -2,6 +2,7 @@
 name: security-auditor
 description: "Internal dynos-work agent. Adversarial security review and compliance audit of all changed code. Runs on every task. Always blocks completion. Read-only."
 model: opus
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work Security Auditor

--- a/agents/spec-completion-auditor.md
+++ b/agents/spec-completion-auditor.md
@@ -2,6 +2,7 @@
 name: spec-completion-auditor
 description: "Internal dynos-work agent. Verifies every acceptance criterion is met with evidence. Runs on every task. Always blocks completion. Read-only."
 model: sonnet
+tools: [Read, Grep, Glob]
 ---
 
 # dynos-work Spec-Completion Auditor

--- a/agents/state-encoder.md
+++ b/agents/state-encoder.md
@@ -1,6 +1,7 @@
 ---
 name: state-encoder
 description: "High-Dimensional State Encoding Agent. Converts a module's current code graph and recent finding density into a structured state signature."
+tools: [Read, Grep, Glob]
 ---
 
 # State-Encoder Agent ($)

--- a/agents/testing-executor.md
+++ b/agents/testing-executor.md
@@ -2,6 +2,7 @@
 name: testing-executor
 description: "Internal dynos-work agent. Writes unit, integration, and e2e tests. Spawned by /dynos-work:execute for testing execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work Testing Executor

--- a/agents/ui-auditor.md
+++ b/agents/ui-auditor.md
@@ -2,6 +2,7 @@
 name: ui-auditor
 description: "Internal dynos-work agent. Verifies UI correctness, completeness, accessibility, and all states. Blocks on UI tasks. Read-only."
 model: sonnet
+tools: [Read, Grep, Glob, Bash]
 ---
 
 # dynos-work UI Auditor

--- a/agents/ui-executor.md
+++ b/agents/ui-executor.md
@@ -2,6 +2,7 @@
 name: ui-executor
 description: "Internal dynos-work agent. Implements UI components, pages, interactions, and styles. Spawned by /dynos-work:execute for UI execution segments."
 model: opus
+tools: [Read, Write, Edit, Grep, Glob, Bash]
 ---
 
 # dynos-work UI Executor

--- a/tests/test_agent_tool_boundaries.py
+++ b/tests/test_agent_tool_boundaries.py
@@ -1,0 +1,237 @@
+"""Tests for PR #13 — per-agent tool boundaries via frontmatter.
+
+Validates:
+  - Every agent .md file has a tools: field in frontmatter
+  - Executors have write tools (Write, Edit)
+  - Auditors do NOT have write tools
+  - Read-only agents (planner, coordinator, encoder) don't have write tools
+  - All agents have at minimum Read and Grep
+  - Tools field parses as a valid YAML list
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+AGENTS_DIR = Path(__file__).resolve().parent.parent / "agents"
+
+# All agent files (excluding _shared)
+AGENT_FILES = sorted(
+    f for f in AGENTS_DIR.glob("*.md")
+    if f.is_file() and not f.name.startswith("_")
+)
+
+# Classification of agents
+EXECUTORS = {
+    "backend-executor",
+    "db-executor",
+    "integration-executor",
+    "ml-executor",
+    "refactor-executor",
+    "testing-executor",
+    "ui-executor",
+}
+
+READ_ONLY_AUDITORS = {
+    "code-quality-auditor",
+    "db-schema-auditor",
+    "dead-code-auditor",
+    "security-auditor",
+    "spec-completion-auditor",
+    "ui-auditor",
+}
+
+READ_ONLY_OTHER = {
+    "planning",
+    "repair-coordinator",
+    "investigator",
+    "state-encoder",
+}
+
+WRITE_TOOLS = {"Write", "Edit"}
+READ_TOOLS = {"Read", "Grep"}
+
+
+def _parse_frontmatter(path: Path) -> dict:
+    """Extract YAML frontmatter from a markdown file (no PyYAML dependency)."""
+    text = path.read_text()
+    match = re.match(r"^---\n(.*?\n)---", text, re.DOTALL)
+    assert match, f"No frontmatter in {path.name}"
+    fm: dict = {}
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if val.startswith("[") and val.endswith("]"):
+            # Parse YAML-style list: [Read, Write, Edit]
+            items = [item.strip().strip('"').strip("'") for item in val[1:-1].split(",")]
+            fm[key] = [i for i in items if i]
+        elif val.startswith('"') and val.endswith('"'):
+            fm[key] = val[1:-1]
+        else:
+            fm[key] = val
+    return fm
+
+
+# ---------------------------------------------------------------------------
+# Every agent has a tools: field
+# ---------------------------------------------------------------------------
+
+class TestAllAgentsHaveTools:
+    @pytest.mark.parametrize("agent_file", AGENT_FILES, ids=lambda f: f.stem)
+    def test_tools_field_exists(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert "tools" in fm, f"{agent_file.name} missing tools: field"
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES, ids=lambda f: f.stem)
+    def test_tools_is_list(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert isinstance(fm["tools"], list), f"{agent_file.name} tools: must be a list"
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES, ids=lambda f: f.stem)
+    def test_tools_not_empty(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert len(fm["tools"]) > 0, f"{agent_file.name} tools: must not be empty"
+
+    def test_all_17_agents_found(self):
+        assert len(AGENT_FILES) == 17, f"Expected 17 agents, found {len(AGENT_FILES)}"
+
+
+# ---------------------------------------------------------------------------
+# Minimum tools: every agent needs Read + Grep
+# ---------------------------------------------------------------------------
+
+class TestMinimumTools:
+    @pytest.mark.parametrize("agent_file", AGENT_FILES, ids=lambda f: f.stem)
+    def test_has_read(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert "Read" in fm["tools"], f"{agent_file.name} missing Read"
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES, ids=lambda f: f.stem)
+    def test_has_grep(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert "Grep" in fm["tools"], f"{agent_file.name} missing Grep"
+
+
+# ---------------------------------------------------------------------------
+# Executors MUST have write tools
+# ---------------------------------------------------------------------------
+
+class TestExecutorsHaveWriteTools:
+    @pytest.fixture(params=sorted(EXECUTORS))
+    def executor_file(self, request) -> Path:
+        return AGENTS_DIR / f"{request.param}.md"
+
+    def test_has_write(self, executor_file: Path):
+        fm = _parse_frontmatter(executor_file)
+        assert "Write" in fm["tools"], f"{executor_file.name} executor missing Write"
+
+    def test_has_edit(self, executor_file: Path):
+        fm = _parse_frontmatter(executor_file)
+        assert "Edit" in fm["tools"], f"{executor_file.name} executor missing Edit"
+
+    def test_has_bash(self, executor_file: Path):
+        fm = _parse_frontmatter(executor_file)
+        assert "Bash" in fm["tools"], f"{executor_file.name} executor missing Bash"
+
+    def test_has_glob(self, executor_file: Path):
+        fm = _parse_frontmatter(executor_file)
+        assert "Glob" in fm["tools"], f"{executor_file.name} executor missing Glob"
+
+
+# ---------------------------------------------------------------------------
+# Auditors must NOT have write tools
+# ---------------------------------------------------------------------------
+
+class TestAuditorsNoWriteTools:
+    @pytest.fixture(params=sorted(READ_ONLY_AUDITORS))
+    def auditor_file(self, request) -> Path:
+        return AGENTS_DIR / f"{request.param}.md"
+
+    def test_no_write(self, auditor_file: Path):
+        fm = _parse_frontmatter(auditor_file)
+        assert "Write" not in fm["tools"], f"{auditor_file.name} auditor must not have Write"
+
+    def test_no_edit(self, auditor_file: Path):
+        fm = _parse_frontmatter(auditor_file)
+        assert "Edit" not in fm["tools"], f"{auditor_file.name} auditor must not have Edit"
+
+
+# ---------------------------------------------------------------------------
+# Other read-only agents must NOT have write tools
+# ---------------------------------------------------------------------------
+
+class TestReadOnlyOtherNoWriteTools:
+    @pytest.fixture(params=sorted(READ_ONLY_OTHER))
+    def agent_file(self, request) -> Path:
+        return AGENTS_DIR / f"{request.param}.md"
+
+    def test_no_write(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert "Write" not in fm["tools"], f"{agent_file.name} must not have Write"
+
+    def test_no_edit(self, agent_file: Path):
+        fm = _parse_frontmatter(agent_file)
+        assert "Edit" not in fm["tools"], f"{agent_file.name} must not have Edit"
+
+
+# ---------------------------------------------------------------------------
+# Specific tool assignments
+# ---------------------------------------------------------------------------
+
+class TestSpecificAssignments:
+    def test_planner_no_bash(self):
+        """Planner reads codebase, doesn't execute anything."""
+        fm = _parse_frontmatter(AGENTS_DIR / "planning.md")
+        assert "Bash" not in fm["tools"]
+
+    def test_spec_completion_auditor_no_bash(self):
+        """Spec-completion auditor only reads specs and code."""
+        fm = _parse_frontmatter(AGENTS_DIR / "spec-completion-auditor.md")
+        assert "Bash" not in fm["tools"]
+
+    def test_repair_coordinator_no_bash(self):
+        """Repair coordinator reads reports and plans, doesn't execute."""
+        fm = _parse_frontmatter(AGENTS_DIR / "repair-coordinator.md")
+        assert "Bash" not in fm["tools"]
+
+    def test_state_encoder_no_bash(self):
+        """State encoder is pure analysis."""
+        fm = _parse_frontmatter(AGENTS_DIR / "state-encoder.md")
+        assert "Bash" not in fm["tools"]
+
+    def test_investigator_has_bash(self):
+        """Investigator needs Bash for diagnostic commands."""
+        fm = _parse_frontmatter(AGENTS_DIR / "investigator.md")
+        assert "Bash" in fm["tools"]
+
+    def test_security_auditor_has_bash(self):
+        """Security auditor needs Bash for compliance hook."""
+        fm = _parse_frontmatter(AGENTS_DIR / "security-auditor.md")
+        assert "Bash" in fm["tools"]
+
+    def test_code_quality_auditor_has_bash(self):
+        """Code-quality auditor needs Bash for doc-accuracy hook."""
+        fm = _parse_frontmatter(AGENTS_DIR / "code-quality-auditor.md")
+        assert "Bash" in fm["tools"]
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every agent is classified
+# ---------------------------------------------------------------------------
+
+class TestClassificationCoverage:
+    def test_all_agents_classified(self):
+        """Every agent file is in exactly one category."""
+        all_names = {f.stem for f in AGENT_FILES}
+        classified = EXECUTORS | READ_ONLY_AUDITORS | READ_ONLY_OTHER
+        unclassified = all_names - classified
+        assert not unclassified, f"Unclassified agents: {unclassified}"
+
+    def test_no_duplicate_classification(self):
+        overlap = (EXECUTORS & READ_ONLY_AUDITORS) | (EXECUTORS & READ_ONLY_OTHER) | (READ_ONLY_AUDITORS & READ_ONLY_OTHER)
+        assert not overlap, f"Agents in multiple categories: {overlap}"


### PR DESCRIPTION
## Summary

- Adds `tools:` frontmatter field to all 17 agent `.md` files declaring the minimum tool set each agent needs
- Closes the **over-privileged automation** failure mode (Access plane, `docs/control-plane-gaps.md`)
- Follows least-privilege principle: auditors get read-only tools, executors get write tools

### Tool assignments

| Role | Agents | Tools |
|---|---|---|
| Executors (7) | backend, db, integration, ml, refactor, testing, ui | Read, Write, Edit, Grep, Glob, Bash |
| Auditors with hooks (5) | code-quality, db-schema, dead-code, security, ui | Read, Grep, Glob, Bash |
| Pure-read auditor (1) | spec-completion | Read, Grep, Glob |
| Planner (1) | planning | Read, Grep, Glob |
| Coordinator (1) | repair-coordinator | Read, Grep, Glob |
| Investigator (1) | investigator | Read, Grep, Glob, Bash |
| State encoder (1) | state-encoder | Read, Grep, Glob |

**No auditor has Write or Edit. No planner has Bash.**

## Verification checklist

- [x] Every agent file has a valid `tools:` list in frontmatter
- [x] All 7 executors have write tools (Write, Edit, Bash)
- [x] All 6 auditors lack Write and Edit
- [x] Planner, coordinator, encoder lack Bash
- [x] Investigator has Bash (needs diagnostic shell access)
- [x] 143 parametrized tests cover every agent
- [x] Full suite: 967 passed, same 10 pre-existing failures

## Test plan

- [x] `pytest tests/test_agent_tool_boundaries.py -v` — 143 tests: tools field exists, correct type, minimum tools, executor write access, auditor read-only enforcement, specific assignments, classification coverage
- [x] Full `pytest tests/` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)