### PR TITLE
[feat] PR #17 — usage telemetry for dormancy detection

### DIFF
--- a/cli/assets/bin/dynos
+++ b/cli/assets/bin/dynos
@@ -36,6 +36,7 @@ Global commands:
   registry      Project registration: register, unregister, list, pause, resume
   config        Get or set project policy (e.g. learning_enabled)
   stats dora    DORA metrics from task retrospectives
+  stats usage   Module usage telemetry (dormancy detection)
 
 Internals (advanced):
   route         Deterministic audit/executor routing
@@ -264,8 +265,10 @@ print('no')
   stats)
     if [ $# -gt 0 ] && [ "$1" = "dora" ]; then
       shift; exec python3 "${HOOKS_DIR}/dynosctl.py" stats-dora "$@"
+    elif [ $# -gt 0 ] && [ "$1" = "usage" ]; then
+      shift; exec python3 "${HOOKS_DIR}/dynosctl.py" stats-usage "$@"
     fi
-    echo "Usage: dynos stats dora [--root .] [--json]" >&2; exit 1
+    echo "Usage: dynos stats {dora|usage} [--json]" >&2; exit 1
     ;;
   ctl)        exec python3 "${HOOKS_DIR}/dynosctl.py" "$@" ;;
   postmortem) exec python3 "${HOOKS_DIR}/dynopostmortem.py" "$@" ;;

--- a/hooks/cli_base.py
+++ b/hooks/cli_base.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import argparse
 from typing import Callable
 
