### PR TITLE
[feat] performance auditor, typecheck/lint hooks, ADR plan section

### DIFF
--- a/agents/_shared/audit-report.md
+++ b/agents/_shared/audit-report.md
@@ -44,7 +44,8 @@ All auditors write their report as a JSON file to `.dynos/task-{id}/audit-report
 Auditor-specific notes:
 - `spec-completion-auditor`: `requirement_coverage` is mandatory and must cover every numbered criterion. Finding IDs use prefix `sc-`. Severity is always `critical`.
 - `security-auditor`: `severity` meanings: `critical` = direct exploitability, `major` = significant risk, `minor` = defense-in-depth. Finding IDs use prefix `sec-` (category `security`) or `comp-` (category `compliance`).
-- `code-quality-auditor`: Distinguish blocking from warning in the `blocking` field. Finding IDs use prefix `cq-`. Categories: `code-quality` (default) or `doc-accuracy` (only when `.md` files are in the diff — uses deterministic `validate_docs_accuracy.py` hook).
+- `code-quality-auditor`: Distinguish blocking from warning in the `blocking` field. Finding IDs use prefix `cq-`. Categories: `code-quality` (default), `doc-accuracy` (when `.md` files in diff), or `typecheck-lint` (always runs — uses deterministic `typecheck_lint.py` hook).
 - `ui-auditor`: Every UI state must have specific file evidence. Finding IDs use prefix `ui-`.
 - `db-schema-auditor`: `severity` meanings: `critical` = data loss risk or broken referential integrity, `major` = missing index or N+1, `minor` = naming or minor optimization. Finding IDs use prefix `db-`.
 - `dead-code-auditor`: `severity` meanings: `critical` = unreferenced files or unused exports from core modules, `major` = dead functions or unused imports in multiple files, `minor` = single unused import or isolated commented-out block. Finding IDs use prefix `dc-`.
+- `performance-auditor`: `severity` meanings: `critical` = will cause outage at scale (connection leak, unbounded query), `major` = significant latency risk (N+1, missing index, missing timeout), `minor` = optimization opportunity. Finding IDs use prefix `perf-`. Category: `performance`.

--- a/agents/code-quality-auditor.md
+++ b/agents/code-quality-auditor.md
@@ -33,6 +33,26 @@ You are the Code Quality Auditor. You verify that implementations are maintainab
 
 **Cleanliness:** No dead code. No debug logs. No unused imports. No magic numbers.
 
+### Category: typecheck-lint
+
+**Always runs.** Run the deterministic typecheck and lint hook:
+
+```bash
+python3 "${PLUGIN_HOOKS}/typecheck_lint.py" --root . --changed-files {comma-separated changed files}
+```
+
+The hook auto-detects project ecosystems and runs the appropriate tools:
+- **Python:** mypy (type checking) + ruff/flake8 (linting)
+- **TypeScript/JavaScript:** tsc --noEmit (type checking) + eslint (linting)
+- **Go:** go vet (type checking) + golangci-lint (linting)
+
+For each failed check, emit a finding with:
+- ID prefix: `cq-`
+- Category: `typecheck-lint`
+- Severity: `major` for type errors (fabricated function signatures, wrong argument types). `minor` for lint warnings.
+- Blocking: `true` for type errors, `false` for lint warnings
+- If no tools are available for the detected ecosystem, note this in the report but do not emit false findings.
+
 ### Category: doc-accuracy
 
 **Only runs when the diff includes `.md` files.** If no markdown files were changed by this task, skip this category entirely.

--- a/agents/performance-auditor.md
+++ b/agents/performance-auditor.md
@@ -1,0 +1,67 @@
+---
+name: performance-auditor
+description: "Internal dynos-work agent. Analyzes query plans, algorithmic complexity, resource usage patterns, and latency risks. Blocks on backend/db tasks. Read-only."
+model: sonnet
+tools: [Read, Grep, Glob, Bash]
+---
+
+# dynos-work Performance Auditor
+
+You are the Performance Auditor. You think like a site reliability engineer reviewing code before it hits production at scale. You are read-only.
+
+**You run when backend or db files are touched. You block on significant performance regressions.**
+
+## You receive
+
+- **Diff-scoped file list** — only files changed by this task (from `git diff --name-only {snapshot_head_sha}`). Focus your audit on THESE files only, not the entire codebase.
+- `.dynos/task-{id}/spec.md`
+- `.dynos/task-{id}/evidence/`
+
+## What you inspect
+
+### Query patterns
+
+- **N+1 queries:** loop that issues a query per iteration (ORM `.get()` inside a for loop, sequential API calls in a loop). Flag with exact file:line.
+- **Missing indexes:** queries filtering or joining on columns without indexes. Cross-reference query WHERE/JOIN columns against schema/migration files.
+- **Unbounded queries:** `SELECT *` without LIMIT on tables that grow. Any query that returns all rows without pagination.
+- **Missing transactions:** multiple writes that should be atomic but aren't wrapped in a transaction.
+
+### Algorithmic complexity
+
+- **O(n^2) or worse:** nested loops over the same collection, repeated linear scans, cartesian products.
+- **Unnecessary recomputation:** values computed in a loop that could be computed once. Missing memoization for expensive pure functions.
+- **Large payload serialization:** serializing entire object graphs when only a subset is needed.
+
+### Resource usage
+
+- **Connection/pool exhaustion:** database connections opened but not closed/returned. HTTP clients without connection pooling or timeout.
+- **Memory accumulation:** unbounded lists/dicts that grow with input size without cleanup. Loading entire files into memory when streaming is possible.
+- **Missing timeouts:** external HTTP calls, database queries, or subprocess invocations without timeout parameters.
+- **Blocking the event loop:** synchronous I/O in async code paths (sync file reads, sync HTTP calls in async handlers).
+
+### Deterministic checks
+
+Before the LLM review, run the deterministic performance hook on changed files:
+
+```bash
+python3 "${PLUGIN_HOOKS}/performance_check.py" --root . --changed-files {comma-separated changed files}
+```
+
+The hook statically detects: N+1 patterns, missing timeouts, unbounded queries, O(n^2) loops, missing connection cleanup. Incorporate its findings into your report — these are tool-grounded, not opinions.
+
+## Output
+
+Write report to `.dynos/task-{id}/audit-reports/performance-{timestamp}.json`.
+
+Write your report following the canonical schema defined in `agents/_shared/audit-report.md`.
+
+**Every finding must include a `category` field** — `"performance"`.
+
+**Severity:** `critical` = will cause outage at scale (connection leak, unbounded query on large table, O(n^2) on user-facing endpoint). `major` = significant latency risk (N+1, missing index on hot path, missing timeout). `minor` = optimization opportunity (unnecessary recomputation, suboptimal serialization).
+
+## Hard rules
+
+- Do not modify files
+- Think about production scale — 10x, 100x, 1000x the current data volume
+- Performance findings are based on code patterns and deterministic hook output — do not guess about runtime behavior without evidence
+- Always write report

--- a/agents/planning.md
+++ b/agents/planning.md
@@ -116,6 +116,17 @@ Write to `.dynos/task-{id}/plan.md`:
 ## Technical Approach
 [2-3 paragraphs describing the overall approach. Start with the WHY — why this approach over alternatives. Then the WHAT — the high-level architecture. Then the HOW — the key technical decisions. Name the existing patterns in the codebase that this work should follow.]
 
+## Architecture Decisions
+*(Required when risk_level is high or critical. Omit for low/medium-risk tasks.)*
+
+[For every significant technical decision in this task, document it as a typed ADR:
+
+| ID | Decision | Rationale | Alternatives considered | Tradeoffs |
+|---|---|---|---|---|
+| ADR-1 | Use REST over GraphQL | CRUD-heavy data; simpler client caching | GraphQL (flexible queries), gRPC (perf) | Less flexible queries, but simpler error handling |
+
+Each ADR is a constraint that downstream executors must follow. If an executor encounters a gray area not covered by an ADR, they should stop and ask rather than guess.]
+
 ## Reference Code
 [List 2-5 existing files in the codebase that executors should read before implementing, with a one-sentence note on what pattern each demonstrates. This prevents executors from inventing new patterns when existing ones work.]
 

--- a/agents/repair-coordinator.md
+++ b/agents/repair-coordinator.md
@@ -44,6 +44,7 @@ You are the Repair Coordinator. You receive audit findings and produce a precise
 - ML/model findings → `ml-executor`
 - Compliance findings (category `compliance`, prefix `comp-`) → route by affected file type: dependency manifests and license issues → `integration-executor`; missing privacy features (data export, account deletion) → `backend-executor`
 - Doc-accuracy findings (category `doc-accuracy`, prefix `cq-`) → route to the executor that owns the affected `.md` file's subject area; if unclear, → `integration-executor`
+- Performance findings (category `performance`, prefix `perf-`) → route by affected file type: query/ORM findings → `db-executor`; API/endpoint latency findings → `backend-executor`; frontend performance → `ui-executor`
 
 ## Instruction quality
 

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -45,13 +45,15 @@ _API_CONTRACT_DOMAINS: set[str] = {"backend", "ui", "security"}
 _DATA_MODEL_DOMAINS: set[str] = {"db"}
 
 
-def conditional_plan_headings(domains: Iterable[str]) -> list[str]:
-    """Return additional required plan headings based on classification domains.
+_HIGH_RISK_LEVELS: set[str] = {"high", "critical"}
 
-    - ``API Contracts`` is required when domains include backend, ui, or security
-      (any task touching API surfaces needs explicit contract documentation).
-    - ``Data Model`` is required when domains include db
-      (any task touching the data layer needs schema documentation).
+
+def conditional_plan_headings(domains: Iterable[str], risk_level: str = "medium") -> list[str]:
+    """Return additional required plan headings based on classification.
+
+    - ``API Contracts`` is required when domains include backend, ui, or security.
+    - ``Data Model`` is required when domains include db.
+    - ``Architecture Decisions`` is required when risk_level is high or critical.
     """
     extra: list[str] = []
     domain_set = set(domains) if not isinstance(domains, set) else domains
@@ -59,6 +61,8 @@ def conditional_plan_headings(domains: Iterable[str]) -> list[str]:
         extra.append("API Contracts")
     if domain_set & _DATA_MODEL_DOMAINS:
         extra.append("Data Model")
+    if risk_level in _HIGH_RISK_LEVELS:
+        extra.append("Architecture Decisions")
     return extra
 
 
@@ -233,7 +237,8 @@ def validate_task_artifacts(task_dir: Path, strict: bool = False) -> list[str]:
         plan_text = require(plan_path)
         classification = manifest.get("classification") or {}
         domains = classification.get("domains", [])
-        all_required = REQUIRED_PLAN_HEADINGS + conditional_plan_headings(domains)
+        risk_level = classification.get("risk_level", "medium")
+        all_required = REQUIRED_PLAN_HEADINGS + conditional_plan_headings(domains, risk_level)
         for heading in all_required:
             if heading not in collect_headings(plan_text):
                 errors.append(f"plan missing heading: {heading}")

--- a/hooks/performance_check.py
+++ b/hooks/performance_check.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Deterministic performance pattern detection for the performance-auditor.
+
+Statically scans source files for common performance anti-patterns.
+Works for ANY project type — detects patterns across Python, JS/TS, Go, Java, Ruby.
+
+Usage:
+    python3 hooks/performance_check.py --root <project-root> --changed-files file1.py,file2.ts
+
+Outputs JSON to stdout with detected patterns and file:line locations.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+CODE_EXTENSIONS = {
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".rb", ".java",
+    ".kt", ".swift", ".cs", ".php", ".ex", ".exs", ".dart",
+}
+
+SKIP_DIRS = {".git", "node_modules", ".dynos", "__pycache__", "dist", "build", "vendor"}
+
+
+# ---------------------------------------------------------------------------
+# Pattern detectors
+# ---------------------------------------------------------------------------
+
+def _detect_n_plus_one(content: str, filepath: str) -> list[dict[str, Any]]:
+    """Detect N+1 query patterns: DB calls inside loops."""
+    findings: list[dict[str, Any]] = []
+    lines = content.splitlines()
+    in_loop = False
+    loop_start = 0
+
+    # Python: for/while loop containing .query, .execute, .get, .filter, .find
+    db_call_re = re.compile(
+        r"\.(query|execute|find|findOne|findAll|get|filter|select|fetch|where|raw|all)\s*\(", re.IGNORECASE
+    )
+    loop_re = re.compile(r"^\s*(for |while |\.forEach|\.map\(|\.each\b)")
+
+    for i, line in enumerate(lines, 1):
+        if loop_re.search(line):
+            in_loop = True
+            loop_start = i
+        elif in_loop and line.strip() and not line.strip().startswith(("#", "//", "*")):
+            indent_match = re.match(r"^(\s*)", line)
+            loop_indent_match = re.match(r"^(\s*)", lines[loop_start - 1]) if loop_start > 0 else None
+            if indent_match and loop_indent_match:
+                if len(indent_match.group(1)) <= len(loop_indent_match.group(1)) and line.strip():
+                    in_loop = False
+
+        if in_loop and db_call_re.search(line):
+            findings.append({
+                "pattern": "n_plus_one",
+                "location": f"{filepath}:{i}",
+                "line": line.strip()[:120],
+                "severity": "major",
+                "description": f"Database/query call inside loop (loop starts at line {loop_start})",
+            })
+
+    return findings
+
+
+def _detect_missing_timeout(content: str, filepath: str) -> list[dict[str, Any]]:
+    """Detect HTTP/subprocess/DB calls without timeout parameters."""
+    findings: list[dict[str, Any]] = []
+    lines = content.splitlines()
+
+    # Patterns that should have timeout
+    call_patterns = [
+        (re.compile(r"requests\.(get|post|put|patch|delete)\s*\("), "requests"),
+        (re.compile(r"fetch\s*\("), "fetch"),
+        (re.compile(r"axios\.(get|post|put|patch|delete)\s*\("), "axios"),
+        (re.compile(r"subprocess\.run\s*\("), "subprocess.run"),
+        (re.compile(r"subprocess\.Popen\s*\("), "subprocess.Popen"),
+        (re.compile(r"http\.(?:Get|Post|Do)\s*\("), "go-http"),
+    ]
+
+    for i, line in enumerate(lines, 1):
+        for pattern, name in call_patterns:
+            if pattern.search(line) and "timeout" not in line.lower():
+                # Check next 3 lines for timeout param
+                context = "\n".join(lines[i - 1:min(i + 3, len(lines))])
+                if "timeout" not in context.lower():
+                    findings.append({
+                        "pattern": "missing_timeout",
+                        "location": f"{filepath}:{i}",
+                        "line": line.strip()[:120],
+                        "severity": "major",
+                        "description": f"{name} call without timeout parameter",
+                    })
+    return findings
+
+
+def _detect_unbounded_query(content: str, filepath: str) -> list[dict[str, Any]]:
+    """Detect queries that return all rows without LIMIT/pagination."""
+    findings: list[dict[str, Any]] = []
+    lines = content.splitlines()
+
+    # SELECT without LIMIT
+    select_re = re.compile(r"SELECT\s+.*\s+FROM\s+", re.IGNORECASE)
+    find_all_re = re.compile(r"\.(findAll|find_all|all|objects\.all|select)\s*\(\s*\)", re.IGNORECASE)
+
+    for i, line in enumerate(lines, 1):
+        if select_re.search(line) and "LIMIT" not in line.upper() and "COUNT" not in line.upper():
+            context = "\n".join(lines[i - 1:min(i + 2, len(lines))])
+            if "LIMIT" not in context.upper() and "limit" not in context.lower():
+                findings.append({
+                    "pattern": "unbounded_query",
+                    "location": f"{filepath}:{i}",
+                    "line": line.strip()[:120],
+                    "severity": "major",
+                    "description": "Query without LIMIT — may return unbounded rows",
+                })
+        if find_all_re.search(line):
+            context = "\n".join(lines[i - 1:min(i + 3, len(lines))])
+            if "limit" not in context.lower() and "paginate" not in context.lower() and "[::" not in context:
+                findings.append({
+                    "pattern": "unbounded_query",
+                    "location": f"{filepath}:{i}",
+                    "line": line.strip()[:120],
+                    "severity": "major",
+                    "description": "Query returning all rows without pagination",
+                })
+
+    return findings
+
+
+def _detect_quadratic(content: str, filepath: str) -> list[dict[str, Any]]:
+    """Detect O(n^2) nested loop patterns."""
+    findings: list[dict[str, Any]] = []
+    lines = content.splitlines()
+    loop_re = re.compile(r"^\s*(for |while |\.forEach|\.map\(|\.filter\(|\.some\(|\.every\()")
+
+    loop_depth = 0
+    loop_lines: list[int] = []
+
+    for i, line in enumerate(lines, 1):
+        if loop_re.search(line):
+            loop_depth += 1
+            loop_lines.append(i)
+            if loop_depth >= 2:
+                findings.append({
+                    "pattern": "quadratic_loop",
+                    "location": f"{filepath}:{i}",
+                    "line": line.strip()[:120],
+                    "severity": "major",
+                    "description": f"Nested loop (depth {loop_depth}) — potential O(n^2) or worse. Outer loop at line {loop_lines[0]}",
+                })
+        # Very rough scope tracking — reset on dedent to function level
+        if line.strip() and not line.strip().startswith(("#", "//", "*", "/*")):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if indent == 0 and (stripped.startswith("def ") or stripped.startswith("func ") or
+                                stripped.startswith("function ") or stripped.startswith("class ") or
+                                stripped.startswith("export ")):
+                loop_depth = 0
+                loop_lines = []
+
+    return findings
+
+
+def _detect_missing_connection_cleanup(content: str, filepath: str) -> list[dict[str, Any]]:
+    """Detect database/HTTP connections opened without close/cleanup."""
+    findings: list[dict[str, Any]] = []
+    lines = content.splitlines()
+
+    open_patterns = [
+        (re.compile(r"(connect|createConnection|createPool|open)\s*\("), "close"),
+        (re.compile(r"(psycopg2\.connect|sqlite3\.connect|pymongo\.MongoClient)\s*\("), "close"),
+    ]
+
+    full = content.lower()
+    for pattern, close_word in open_patterns:
+        for i, line in enumerate(lines, 1):
+            if pattern.search(line):
+                # Check if there's a corresponding close/with/finally in the same function scope
+                scope = "\n".join(lines[i - 1:min(i + 30, len(lines))])
+                if (close_word not in scope.lower() and "with " not in scope.lower() and
+                        "finally" not in scope.lower() and "context" not in scope.lower()):
+                    findings.append({
+                        "pattern": "missing_connection_cleanup",
+                        "location": f"{filepath}:{i}",
+                        "line": line.strip()[:120],
+                        "severity": "critical",
+                        "description": "Connection opened without visible close/cleanup in scope",
+                    })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Main scanner
+# ---------------------------------------------------------------------------
+
+def scan_files(root: Path, changed_files: list[str] | None = None) -> dict[str, Any]:
+    """Scan files for performance anti-patterns."""
+    targets: list[Path] = []
+    if changed_files:
+        for f in changed_files:
+            p = root / f
+            if p.exists() and p.suffix in CODE_EXTENSIONS:
+                targets.append(p)
+    else:
+        count = 0
+        for f in root.rglob("*"):
+            if any(d in f.parts for d in SKIP_DIRS):
+                continue
+            if f.suffix in CODE_EXTENSIONS and f.is_file():
+                targets.append(f)
+                count += 1
+                if count >= 500:
+                    break
+
+    all_findings: list[dict[str, Any]] = []
+    detectors = [
+        _detect_n_plus_one,
+        _detect_missing_timeout,
+        _detect_unbounded_query,
+        _detect_quadratic,
+        _detect_missing_connection_cleanup,
+    ]
+
+    for fpath in targets:
+        try:
+            content = fpath.read_text(errors="ignore")
+        except (OSError, PermissionError):
+            continue
+        rel = str(fpath.relative_to(root)) if fpath.is_relative_to(root) else str(fpath)
+        for detector in detectors:
+            all_findings.extend(detector(content, rel))
+
+    return {
+        "files_scanned": len(targets),
+        "findings": all_findings,
+        "patterns_checked": ["n_plus_one", "missing_timeout", "unbounded_query", "quadratic_loop", "missing_connection_cleanup"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deterministic performance pattern detection")
+    parser.add_argument("--root", required=True, help="Project root directory")
+    parser.add_argument("--changed-files", help="Comma-separated list of changed files")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    changed = args.changed_files.split(",") if args.changed_files else None
+    result = scan_files(root, changed)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -608,6 +608,8 @@ def build_audit_plan(root: Path, task_type: str, domains: list[str], fast_track:
             eligible.append("ui-auditor")
         if "db" in domains:
             eligible.append("db-schema-auditor")
+        if "backend" in domains or "db" in domains:
+            eligible.append("performance-auditor")
 
     for auditor in eligible:
         # Skip check

--- a/hooks/typecheck_lint.py
+++ b/hooks/typecheck_lint.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Deterministic typecheck and lint runner for dynos-work.
+
+Auto-detects project ecosystem and runs the appropriate type checker and
+linter. Works for ANY project type — detects from config files.
+
+Usage:
+    python3 hooks/typecheck_lint.py --root <project-root>
+    python3 hooks/typecheck_lint.py --root <project-root> --changed-files file1.py,file2.ts
+
+Outputs JSON to stdout with pass/fail status and error details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run(cmd: list[str], cwd: str | None = None, timeout: int = 120) -> tuple[int, str, str]:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+        return r.returncode, r.stdout, r.stderr
+    except FileNotFoundError:
+        return -1, "", f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -2, "", f"timeout after {timeout}s"
+
+
+# ---------------------------------------------------------------------------
+# Type checkers
+# ---------------------------------------------------------------------------
+
+def check_python_types(root: Path, changed: list[str] | None) -> dict[str, Any]:
+    """Run mypy if available."""
+    targets = changed if changed else ["."]
+    rc, stdout, stderr = _run(
+        ["mypy", "--no-error-summary", "--no-color"] + targets,
+        cwd=str(root), timeout=120,
+    )
+    if rc == -1:
+        return {"tool": "mypy", "available": False, "reason": "mypy not installed"}
+    errors = [l for l in stdout.splitlines() if ": error:" in l]
+    return {
+        "tool": "mypy",
+        "available": True,
+        "passed": rc == 0,
+        "error_count": len(errors),
+        "errors": errors[:20],
+    }
+
+
+def check_typescript_types(root: Path) -> dict[str, Any]:
+    """Run tsc --noEmit if tsconfig.json exists."""
+    if not (root / "tsconfig.json").exists():
+        return {"tool": "tsc", "available": False, "reason": "no tsconfig.json"}
+    rc, stdout, stderr = _run(
+        ["npx", "tsc", "--noEmit", "--pretty", "false"],
+        cwd=str(root), timeout=120,
+    )
+    if rc == -1:
+        return {"tool": "tsc", "available": False, "reason": "npx/tsc not installed"}
+    output = stdout + stderr
+    errors = [l for l in output.splitlines() if ": error TS" in l]
+    return {
+        "tool": "tsc",
+        "available": True,
+        "passed": rc == 0,
+        "error_count": len(errors),
+        "errors": errors[:20],
+    }
+
+
+def check_go_types(root: Path) -> dict[str, Any]:
+    """Run go vet if go.mod exists."""
+    if not (root / "go.mod").exists():
+        return {"tool": "go vet", "available": False, "reason": "no go.mod"}
+    rc, stdout, stderr = _run(["go", "vet", "./..."], cwd=str(root), timeout=120)
+    if rc == -1:
+        return {"tool": "go vet", "available": False, "reason": "go not installed"}
+    errors = [l for l in stderr.splitlines() if l.strip()]
+    return {
+        "tool": "go vet",
+        "available": True,
+        "passed": rc == 0,
+        "error_count": len(errors),
+        "errors": errors[:20],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Linters
+# ---------------------------------------------------------------------------
+
+def lint_python(root: Path, changed: list[str] | None) -> dict[str, Any]:
+    """Run ruff or flake8 if available."""
+    targets = changed if changed else ["."]
+    # Try ruff first (fast)
+    rc, stdout, stderr = _run(
+        ["ruff", "check", "--output-format=json"] + targets,
+        cwd=str(root), timeout=60,
+    )
+    if rc != -1:
+        try:
+            issues = json.loads(stdout) if stdout.strip() else []
+        except json.JSONDecodeError:
+            issues = []
+        return {
+            "tool": "ruff",
+            "available": True,
+            "passed": rc == 0,
+            "issue_count": len(issues) if isinstance(issues, list) else 0,
+            "issues": (issues[:20] if isinstance(issues, list) else []),
+        }
+    # Fallback to flake8
+    rc, stdout, stderr = _run(
+        ["flake8", "--format=json"] + targets,
+        cwd=str(root), timeout=60,
+    )
+    if rc != -1:
+        return {
+            "tool": "flake8",
+            "available": True,
+            "passed": rc == 0,
+            "issue_count": stdout.count("\n"),
+            "issues": stdout.splitlines()[:20],
+        }
+    return {"tool": "ruff/flake8", "available": False, "reason": "neither ruff nor flake8 installed"}
+
+
+def lint_javascript(root: Path) -> dict[str, Any]:
+    """Run eslint if .eslintrc or eslint config exists."""
+    has_config = any(
+        (root / f).exists()
+        for f in [".eslintrc", ".eslintrc.js", ".eslintrc.json", ".eslintrc.yml",
+                  "eslint.config.js", "eslint.config.mjs", "eslint.config.ts"]
+    )
+    if not has_config:
+        # Check package.json for eslintConfig
+        pkg = root / "package.json"
+        if pkg.exists():
+            try:
+                data = json.loads(pkg.read_text())
+                if "eslintConfig" not in data:
+                    return {"tool": "eslint", "available": False, "reason": "no eslint config found"}
+            except (json.JSONDecodeError, OSError):
+                return {"tool": "eslint", "available": False, "reason": "no eslint config found"}
+        else:
+            return {"tool": "eslint", "available": False, "reason": "no eslint config found"}
+
+    rc, stdout, stderr = _run(
+        ["npx", "eslint", ".", "--format=json", "--max-warnings=0"],
+        cwd=str(root), timeout=120,
+    )
+    if rc == -1:
+        return {"tool": "eslint", "available": False, "reason": "npx/eslint not installed"}
+    try:
+        results = json.loads(stdout) if stdout.strip() else []
+        total_errors = sum(r.get("errorCount", 0) for r in results) if isinstance(results, list) else 0
+        total_warnings = sum(r.get("warningCount", 0) for r in results) if isinstance(results, list) else 0
+    except json.JSONDecodeError:
+        total_errors = 0
+        total_warnings = 0
+    return {
+        "tool": "eslint",
+        "available": True,
+        "passed": rc == 0,
+        "error_count": total_errors,
+        "warning_count": total_warnings,
+    }
+
+
+def lint_go(root: Path) -> dict[str, Any]:
+    """Run golangci-lint if available and go.mod exists."""
+    if not (root / "go.mod").exists():
+        return {"tool": "golangci-lint", "available": False, "reason": "no go.mod"}
+    rc, stdout, stderr = _run(
+        ["golangci-lint", "run", "--out-format=json"],
+        cwd=str(root), timeout=120,
+    )
+    if rc == -1:
+        return {"tool": "golangci-lint", "available": False, "reason": "golangci-lint not installed"}
+    try:
+        data = json.loads(stdout) if stdout.strip() else {}
+        issues = data.get("Issues", []) if isinstance(data, dict) else []
+    except json.JSONDecodeError:
+        issues = []
+    return {
+        "tool": "golangci-lint",
+        "available": True,
+        "passed": rc == 0,
+        "issue_count": len(issues),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ecosystem detection and runner
+# ---------------------------------------------------------------------------
+
+def run_checks(root: Path, changed_files: list[str] | None = None) -> dict[str, Any]:
+    """Detect ecosystems and run appropriate checkers."""
+    results: dict[str, Any] = {"typechecks": [], "linters": []}
+
+    # Python
+    py_markers = ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"]
+    if any((root / m).exists() for m in py_markers):
+        py_changed = [f for f in (changed_files or []) if f.endswith(".py")]
+        results["typechecks"].append(check_python_types(root, py_changed or None))
+        results["linters"].append(lint_python(root, py_changed or None))
+
+    # TypeScript/JavaScript
+    if (root / "package.json").exists():
+        results["typechecks"].append(check_typescript_types(root))
+        results["linters"].append(lint_javascript(root))
+
+    # Go
+    if (root / "go.mod").exists():
+        results["typechecks"].append(check_go_types(root))
+        results["linters"].append(lint_go(root))
+
+    # Summary
+    all_checks = results["typechecks"] + results["linters"]
+    available = [c for c in all_checks if c.get("available")]
+    failed = [c for c in available if not c.get("passed", True)]
+    results["summary"] = {
+        "ecosystems_detected": len(set(c["tool"].split("/")[0] for c in all_checks if c.get("available"))),
+        "checks_run": len(available),
+        "checks_passed": len(available) - len(failed),
+        "checks_failed": len(failed),
+    }
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deterministic typecheck and lint runner")
+    parser.add_argument("--root", required=True, help="Project root directory")
+    parser.add_argument("--changed-files", help="Comma-separated list of changed files")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    changed = args.changed_files.split(",") if args.changed_files else None
+    result = run_checks(root, changed)
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_tool_boundaries.py
+++ b/tests/test_agent_tool_boundaries.py
@@ -38,6 +38,7 @@ READ_ONLY_AUDITORS = {
     "code-quality-auditor",
     "db-schema-auditor",
     "dead-code-auditor",
+    "performance-auditor",
     "security-auditor",
     "spec-completion-auditor",
     "ui-auditor",
@@ -98,7 +99,7 @@ class TestAllAgentsHaveTools:
         assert len(fm["tools"]) > 0, f"{agent_file.name} tools: must not be empty"
 
     def test_all_17_agents_found(self):
-        assert len(AGENT_FILES) == 17, f"Expected 17 agents, found {len(AGENT_FILES)}"
+        assert len(AGENT_FILES) == 18, f"Expected 18 agents, found {len(AGENT_FILES)}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_performance_typecheck.py
+++ b/tests/test_performance_typecheck.py
@@ -1,0 +1,244 @@
+"""Tests for performance auditor, typecheck/lint hooks, and ADR plan section.
+
+Covers:
+  - Performance check hook detects patterns (N+1, missing timeout, unbounded query, quadratic, connection leak)
+  - Typecheck/lint hook auto-detects ecosystems
+  - Performance auditor agent exists with correct frontmatter
+  - ADR section conditional on risk_level
+  - Router includes performance-auditor for backend/db domains
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Performance check hook
+# ---------------------------------------------------------------------------
+
+class TestPerformanceCheck:
+    def test_detects_n_plus_one(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "app.py").write_text(
+            "for user in users:\n    db.query(f'SELECT * FROM orders WHERE user_id={user.id}')\n"
+        )
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "n_plus_one" in patterns
+
+    def test_detects_missing_timeout(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "client.py").write_text("response = requests.get('https://api.example.com/data')\n")
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "missing_timeout" in patterns
+
+    def test_no_false_positive_with_timeout(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "client.py").write_text("response = requests.get('https://api.example.com/data', timeout=30)\n")
+        result = scan_files(tmp_path)
+        timeout_findings = [f for f in result["findings"] if f["pattern"] == "missing_timeout"]
+        assert len(timeout_findings) == 0
+
+    def test_detects_unbounded_query(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "repo.py").write_text("rows = db.execute('SELECT * FROM users')\n")
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "unbounded_query" in patterns
+
+    def test_detects_quadratic_loop(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "algo.py").write_text("for i in items:\n    for j in items:\n        compare(i, j)\n")
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "quadratic_loop" in patterns
+
+    def test_detects_connection_leak(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "db.py").write_text("conn = psycopg2.connect(db_url)\ncursor = conn.cursor()\ncursor.execute(query)\n")
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "missing_connection_cleanup" in patterns
+
+    def test_clean_code_no_findings(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "clean.py").write_text("def add(a, b):\n    return a + b\n")
+        result = scan_files(tmp_path)
+        assert len(result["findings"]) == 0
+
+    def test_cli_json_output(self, tmp_path: Path):
+        (tmp_path / "app.py").write_text("x = 1\n")
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "performance_check.py"),
+             "--root", str(tmp_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "files_scanned" in data
+
+    def test_changed_files_filter(self, tmp_path: Path):
+        from performance_check import scan_files
+        (tmp_path / "a.py").write_text("for x in items:\n    db.query(x)\n")
+        (tmp_path / "b.py").write_text("clean = True\n")
+        result = scan_files(tmp_path, changed_files=["b.py"])
+        assert len(result["findings"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Typecheck/lint hook
+# ---------------------------------------------------------------------------
+
+class TestTypecheckLint:
+    def test_detects_no_ecosystems_in_empty_dir(self, tmp_path: Path):
+        from typecheck_lint import run_checks
+        result = run_checks(tmp_path)
+        assert result["summary"]["ecosystems_detected"] == 0
+
+    def test_cli_json_output(self, tmp_path: Path):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "typecheck_lint.py"),
+             "--root", str(tmp_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "typechecks" in data
+        assert "linters" in data
+        assert "summary" in data
+
+    def test_detects_python_ecosystem(self, tmp_path: Path):
+        from typecheck_lint import run_checks
+        (tmp_path / "requirements.txt").write_text("flask\n")
+        result = run_checks(tmp_path)
+        tools = [c["tool"] for c in result["typechecks"] + result["linters"]]
+        assert any("mypy" in t or "ruff" in t or "flake8" in t for t in tools)
+
+
+# ---------------------------------------------------------------------------
+# Performance auditor agent
+# ---------------------------------------------------------------------------
+
+class TestPerformanceAuditorAgent:
+    @pytest.fixture
+    def agent_text(self) -> str:
+        return (ROOT / "agents" / "performance-auditor.md").read_text()
+
+    def test_exists(self):
+        assert (ROOT / "agents" / "performance-auditor.md").is_file()
+
+    def test_has_tools_frontmatter(self, agent_text: str):
+        assert "tools:" in agent_text
+        assert "Read" in agent_text
+        assert "Write" not in agent_text.split("---")[1]  # read-only
+
+    def test_has_performance_hook_invocation(self, agent_text: str):
+        assert "performance_check.py" in agent_text
+
+    def test_uses_perf_prefix(self, agent_text: str):
+        assert "perf-" in agent_text.lower() or '"performance"' in agent_text
+
+    def test_severity_definitions(self, agent_text: str):
+        assert "critical" in agent_text
+        assert "major" in agent_text
+        assert "minor" in agent_text
+
+
+# ---------------------------------------------------------------------------
+# ADR section in planning — conditional on risk_level
+# ---------------------------------------------------------------------------
+
+class TestADRConditionalSection:
+    def test_high_risk_requires_adrs(self):
+        from lib_validate import conditional_plan_headings
+        assert "Architecture Decisions" in conditional_plan_headings(["backend"], risk_level="high")
+
+    def test_critical_risk_requires_adrs(self):
+        from lib_validate import conditional_plan_headings
+        assert "Architecture Decisions" in conditional_plan_headings(["backend"], risk_level="critical")
+
+    def test_medium_risk_no_adrs(self):
+        from lib_validate import conditional_plan_headings
+        assert "Architecture Decisions" not in conditional_plan_headings(["backend"], risk_level="medium")
+
+    def test_low_risk_no_adrs(self):
+        from lib_validate import conditional_plan_headings
+        assert "Architecture Decisions" not in conditional_plan_headings(["backend"], risk_level="low")
+
+    def test_planner_template_has_adr_section(self):
+        text = (ROOT / "agents" / "planning.md").read_text()
+        assert "## Architecture Decisions" in text
+
+    def test_planner_template_adr_conditional_note(self):
+        text = (ROOT / "agents" / "planning.md").read_text()
+        assert "risk_level is high or critical" in text
+
+
+# ---------------------------------------------------------------------------
+# Router includes performance-auditor
+# ---------------------------------------------------------------------------
+
+class TestRouterPerformanceAuditor:
+    def test_backend_domain_includes_perf_auditor(self):
+        from unittest import mock
+        with mock.patch("router.is_learning_enabled", return_value=True), \
+             mock.patch("router.resolve_skip", return_value={"skip": False, "reason": "no skip", "streak": 0, "threshold": 0}), \
+             mock.patch("router.resolve_model", return_value={"model": None, "source": "default"}), \
+             mock.patch("router.resolve_route", return_value={"mode": "generic", "agent_path": None, "agent_name": None, "composite_score": 0.0, "source": "no learned agent"}), \
+             mock.patch("router.log_event"):
+            from router import build_audit_plan
+            plan = build_audit_plan(Path("."), "feature", ["backend"])
+            names = [a["name"] for a in plan["auditors"]]
+            assert "performance-auditor" in names
+
+    def test_db_domain_includes_perf_auditor(self):
+        from unittest import mock
+        with mock.patch("router.is_learning_enabled", return_value=True), \
+             mock.patch("router.resolve_skip", return_value={"skip": False, "reason": "no skip", "streak": 0, "threshold": 0}), \
+             mock.patch("router.resolve_model", return_value={"model": None, "source": "default"}), \
+             mock.patch("router.resolve_route", return_value={"mode": "generic", "agent_path": None, "agent_name": None, "composite_score": 0.0, "source": "no learned agent"}), \
+             mock.patch("router.log_event"):
+            from router import build_audit_plan
+            plan = build_audit_plan(Path("."), "feature", ["db"])
+            names = [a["name"] for a in plan["auditors"]]
+            assert "performance-auditor" in names
+
+    def test_ui_only_no_perf_auditor(self):
+        from unittest import mock
+        with mock.patch("router.is_learning_enabled", return_value=True), \
+             mock.patch("router.resolve_skip", return_value={"skip": False, "reason": "no skip", "streak": 0, "threshold": 0}), \
+             mock.patch("router.resolve_model", return_value={"model": None, "source": "default"}), \
+             mock.patch("router.resolve_route", return_value={"mode": "generic", "agent_path": None, "agent_name": None, "composite_score": 0.0, "source": "no learned agent"}), \
+             mock.patch("router.log_event"):
+            from router import build_audit_plan
+            plan = build_audit_plan(Path("."), "feature", ["ui"])
+            names = [a["name"] for a in plan["auditors"]]
+            assert "performance-auditor" not in names
+
+
+# ---------------------------------------------------------------------------
+# Audit report schema
+# ---------------------------------------------------------------------------
+
+class TestAuditReportSchema:
+    def test_perf_prefix_documented(self):
+        text = (ROOT / "agents" / "_shared" / "audit-report.md").read_text()
+        assert "perf-" in text
+
+    def test_performance_auditor_documented(self):
+        text = (ROOT / "agents" / "_shared" / "audit-report.md").read_text()
+        assert "performance-auditor" in text
+
+    def test_typecheck_lint_documented(self):
+        text = (ROOT / "agents" / "_shared" / "audit-report.md").read_text()
+        assert "typecheck-lint" in text


### PR DESCRIPTION
## Summary

Closes 3 blueprint gaps in one PR:

### 1. Performance auditor (new agent + hook)
- `agents/performance-auditor.md` — 18th agent, read-only, spawns for backend/db domains
- `hooks/performance_check.py` — deterministic detection of 5 anti-patterns: N+1 queries, missing timeouts, unbounded queries, O(n^2) loops, connection leaks
- Wired into `router.py build_audit_plan` — auto-spawns when domains include backend or db
- Findings use `perf-` prefix, category `performance`

### 2. Typecheck/lint hooks
- `hooks/typecheck_lint.py` — auto-detects ecosystem, runs appropriate tools:
  - Python: mypy + ruff/flake8
  - TypeScript/JavaScript: tsc --noEmit + eslint
  - Go: go vet + golangci-lint
- Wired into `code-quality-auditor` as `typecheck-lint` category (always runs)

### 3. Architecture Decision Records
- `## Architecture Decisions` section added to planning template
- Required when `risk_level` is `high` or `critical` (conditional, same pattern as API Contracts/Data Model)
- Typed ADR table: Decision, Rationale, Alternatives considered, Tradeoffs

## Verification

- [x] 29 new tests pass (perf patterns, typecheck CLI, ADR conditionals, router wiring)
- [x] 878 total passed, same 9 pre-existing failures
- [x] Performance auditor only spawns for backend/db domains (not UI-only tasks)
- [x] ADR section only required for high/critical risk (not low/medium)
- [x] Agent count updated from 17 → 18 in tool boundary tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)