### PR TITLE
[fix] no tight-loop retry for failed eventbus handlers

### DIFF
--- a/cli/assets/hooks/eventbus.py
+++ b/cli/assets/hooks/eventbus.py
@@ -185,6 +185,10 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     # still fire. A skipped handler counts as succeeded for follow-on gating.
     _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
 
+    # Track consumers that failed during this drain call — don't retry them
+    # in subsequent iterations. Retries happen on the NEXT drain() invocation.
+    failed_this_drain: set[tuple[str, str]] = set()  # {(event_type, consumer)}
+
     while iteration < max_iterations:
         iteration += 1
         processed_any = False
@@ -194,6 +198,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
 
         for event_type, handlers in HANDLERS.items():
             for consumer_name, handler_fn in handlers:
+                # Skip consumers that already failed this drain — retry on next drain() call
+                if (event_type, consumer_name) in failed_this_drain:
+                    continue
                 # When learning is disabled, skip the handler execution but still
                 # consume and mark events processed so the chain continues to
                 # non-learning handlers downstream (dashboard, register, postmortem)
@@ -244,6 +251,8 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
                     # Only mark processed on success — failed events stay for retry
                     if success:
                         mark_processed(event_path, consumer_name)
+                    else:
+                        failed_this_drain.add((event_type, consumer_name))
 
                     # Track in summary
                     status = "ok" if success else "failed"

--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -185,6 +185,10 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     # still fire. A skipped handler counts as succeeded for follow-on gating.
     _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
 
+    # Track consumers that failed during this drain call — don't retry them
+    # in subsequent iterations. Retries happen on the NEXT drain() invocation.
+    failed_this_drain: set[tuple[str, str]] = set()  # {(event_type, consumer)}
+
     while iteration < max_iterations:
         iteration += 1
         processed_any = False
@@ -194,6 +198,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
 
         for event_type, handlers in HANDLERS.items():
             for consumer_name, handler_fn in handlers:
+                # Skip consumers that already failed this drain — retry on next drain() call
+                if (event_type, consumer_name) in failed_this_drain:
+                    continue
                 # When learning is disabled, skip the handler execution but still
                 # consume and mark events processed so the chain continues to
                 # non-learning handlers downstream (dashboard, register, postmortem)
@@ -244,6 +251,8 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
                     # Only mark processed on success — failed events stay for retry
                     if success:
                         mark_processed(event_path, consumer_name)
+                    else:
+                        failed_this_drain.add((event_type, consumer_name))
 
                     # Track in summary
                     status = "ok" if success else "failed"

--- a/tests/test_eventbus_drain.py
+++ b/tests/test_eventbus_drain.py
@@ -212,6 +212,32 @@ class TestLearningDisabled:
 
 
 # ---------------------------------------------------------------------------
+# No tight-loop retry within a single drain call
+# ---------------------------------------------------------------------------
+
+class TestNoTightRetry:
+    def test_permanently_failing_handler_runs_once_per_drain(self, tmp_path: Path):
+        """A handler that always fails should run exactly once per drain(),
+        not once per iteration (which would be 10 times with max_iterations=10)."""
+        root = _setup(tmp_path)
+        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
+
+        calls = {"n": 0}
+        def always_fail(root, payload):
+            calls["n"] += 1
+            return False
+
+        handlers = _make_handlers({"memory": always_fail, "trajectory": True})
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"):
+            from eventbus import drain
+            drain(root, max_iterations=10)
+
+        assert calls["n"] == 1, f"permanently failing handler ran {calls['n']} times, expected 1"
+
+
+# ---------------------------------------------------------------------------
 # Multiple queued events: AND semantics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Failed handlers now run exactly once per `drain()` call, not once per iteration (which was 10 times with `max_iterations=10`). Retries are deferred to the next `drain()` invocation.

### How

`failed_this_drain: set[tuple[str, str]]` tracks (event_type, consumer) pairs that failed. Subsequent iterations skip them. The set is scoped to the drain call, so the next `drain()` (e.g., next daemon cycle) retries normally.

### Test

`test_permanently_failing_handler_runs_once_per_drain` — always-failing handler with `max_iterations=10` asserts `calls == 1`.

## Verification

- [x] 919 tests pass (10 drain tests), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)