+from lib_usage_telemetry import record_usage as _record_usage
+_record_usage("cli_base")
+
 
 def cli_main(build_parser_fn: Callable[[], argparse.ArgumentParser]) -> int:
     """Build a parser, parse argv, and dispatch to the handler set via *set_defaults(func=...)*."""

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -193,6 +193,33 @@ def cmd_crawl_targets(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_stats_usage(args: argparse.Namespace) -> int:
+    """Show module usage telemetry for dormancy detection."""
+    import json as _json
+    from lib_usage_telemetry import read_telemetry, summarize_telemetry
+
+    monitored = ["dream", "postmortem_improve", "lib_qlearn", "cli_base"]
+
+    if args.json:
+        counts = summarize_telemetry()
+        result = {mod: counts.get(mod, 0) for mod in monitored}
+        result["_other"] = {k: v for k, v in counts.items() if k not in monitored}
+        print(_json.dumps(result, indent=2))
+    else:
+        counts = summarize_telemetry()
+        print("Module Usage Telemetry (dormancy detection)")
+        print(f"{'Module':<25} {'Invocations':>12}  Status")
+        print("-" * 55)
+        for mod in monitored:
+            count = counts.get(mod, 0)
+            status = "ACTIVE" if count > 0 else "DORMANT"
+            print(f"{mod:<25} {count:>12}  {status}")
+        other = {k: v for k, v in counts.items() if k not in monitored}
+        if other:
+            print(f"\nOther modules recorded: {len(other)}")
+    return 0
+
+
 def cmd_config(args: argparse.Namespace) -> int:
     """Get or set project policy values."""
     import json as _json
@@ -378,6 +405,10 @@ def build_parser() -> argparse.ArgumentParser:
     dora_parser.add_argument("--root", default=".", help="Project root")
     dora_parser.add_argument("--json", action="store_true", help="Output as JSON")
     dora_parser.set_defaults(func=cmd_stats_dora)
+
+    usage_parser = subparsers.add_parser("stats-usage", help="Module usage telemetry for dormancy detection")
+    usage_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    usage_parser.set_defaults(func=cmd_stats_usage)
 
     config_parser = subparsers.add_parser("config", help="Get or set project policy values")
     config_parser.add_argument("action", choices=["get", "set"], help="Action: get or set")

--- a/hooks/dream.py
+++ b/hooks/dream.py
@@ -12,6 +12,8 @@ import tempfile
 from pathlib import Path
 
 from lib_core import now_iso
+from lib_usage_telemetry import record_usage as _record_usage
+_record_usage("dream")
 from lib_defaults import (
     COMPONENT_MIN_ACCEPTABLE,
     DESIGN_ARCH_COMPLEXITY_DIVISOR,

--- a/hooks/lib_qlearn.py
+++ b/hooks/lib_qlearn.py
@@ -16,6 +16,8 @@ import random
 from pathlib import Path
 
 from lib_core import _persistent_project_dir, load_json, now_iso, project_policy, write_json
+from lib_usage_telemetry import record_usage as _record_usage
+_record_usage("lib_qlearn")
 from lib_defaults import (
     EFFICIENCY_CLAMP,
     EFFICIENCY_WEIGHT,

--- a/hooks/lib_usage_telemetry.py
+++ b/hooks/lib_usage_telemetry.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Lightweight usage telemetry for dormancy detection.
+
+Records a timestamp + caller whenever a monitored module is invoked.
+Data written to ~/.dynos/usage-telemetry.jsonl (append-only, one JSON
+object per line). After the monitoring period, modules with zero entries
+are safe to remove.
+
+Usage (in monitored module, at module load time):
+    from lib_usage_telemetry import record_usage
+    record_usage("dream")
+
+Or for function-level tracking:
+    record_usage("dream", function="simulate_option")
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _telemetry_path() -> Path:
+    dynos_home = Path(os.environ.get("DYNOS_HOME", str(Path.home() / ".dynos")))
+    return dynos_home / "usage-telemetry.jsonl"
+
+
+def record_usage(module: str, function: str | None = None) -> None:
+    """Append a usage record. Never raises — telemetry must not break callers."""
+    try:
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "module": module,
+            "pid": os.getpid(),
+        }
+        if function:
+            entry["function"] = function
+        # Capture caller info
+        stack = traceback.extract_stack(limit=3)
+        if len(stack) >= 2:
+            caller = stack[-2]
+            entry["caller_file"] = caller.filename
+            entry["caller_line"] = caller.lineno
+
+        path = _telemetry_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception:
+        pass  # Never fail
+
+
+def read_telemetry() -> list[dict]:
+    """Read all telemetry entries. Returns empty list if no data."""
+    path = _telemetry_path()
+    if not path.exists():
+        return []
+    entries = []
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return entries
+
+
+def summarize_telemetry() -> dict[str, int]:
+    """Return invocation counts per module."""
+    entries = read_telemetry()
+    counts: dict[str, int] = {}
+    for e in entries:
+        mod = e.get("module", "unknown")
+        counts[mod] = counts.get(mod, 0) + 1
+    return counts

--- a/hooks/postmortem_improve.py
+++ b/hooks/postmortem_improve.py
@@ -12,6 +12,9 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from lib_usage_telemetry import record_usage as _record_usage
+_record_usage("postmortem_improve")
+
 from lib_core import (
     _persistent_project_dir,
     _safe_float,

--- a/tests/test_usage_telemetry.py
+++ b/tests/test_usage_telemetry.py
@@ -1,0 +1,187 @@
+"""Tests for PR #17 — usage telemetry for dormancy detection.
+
+Validates:
+  - Telemetry recording and reading
+  - Monitored modules are instrumented
+  - CLI stats-usage command works
+  - Static analysis findings (3 of 4 modules are active)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# lib_usage_telemetry core
+# ---------------------------------------------------------------------------
+
+class TestRecordUsage:
+    def test_records_entry(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": str(tmp_path)}):
+            from lib_usage_telemetry import record_usage, read_telemetry
+            record_usage("test_module")
+            entries = read_telemetry()
+            assert len(entries) == 1
+            assert entries[0]["module"] == "test_module"
+            assert "ts" in entries[0]
+            assert "pid" in entries[0]
+
+    def test_records_function(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": str(tmp_path)}):
+            from lib_usage_telemetry import record_usage, read_telemetry
+            record_usage("test_module", function="my_func")
+            entries = read_telemetry()
+            assert entries[0]["function"] == "my_func"
+
+    def test_appends_multiple(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": str(tmp_path)}):
+            from lib_usage_telemetry import record_usage, read_telemetry
+            record_usage("mod_a")
+            record_usage("mod_b")
+            record_usage("mod_a")
+            entries = read_telemetry()
+            assert len(entries) == 3
+
+    def test_never_raises(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": "/nonexistent/path/that/cannot/be/created/xxxxxxx"}):
+            from lib_usage_telemetry import record_usage
+            # Should not raise even with bad path
+            record_usage("test")
+
+
+class TestSummarizeTelemetry:
+    def test_counts_per_module(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": str(tmp_path)}):
+            from lib_usage_telemetry import record_usage, summarize_telemetry
+            record_usage("mod_a")
+            record_usage("mod_b")
+            record_usage("mod_a")
+            counts = summarize_telemetry()
+            assert counts["mod_a"] == 2
+            assert counts["mod_b"] == 1
+
+    def test_empty_when_no_data(self, tmp_path: Path):
+        with mock.patch.dict(os.environ, {"DYNOS_HOME": str(tmp_path)}):
+            from lib_usage_telemetry import summarize_telemetry
+            assert summarize_telemetry() == {}
+
+
+# ---------------------------------------------------------------------------
+# Instrumentation verification
+# ---------------------------------------------------------------------------
+
+class TestModulesInstrumented:
+    """Verify that each monitored module calls record_usage at import time."""
+
+    def test_dream_instrumented(self):
+        text = (ROOT / "hooks" / "dream.py").read_text()
+        assert "record_usage" in text
+        assert '"dream"' in text
+
+    def test_postmortem_improve_instrumented(self):
+        text = (ROOT / "hooks" / "postmortem_improve.py").read_text()
+        assert "record_usage" in text
+        assert '"postmortem_improve"' in text
+
+    def test_lib_qlearn_instrumented(self):
+        text = (ROOT / "hooks" / "lib_qlearn.py").read_text()
+        assert "record_usage" in text
+        assert '"lib_qlearn"' in text
+
+    def test_cli_base_instrumented(self):
+        text = (ROOT / "hooks" / "cli_base.py").read_text()
+        assert "record_usage" in text
+        assert '"cli_base"' in text
+
+
+# ---------------------------------------------------------------------------
+# Static analysis findings (verified in the exploration)
+# ---------------------------------------------------------------------------
+
+class TestStaticAnalysisFindings:
+    """Codify the static analysis results so they don't regress."""
+
+    def test_cli_base_has_importers(self):
+        """cli_base is imported by 24+ modules — NOT dormant."""
+        from pathlib import Path
+        hooks = ROOT / "hooks"
+        importers = []
+        for f in hooks.glob("*.py"):
+            if f.name == "cli_base.py":
+                continue
+            try:
+                if "from cli_base import" in f.read_text():
+                    importers.append(f.name)
+            except OSError:
+                continue
+        assert len(importers) >= 20, f"cli_base should have 20+ importers, found {len(importers)}"
+
+    def test_lib_qlearn_has_importers(self):
+        """lib_qlearn is imported by ctl.py and proactive.py — NOT dormant."""
+        hooks = ROOT / "hooks"
+        importers = []
+        for f in hooks.glob("*.py"):
+            if f.name == "lib_qlearn.py":
+                continue
+            try:
+                if "from lib_qlearn import" in f.read_text():
+                    importers.append(f.name)
+            except OSError:
+                continue
+        assert len(importers) >= 2
+
+    def test_postmortem_improve_has_importers(self):
+        """postmortem_improve is imported by postmortem.py — NOT dormant."""
+        text = (ROOT / "hooks" / "postmortem.py").read_text()
+        assert "from postmortem_improve import" in text
+
+    def test_dream_has_no_python_importers(self):
+        """dream.py has zero Python importers (only subprocess call from founder skill)."""
+        hooks = ROOT / "hooks"
+        importers = []
+        for f in hooks.glob("*.py"):
+            if f.name == "dream.py":
+                continue
+            try:
+                content = f.read_text()
+                if "from dream import" in content or "import dream" in content:
+                    importers.append(f.name)
+            except OSError:
+                continue
+        assert len(importers) == 0, f"dream.py should have 0 Python importers, found {importers}"
+
+
+# ---------------------------------------------------------------------------
+# CLI: stats-usage
+# ---------------------------------------------------------------------------
+
+class TestStatsUsageCli:
+    def test_runs_successfully(self):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "ctl.py"), "stats-usage"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert "Module Usage Telemetry" in result.stdout
+
+    def test_json_output(self):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "ctl.py"), "stats-usage", "--json"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "dream" in data
+        assert "postmortem_improve" in data
+        assert "lib_qlearn" in data
+        assert "cli_base" in data


### PR DESCRIPTION
## Summary

- Adds lightweight module-level usage telemetry to the 4 dormancy candidates from the original architecture audit
- Each monitored module records a timestamp to `~/.dynos/usage-telemetry.jsonl` on import
- Query via `dynos stats usage [--json]`

### Static analysis findings (codified as regression tests)

| Module | Status | Evidence |
|---|---|---|
| `cli_base.py` | **ACTIVE** | 24+ modules import it — foundational CLI utility |
| `lib_qlearn.py` | **ACTIVE** | ctl.py + proactive.py — core repair pipeline |
| `postmortem_improve.py` | **ACTIVE** | postmortem.py imports 5+ functions |
| `dream.py` | **DORMANT** | Zero Python importers; only subprocess call from founder skill |

**The original audit was wrong about 3 of 4 modules.** Runtime telemetry will confirm over the monitoring period. After 1 week with zero `dream` entries, it's safe to remove (with founder skill migration).

## Verification checklist

- [x] Telemetry recording/reading works correctly
- [x] All 4 modules instrumented with `record_usage()` at import time
- [x] Telemetry never raises (fail-safe — doesn't break callers)
- [x] Static analysis findings codified as regression tests
- [x] `stats-usage` CLI produces valid output (human + JSON)
- [x] Full suite: 1022 passed, same 10 pre-existing failures

## Test plan

- [x] `pytest tests/test_usage_telemetry.py -v` — 16 tests
- [x] Full `pytest tests/` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)