### PR TITLE
[fix] remove 5 dead functions and 2 unused imports

### DIFF
--- a/cli/assets/hooks/lib_contracts.py
+++ b/cli/assets/hooks/lib_contracts.py
@@ -37,23 +37,6 @@ def load_contract(skill_name: str) -> dict:
     return load_json(contract_path)
 
 
-def list_contracts() -> list[dict]:
-    """Load all contract.json files from all skills."""
-    contracts = []
-    skills_dir = _PLUGIN_ROOT / "skills"
-    if not skills_dir.exists():
-        return contracts
-    for skill_dir in sorted(skills_dir.iterdir()):
-        contract_path = skill_dir / "contract.json"
-        if contract_path.exists():
-            try:
-                contract = load_json(contract_path)
-                contract["_skill_dir"] = str(skill_dir)
-                contracts.append(contract)
-            except (json.JSONDecodeError, OSError):
-                continue
-    return contracts
-
 
 # ---------------------------------------------------------------------------
 # Source resolution

--- a/cli/assets/hooks/lib_core.py
+++ b/cli/assets/hooks/lib_core.py
@@ -300,7 +300,7 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
         raise ValueError(f"Illegal stage transition: {current_stage} -> {next_stage}")
     # ---- Receipt-based transition gates (unmissable) ----
     if not force:
-        from lib_receipts import read_receipt, validate_chain
+        from lib_receipts import read_receipt
         gate_errors: list[str] = []
 
         # EXECUTION requires plan-validated receipt

--- a/cli/assets/hooks/lib_receipts.py
+++ b/cli/assets/hooks/lib_receipts.py
@@ -7,9 +7,7 @@ The next step refuses to proceed unless the prior receipt exists.
 
 from __future__ import annotations
 
-import hashlib
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -166,13 +164,6 @@ def require_receipt(task_dir: Path, step_name: str) -> dict:
     return receipt
 
 
-def require_receipts(task_dir: Path, step_names: list[str]) -> dict[str, dict]:
-    """Validate multiple receipts exist. Returns all receipts or raises on first missing."""
-    results = {}
-    for name in step_names:
-        results[name] = require_receipt(task_dir, name)
-    return results
-
 
 def validate_chain(task_dir: Path) -> list[str]:
     """Validate the entire receipt chain for a task. Returns list of gaps.
@@ -240,13 +231,6 @@ def validate_chain(task_dir: Path) -> list[str]:
 
     return gaps
 
-
-def hash_file(path: Path) -> str | None:
-    """SHA256 hash of a file's contents. Returns None if file doesn't exist."""
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
-    except (OSError, FileNotFoundError):
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/cli/assets/hooks/router.py
+++ b/cli/assets/hooks/router.py
@@ -790,48 +790,6 @@ def build_executor_prompt(
     return "\n".join(parts)
 
 
-def build_auditor_prompt(
-    root: Path,
-    plan_entry: dict,
-    base_prompt: str,
-) -> str:
-    """Build the complete auditor prompt with learned agent rules injected.
-
-    Same pattern as build_executor_prompt but for auditors.
-    """
-    agent_path = plan_entry.get("agent_path")
-    route_mode = plan_entry.get("route_mode", "generic")
-    agent_name = plan_entry.get("agent_name")
-
-    parts = [base_prompt]
-
-    if route_mode in ("replace", "alongside") and agent_path:
-        try:
-            p = Path(agent_path)
-            if not p.is_absolute():
-                p = root / p
-            if p.exists():
-                agent_content = p.read_text().strip()
-                if agent_content.startswith("---"):
-                    end = agent_content.find("---", 3)
-                    if end != -1:
-                        agent_content = agent_content[end + 3:].strip()
-                parts.append(
-                    f"\n\n## Learned Auditor Instructions ({agent_name})\n"
-                    f"{agent_content}"
-                )
-                log_event(
-                    root,
-                    "learned_agent_injected",
-                    agent_name=agent_name,
-                    agent_path=str(agent_path),
-                    route_mode=route_mode,
-                )
-        except Exception:
-            pass
-
-    return "\n".join(parts)
-
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/hooks/lib_contracts.py
+++ b/hooks/lib_contracts.py
@@ -37,23 +37,6 @@ def load_contract(skill_name: str) -> dict:
     return load_json(contract_path)
 
 
-def list_contracts() -> list[dict]:
-    """Load all contract.json files from all skills."""
-    contracts = []
-    skills_dir = _PLUGIN_ROOT / "skills"
-    if not skills_dir.exists():
-        return contracts
-    for skill_dir in sorted(skills_dir.iterdir()):
-        contract_path = skill_dir / "contract.json"
-        if contract_path.exists():
-            try:
-                contract = load_json(contract_path)
-                contract["_skill_dir"] = str(skill_dir)
-                contracts.append(contract)
-            except (json.JSONDecodeError, OSError):
-                continue
-    return contracts
-
 
 # ---------------------------------------------------------------------------
 # Source resolution

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -300,7 +300,7 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
         raise ValueError(f"Illegal stage transition: {current_stage} -> {next_stage}")
     # ---- Receipt-based transition gates (unmissable) ----
     if not force:
-        from lib_receipts import read_receipt, validate_chain
+        from lib_receipts import read_receipt
         gate_errors: list[str] = []
 
         # EXECUTION requires plan-validated receipt

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -7,9 +7,7 @@ The next step refuses to proceed unless the prior receipt exists.
 
 from __future__ import annotations
 
-import hashlib
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -166,13 +164,6 @@ def require_receipt(task_dir: Path, step_name: str) -> dict:
     return receipt
 
 
-def require_receipts(task_dir: Path, step_names: list[str]) -> dict[str, dict]:
-    """Validate multiple receipts exist. Returns all receipts or raises on first missing."""
-    results = {}
-    for name in step_names:
-        results[name] = require_receipt(task_dir, name)
-    return results
-
 
 def validate_chain(task_dir: Path) -> list[str]:
     """Validate the entire receipt chain for a task. Returns list of gaps.
