### PR TITLE
[refactor] rename internal event names: learn → memory, evolve → calibration

### DIFF
--- a/cli/assets/hooks/eventbus.py
+++ b/cli/assets/hooks/eventbus.py
@@ -52,7 +52,7 @@ def _run(cmd: list[str], root: Path) -> bool:
         return False
 
 
-def run_learn(root: Path, _payload: dict) -> bool:
+def run_memory(root: Path, _payload: dict) -> bool:
     """Aggregate retrospectives into project memory (deterministic Python)."""
     # patterns.py does everything the learn skill does:
     # EMA effectiveness scores, model policy, skip policy, baseline policy,
@@ -71,8 +71,8 @@ def run_trajectory(root: Path, _payload: dict) -> bool:
     )
 
 
-def run_evolve(root: Path, _payload: dict) -> bool:
-    """Deterministic learned agent generation."""
+def run_calibration(root: Path, _payload: dict) -> bool:
+    """Deterministic project-specific agent generation."""
     return _run(
         ["python3", str(SCRIPT_DIR / "evolve.py"), "auto", "--root", str(root)],
         root,
@@ -137,14 +137,14 @@ HandlerEntry = tuple[str, Callable[[Path, dict], bool]]
 
 HANDLERS: dict[str, list[HandlerEntry]] = {
     "task-completed": [
-        ("learn", run_learn),
+        ("memory", run_memory),
         ("trajectory", run_trajectory),
     ],
-    "learn-completed": [
-        ("evolve", run_evolve),
+    "memory-completed": [
+        ("calibration", run_calibration),
         ("patterns", run_patterns),
     ],
-    "evolve-completed": [
+    "calibration-completed": [
         ("postmortem", run_postmortem),
         ("improve", run_improve),
         ("benchmark", run_benchmark),
@@ -157,9 +157,9 @@ HANDLERS: dict[str, list[HandlerEntry]] = {
 
 # Maps event type to the follow-on event emitted when handlers complete
 FOLLOW_ON: dict[str, str] = {
-    "task-completed": "learn-completed",
-    "learn-completed": "evolve-completed",
-    "evolve-completed": "benchmark-completed",
+    "task-completed": "memory-completed",
+    "memory-completed": "calibration-completed",
+    "calibration-completed": "benchmark-completed",
 }
 
 
@@ -180,7 +180,7 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     from lib_core import is_learning_enabled
     learning = is_learning_enabled(root)
     # Handlers that are part of the learning layer — skipped when learning is disabled.
-    _LEARNING_HANDLERS = {"learn", "trajectory", "evolve", "patterns", "improve", "benchmark"}
+    _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
 
     while iteration < max_iterations:
         iteration += 1
@@ -263,8 +263,8 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
             for r in results:
                 name, status = r.split(":", 1)
                 handlers_run.append({"name": name, "success": status == "ok", "event": evt_type})
-        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("evolve-completed", []))
-        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("learn-completed", []))
+        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("calibration-completed", []))
+        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("memory-completed", []))
         for td in completed_task_dirs:
             try:
                 from lib_receipts import receipt_post_completion

--- a/cli/assets/hooks/lib_events.py
+++ b/cli/assets/hooks/lib_events.py
@@ -22,12 +22,12 @@ from lib_core import load_json, now_iso, write_json
 
 EVENT_TYPES: set[str] = {
     "task-completed",
-    "learn-completed",
-    "evolve-completed",
+    "memory-completed",
+    "calibration-completed",
     "benchmark-completed",
 }
 
-VALID_PIPELINES: set[str] = {"task", "learn", "observability", "eventbus"}
+VALID_PIPELINES: set[str] = {"task", "memory", "observability", "eventbus"}
 
 # Retention: processed events older than this (seconds) are deleted on cleanup
 RETENTION_SECONDS: int = 7 * 24 * 3600  # 7 days

--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -52,7 +52,7 @@ def _run(cmd: list[str], root: Path) -> bool:
         return False
 
 
-def run_learn(root: Path, _payload: dict) -> bool:
+def run_memory(root: Path, _payload: dict) -> bool:
     """Aggregate retrospectives into project memory (deterministic Python)."""
     # patterns.py does everything the learn skill does:
     # EMA effectiveness scores, model policy, skip policy, baseline policy,
@@ -71,8 +71,8 @@ def run_trajectory(root: Path, _payload: dict) -> bool:
     )
 
 
-def run_evolve(root: Path, _payload: dict) -> bool:
-    """Deterministic learned agent generation."""
+def run_calibration(root: Path, _payload: dict) -> bool:
+    """Deterministic project-specific agent generation."""
     return _run(
         ["python3", str(SCRIPT_DIR / "evolve.py"), "auto", "--root", str(root)],
         root,
@@ -137,14 +137,14 @@ HandlerEntry = tuple[str, Callable[[Path, dict], bool]]
 
 HANDLERS: dict[str, list[HandlerEntry]] = {
     "task-completed": [
-        ("learn", run_learn),
+        ("memory", run_memory),
         ("trajectory", run_trajectory),
     ],
-    "learn-completed": [
-        ("evolve", run_evolve),
+    "memory-completed": [
+        ("calibration", run_calibration),
         ("patterns", run_patterns),
     ],
-    "evolve-completed": [
+    "calibration-completed": [
         ("postmortem", run_postmortem),
         ("improve", run_improve),
         ("benchmark", run_benchmark),
@@ -157,9 +157,9 @@ HANDLERS: dict[str, list[HandlerEntry]] = {
 
 # Maps event type to the follow-on event emitted when handlers complete
 FOLLOW_ON: dict[str, str] = {
-    "task-completed": "learn-completed",
-    "learn-completed": "evolve-completed",
-    "evolve-completed": "benchmark-completed",
+    "task-completed": "memory-completed",
+    "memory-completed": "calibration-completed",
+    "calibration-completed": "benchmark-completed",
 }
 
 
@@ -180,7 +180,7 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     from lib_core import is_learning_enabled
     learning = is_learning_enabled(root)
     # Handlers that are part of the learning layer — skipped when learning is disabled.
-    _LEARNING_HANDLERS = {"learn", "trajectory", "evolve", "patterns", "improve", "benchmark"}
+    _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
 
     while iteration < max_iterations:
         iteration += 1
@@ -263,8 +263,8 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
             for r in results:
                 name, status = r.split(":", 1)
                 handlers_run.append({"name": name, "success": status == "ok", "event": evt_type})
-        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("evolve-completed", []))
-        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("learn-completed", []))
+        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("calibration-completed", []))
+        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("memory-completed", []))
         for td in completed_task_dirs:
             try:
                 from lib_receipts import receipt_post_completion

--- a/hooks/lib_events.py
+++ b/hooks/lib_events.py
@@ -22,12 +22,12 @@ from lib_core import load_json, now_iso, write_json
 
 EVENT_TYPES: set[str] = {
     "task-completed",
-    "learn-completed",
-    "evolve-completed",
+    "memory-completed",
+    "calibration-completed",
     "benchmark-completed",
 }
 
-VALID_PIPELINES: set[str] = {"task", "learn", "observability", "eventbus"}
+VALID_PIPELINES: set[str] = {"task", "memory", "observability", "eventbus"}
 
 # Retention: processed events older than this (seconds) are deleted on cleanup
 RETENTION_SECONDS: int = 7 * 24 * 3600  # 7 days

--- a/tests/test_learning_enabled_flag.py
+++ b/tests/test_learning_enabled_flag.py
@@ -153,16 +153,16 @@ class TestResolveSkipWithLearning:
 class TestEventBusLearningGate:
     def test_learning_handlers_identified(self):
         """Verify the learning handler set covers the right handlers."""
-        learning_handlers = {"learn", "trajectory", "evolve", "patterns", "improve", "benchmark"}
+        learning_handlers = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
         observability_handlers = {"dashboard", "register", "postmortem"}
-        # Postmortem is in evolve-completed along with improve and benchmark
+        # Postmortem is in calibration-completed along with improve and benchmark
         # but postmortem writes retrospective improvements — it's borderline
         # For now it's NOT in the learning set (it runs even without learning)
         assert learning_handlers & observability_handlers == set()
 
     def test_learning_handler_names_exist_in_registry(self):
         """Verify all learning handler names exist in the HANDLERS registry."""
-        expected = {"learn", "trajectory", "evolve", "patterns", "improve", "benchmark"}
+        expected = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
         from eventbus import HANDLERS
         all_handler_names = set()
         for handlers in HANDLERS.values():
@@ -172,7 +172,7 @@ class TestEventBusLearningGate:
 
     def test_observability_handlers_not_in_learning_set(self):
         """Dashboard, register, postmortem should run even with learning off."""
-        learning_handlers = {"learn", "trajectory", "evolve", "patterns", "improve", "benchmark"}
+        learning_handlers = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
         assert "dashboard" not in learning_handlers
         assert "register" not in learning_handlers
         assert "postmortem" not in learning_handlers


### PR DESCRIPTION
## Summary

Aligns internal eventbus names with the directory/skill renames.

| Before | After |
|---|---|
| handler `learn` | `memory` |
| handler `evolve` | `calibration` |
| event `learn-completed` | `memory-completed` |
| event `evolve-completed` | `calibration-completed` |
| pipeline `learn` | `memory` |

The event chain is now: `task-completed` → `memory-completed` → `calibration-completed` → `benchmark-completed`

No behavior change. cli/assets synced.

## Verification

- [x] 909 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)