### PR TITLE
[fix] 4 follow-up eventbus bugs from re-audit

### DIFF
--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -175,7 +175,7 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     summary: dict[str, list[str]] = {}
     iteration = 0
     emitted_follow_ons: set[str] = set()  # track across ALL iterations to prevent duplicates
-    _completed_task_dir: str | None = None  # captured from task-completed event payload
+    completed_task_dirs: list[str] = []  # ALL task dirs from task-completed events
 
     from lib_core import is_learning_enabled
     learning = is_learning_enabled(root)
@@ -185,6 +185,8 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     while iteration < max_iterations:
         iteration += 1
         processed_any = False
+        # Track per-iteration: which event types had at least one successful handler
+        succeeded_this_iteration: set[str] = set()
         processed_this_iteration: set[str] = set()
 
         for event_type, handlers in HANDLERS.items():
@@ -203,9 +205,11 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
 
                     # Capture task identity from task-completed events
                     if event_type == "task-completed" and isinstance(payload, dict):
-                        _completed_task_dir = payload.get("task_dir") or _completed_task_dir
+                        td = payload.get("task_dir")
+                        if td and td not in completed_task_dirs:
+                            completed_task_dirs.append(td)
 
-                    # Run handler, swallow errors (|| true semantics)
+                    # Run handler
                     err_msg = None
                     t0 = time.monotonic()
                     try:
@@ -214,6 +218,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
                         err_msg = str(e)
                         print(f"  [warn] {consumer_name}: {e}", file=sys.stderr)
                         success = False
+
+                    if success:
+                        succeeded_this_iteration.add(event_type)
 
                     log_event(
                         root,
@@ -232,9 +239,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
                     status = "ok" if success else "failed"
                     summary.setdefault(event_type, []).append(f"{consumer_name}:{status}")
 
-            # Emit follow-on only if this event type was ACTUALLY processed in THIS
-            # iteration (not just present in cumulative summary) and hasn't been emitted yet
-            if event_type in processed_this_iteration and event_type in FOLLOW_ON:
+            # Emit follow-on only when: (a) event type was processed THIS iteration,
+            # (b) at least one handler succeeded, (c) follow-on not already emitted
+            if event_type in succeeded_this_iteration and event_type in FOLLOW_ON:
                 follow_on = FOLLOW_ON[event_type]
                 if follow_on not in emitted_follow_ons:
                     emit_event(root, follow_on, "eventbus")
@@ -246,27 +253,28 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     # Cleanup old events
     cleanup_old_events(root)
 
-    # Write post-completion receipt if task-completed was processed
-    if "task-completed" in summary and _completed_task_dir:
-        try:
-            from lib_receipts import receipt_post_completion
-            task_dir = Path(_completed_task_dir)
-            if task_dir.exists():
-                handlers_run = []
-                for evt_type, results in summary.items():
-                    for r in results:
-                        name, status = r.split(":", 1)
-                        handlers_run.append({"name": name, "success": status == "ok", "event": evt_type})
-                postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("evolve-completed", []))
-                patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("learn-completed", []))
-                receipt_post_completion(
-                    task_dir,
-                    handlers_run=handlers_run,
-                    postmortem_written=postmortem_ok,
-                    patterns_updated=patterns_ok,
-                )
-        except Exception as exc:
-            print(f"  [warn] post-completion receipt failed: {exc}", file=sys.stderr)
+    # Write post-completion receipt for EACH completed task
+    if "task-completed" in summary and completed_task_dirs:
+        handlers_run = []
+        for evt_type, results in summary.items():
+            for r in results:
+                name, status = r.split(":", 1)
+                handlers_run.append({"name": name, "success": status == "ok", "event": evt_type})
+        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("evolve-completed", []))
+        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("learn-completed", []))
+        for td in completed_task_dirs:
+            try:
+                from lib_receipts import receipt_post_completion
+                task_dir = Path(td)
+                if task_dir.exists():
+                    receipt_post_completion(
+                        task_dir,
+                        handlers_run=handlers_run,
+                        postmortem_written=postmortem_ok,
+                        patterns_updated=patterns_ok,
+                    )
+            except Exception as exc:
+                print(f"  [warn] post-completion receipt failed for {td}: {exc}", file=sys.stderr)
 
     return summary
 