@@ -240,13 +231,6 @@ def validate_chain(task_dir: Path) -> list[str]:
 
     return gaps
 
-
-def hash_file(path: Path) -> str | None:
-    """SHA256 hash of a file's contents. Returns None if file doesn't exist."""
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
-    except (OSError, FileNotFoundError):
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -790,48 +790,6 @@ def build_executor_prompt(
     return "\n".join(parts)
 
 
-def build_auditor_prompt(
-    root: Path,
-    plan_entry: dict,
-    base_prompt: str,
-) -> str:
-    """Build the complete auditor prompt with learned agent rules injected.
-
-    Same pattern as build_executor_prompt but for auditors.
-    """
-    agent_path = plan_entry.get("agent_path")
-    route_mode = plan_entry.get("route_mode", "generic")
-    agent_name = plan_entry.get("agent_name")
-
-    parts = [base_prompt]
-
-    if route_mode in ("replace", "alongside") and agent_path:
-        try:
-            p = Path(agent_path)
-            if not p.is_absolute():
-                p = root / p
-            if p.exists():
-                agent_content = p.read_text().strip()
-                if agent_content.startswith("---"):
-                    end = agent_content.find("---", 3)
-                    if end != -1:
-                        agent_content = agent_content[end + 3:].strip()
-                parts.append(
-                    f"\n\n## Learned Auditor Instructions ({agent_name})\n"
-                    f"{agent_content}"
-                )
-                log_event(
-                    root,
-                    "learned_agent_injected",
-                    agent_name=agent_name,
-                    agent_path=str(agent_path),
-                    route_mode=route_mode,
-                )
-        except Exception:
-            pass
-
-    return "\n".join(parts)
-
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/memory/sweeper.py
+++ b/memory/sweeper.py
@@ -68,10 +68,6 @@ def registry_path() -> Path:
     return global_home() / "registry.json"
 
 
-def global_policy_path() -> Path:
-    return global_home() / "policy" / "global-policy.json"
-
-
 def patterns_dir() -> Path:
     return global_home() / "patterns"
 


### PR DESCRIPTION
## Summary

Cleanup from the closed autofix PRs (#34-#46). Re-verified each finding against current filenames.

| File | Removed | Why dead |
|---|---|---|
| `lib_receipts.py` | `hash_file()`, `require_receipts()`, `import sys`, `import hashlib` | Zero callers in entire codebase |
| `lib_contracts.py` | `list_contracts()` | Zero callers |
| `router.py` | `build_auditor_prompt()` | Zero callers (executor prompt IS used, auditor variant never was) |
| `memory/sweeper.py` | `global_policy_path()` | Zero callers |
| `lib_core.py` | `validate_chain` import | Imported but never used in that file |

## Verification

- [x] 919 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)