--- a/hooks/lib_events.py
+++ b/hooks/lib_events.py
@@ -111,7 +111,11 @@ def mark_processed(event_path: Path, consumer_name: str) -> None:
 
 
 def cleanup_old_events(root: Path) -> int:
-    """Delete processed events older than RETENTION_SECONDS.
+    """Delete fully-processed events older than RETENTION_SECONDS.
+
+    An event is fully processed when ALL registered consumers for its
+    event type have marked it. Partially-processed events are kept
+    regardless of age so slow/offline consumers don't lose work.
 
     Returns count of deleted files.
     """
@@ -119,15 +123,27 @@ def cleanup_old_events(root: Path) -> int:
     cutoff = time.time() - RETENTION_SECONDS
     deleted = 0
 
+    # Import HANDLERS lazily to get the consumer list per event type
+    try:
+        from eventbus import HANDLERS
+    except ImportError:
+        HANDLERS = {}
+
     for event_path in events_dir.glob("*.json"):
         try:
             event = load_json(event_path)
         except (json.JSONDecodeError, FileNotFoundError, OSError):
             continue
 
-        # Only delete fully processed events
-        if not event.get("processed_by"):
+        processed_by = set(event.get("processed_by", []))
+        if not processed_by:
             continue
+
+        # Check that ALL consumers for this event type have processed it
+        event_type = event.get("event_type", "")
+        expected_consumers = {name for name, _ in HANDLERS.get(event_type, [])}
+        if expected_consumers and not expected_consumers.issubset(processed_by):
+            continue  # partially processed — keep it
 
         # Check file age
         try:

--- a/hooks/task-completed
+++ b/hooks/task-completed
@@ -13,11 +13,31 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# --- Step 1: Emit the triggering event ---
+# --- Step 1: Find the most recently completed task and emit with identity ---
+TASK_DIR=$(PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 -c "
+import json, sys
+from pathlib import Path
+dynos = Path('${PROJECT_ROOT}') / '.dynos'
+best = None
+for mp in sorted(dynos.glob('task-*/manifest.json'), reverse=True):
+    try:
+        m = json.loads(mp.read_text())
+        if m.get('stage') == 'DONE':
+            print(str(mp.parent)); sys.exit(0)
+    except: pass
+" 2>/dev/null)
+
+PAYLOAD="{}"
+if [ -n "${TASK_DIR:-}" ]; then
+  TASK_ID=$(basename "$TASK_DIR")
+  PAYLOAD="{\"task_id\": \"${TASK_ID}\", \"task_dir\": \"${TASK_DIR}\"}"
+fi
+
 PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/lib_events.py" emit \
   --root "${PROJECT_ROOT}" \
   --type task-completed \
-  --source task || true
+  --source task \
+  --payload "$PAYLOAD" || true
 
 # --- Step 2: Drain all events (learn → evolve → benchmark → dashboard) ---
 PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/eventbus.py" drain \


### PR DESCRIPTION
## Summary

Follow-up to PR #75. Fixes 4 bugs found in the re-audit of the eventbus/receipt pipeline.

### High severity

| # | Bug | Fix |
|---|---|---|
| 1 | Multiple task-completed events: only last task gets receipt | `completed_task_dirs` is now a list; receipts written for ALL tasks |
| 2 | Failed handlers advance the chain (failed learn → learn-completed → evolve runs on bad state) | Follow-on events only emit when at least one handler **succeeded** (`succeeded_this_iteration` set) |

### Medium severity

| # | Bug | Fix |
|---|---|---|
| 3 | `hooks/task-completed` hook emits bare event without task identity | Hook now finds most recently completed task and passes `task_id` + `task_dir` in payload |
| 4 | `cleanup_old_events()` deletes partially-processed events | Now checks ALL registered consumers have processed before deleting |

## Files changed

- `hooks/eventbus.py` — multi-task receipt, success-gated follow-ons
- `hooks/task-completed` — task identity in event payload
- `hooks/lib_events.py` — fully-processed check in cleanup

## Verification

- [x] 909 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)