### PR TITLE
split patterns.md: LLM-useful rules stay, data tables move to JSON

### DIFF
--- a/hooks/router.py
+++ b/hooks/router.py
@@ -64,6 +64,7 @@ class RouterContext:
 
     @property
     def patterns_text(self) -> str | None:
+        """Deprecated — data tables removed from markdown. Use effectiveness_scores instead."""
         if self._patterns_text is None:
             path = _persistent_project_dir(self.root) / "dynos_patterns.md"
             try:
@@ -71,6 +72,18 @@ class RouterContext:
             except (FileNotFoundError, OSError):
                 self._patterns_text = ""
         return self._patterns_text or None
+
+    @property
+    def effectiveness_scores(self) -> list[dict]:
+        """Read effectiveness scores from JSON (no longer parsed from markdown)."""
+        if not hasattr(self, "_effectiveness"):
+            path = _persistent_project_dir(self.root) / "effectiveness-scores.json"
+            try:
+                data = load_json(path)
+                self._effectiveness = data if isinstance(data, list) else []
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                self._effectiveness = []
+        return self._effectiveness
 
     @property
     def retrospectives(self) -> list[dict]:
@@ -211,6 +224,50 @@ def _parse_effectiveness_scores_from_text(
                 "samples": max(samples, 1),
             }
 
+    return list(rows.values())
+
+
+def _filter_effectiveness_scores(
+    scores: list[dict], role: str, task_type: str,
+) -> list[dict]:
+    """Filter and aggregate effectiveness scores for a given role and task_type.
+
+    Reads from the JSON effectiveness-scores.json (no markdown parsing).
+    Aggregates across source values (generic + learned) per model.
+    """
+    rows: dict[str, dict] = {}
+    for entry in scores:
+        if entry.get("role") != role or entry.get("task_type") != task_type:
+            continue
+        m = entry.get("model", "")
+        if not m or m not in ("haiku", "sonnet", "opus"):
+            continue
+        try:
+            quality = float(entry.get("quality_ema", 0))
+            cost = float(entry.get("cost_ema", 0))
+            efficiency = float(entry.get("efficiency_ema", 0))
+            samples = int(entry.get("sample_count", 1))
+        except (ValueError, TypeError):
+            continue
+
+        if m in rows:
+            existing = rows[m]
+            total = existing["samples"] + samples
+            if total > 0:
+                w_old = existing["samples"] / total
+                w_new = samples / total
+                existing["quality"] = existing["quality"] * w_old + quality * w_new
+                existing["cost"] = existing["cost"] * w_old + cost * w_new
+                existing["efficiency"] = existing["efficiency"] * w_old + efficiency * w_new
+                existing["samples"] = total
+        else:
+            rows[m] = {
+                "model": m,
+                "quality": quality,
+                "cost": cost,
+                "efficiency": efficiency,
+                "samples": max(samples, 1),
+            }
     return list(rows.values())
 
 
@@ -380,16 +437,18 @@ def resolve_model(root: Path, role: str, task_type: str, ctx: RouterContext | No
         log_event(root, "router_model_decision", role=role, task_type=task_type, model=result["model"], source="default (learning_enabled=false)")
         return result
 
-    # 2. UCB1 over effectiveness scores
-    patterns_text = ctx.patterns_text if ctx else None
-    if patterns_text is None:
-        patterns_path = _persistent_project_dir(root) / "dynos_patterns.md"
+    # 2. UCB1 over effectiveness scores (read from JSON, not markdown)
+    if ctx:
+        all_scores = ctx.effectiveness_scores
+    else:
         try:
-            patterns_text = patterns_path.read_text()
-        except (FileNotFoundError, OSError):
-            patterns_text = None
-    if patterns_text:
-        candidates = _parse_effectiveness_scores_from_text(patterns_text, role, task_type)
+            all_scores = load_json(_persistent_project_dir(root) / "effectiveness-scores.json")
+            if not isinstance(all_scores, list):
+                all_scores = []
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            all_scores = []
+    if all_scores:
+        candidates = _filter_effectiveness_scores(all_scores, role, task_type)
         if candidates:
             exploration_c = float(policy.get("ucb_exploration_constant", DEFAULT_UCB_C))
             winner = _ucb_select_model(candidates, exploration_c)
@@ -433,22 +492,7 @@ def resolve_model(root: Path, role: str, task_type: str, ctx: RouterContext | No
         log_event(root, "router_model_decision", role=role, task_type=task_type, model=result["model"], source=result["source"])
         return result
 
-    # 4. Model Policy markdown table fallback (oldest format)
-    if patterns_path.exists():
-        try:
-            model = _parse_model_from_patterns(patterns_path, role, task_type)
-            if model and model != "default":
-                if role == "security-auditor" and model in ("haiku", "sonnet"):
-                    result = {"model": SECURITY_FLOOR_MODEL, "source": "security_floor"}
-                    log_event(root, "router_model_decision", role=role, task_type=task_type, model=result["model"], source=result["source"])
-                    return result
-                result = {"model": model, "source": "learned_history"}
-                log_event(root, "router_model_decision", role=role, task_type=task_type, model=result["model"], source=result["source"])
-                return result
-        except (OSError, ValueError):
-            pass
-
-    # 5. No data — default
+    # 4. No data — default
     if role == "security-auditor":
         result = {"model": SECURITY_FLOOR_MODEL, "source": "security_floor"}
         log_event(root, "router_model_decision", role=role, task_type=task_type, model=result["model"], source=result["source"])
@@ -517,32 +561,11 @@ def resolve_skip(root: Path, auditor: str, task_type: str, ctx: RouterContext | 
 def _get_skip_threshold(root: Path, auditor: str) -> int:
     """Read skip threshold for *auditor*.
 
-    Priority: skip-policy.json -> dynos_patterns.md markdown -> DEFAULT_SKIP_THRESHOLD.
+    Priority: skip-policy.json -> DEFAULT_SKIP_THRESHOLD.
     """
-    # 1. JSON policy file
     entry = _read_policy_json(root, "skip-policy.json", auditor)
     if entry and isinstance(entry, dict) and "threshold" in entry:
         return int(entry["threshold"])
-
-    # 2. Markdown fallback
-    patterns_path = _persistent_project_dir(root) / "dynos_patterns.md"
-    if patterns_path.exists():
-        try:
-            text = patterns_path.read_text()
-            in_table = False
-            for line in text.splitlines():
-                if "## Skip Policy" in line:
-                    in_table = True
-                    continue
-                if in_table and line.startswith("## "):
-                    break
-                if not in_table or not line.startswith("|") or "---" in line or "Auditor" in line:
-                    continue
-                parts = [p.strip() for p in line.split("|") if p.strip()]
-                if len(parts) >= 2 and parts[0] == auditor:
-                    return int(parts[1])
-        except (OSError, ValueError):
-            pass
 
     return DEFAULT_SKIP_THRESHOLD
 

--- a/memory/patterns.py
+++ b/memory/patterns.py
@@ -699,24 +699,13 @@ def build_patterns_markdown(
             )
     else:
         lines.append("| none | n/a | No completed retrospectives available yet. |")
-    # Effectiveness scores (computed deterministically from retrospectives)
-    effectiveness_scores = compute_effectiveness_scores(retrospectives)
-    lines.extend([""] + _build_effectiveness_scores_section(effectiveness_scores))
+    # Data tables (effectiveness scores, model policy, skip policy, agent routing)
+    # are NOT included in the markdown. They are written as JSON files
+    # (model-policy.json, skip-policy.json, route-policy.json) which the
+    # router reads directly. Keeping them out of the markdown avoids
+    # injecting ~60 lines of numeric tables into the LLM context window
+    # where they serve no purpose (the LLM can't act on EMA scores).
 
-    # Model Policy and Skip Policy are always rendered in markdown
-    # (legacy _build_model_policy_data has its own 2-observation threshold).
-    # The cold-start gate only affects EMA-derived policies in JSON files.
-    lines.extend(
-        [""]
-        + _build_model_policy(task_types, executor_roles, auditor_roles, model_policy_data)
-    )
-    lines.extend([""] + _build_skip_policy(auditor_roles, skip_policy_data))
-    lines.extend(
-        [""]
-        + _build_agent_routing(
-            task_types, executor_roles, auditor_roles, registry, route_policy_data
-        )
-    )
     return "\n".join(lines) + "\n"
 
 
@@ -768,8 +757,10 @@ def write_patterns(root: Path) -> dict:
 
     steps_completed.append(f"route:{len(route_policy_data)} routes")
 
-    # Step 4: Write JSON policy files
+    # Step 4: Write JSON policy files + effectiveness scores
     _write_policy_json_files(root, model_policy_data, skip_policy_data, route_policy_data)
+    persistent = _persistent_project_dir(root)
+    write_json(persistent / "effectiveness-scores.json", effectiveness_scores)
     steps_completed.append("json_written")
     log_event(root, "learn_step", step="write_json_policies",
               model_count=len(model_policy_data), skip_count=len(skip_policy_data), route_count=len(route_policy_data))

--- a/tests/test_learning_runtime.py
+++ b/tests/test_learning_runtime.py
@@ -898,10 +898,12 @@ class LearningRuntimeTests(unittest.TestCase):
         payload = json.loads(patterns.stdout)
         self.assertIn(str(self.persistent_dir / "dynos_patterns.md"), payload["written_paths"])
         content = (self.persistent_dir / "dynos_patterns.md").read_text()
-        self.assertIn("## Model Policy", content)
-        self.assertIn("## Skip Policy", content)
-        self.assertIn("## Agent Routing", content)
-        self.assertIn("| backend-executor | feature |", content)
+        # Data tables removed from markdown (now JSON only) — only prevention rules + gold standard remain
+        self.assertIn("## Prevention Rules", content)
+        # Verify JSON policy files were written
+        self.assertTrue((self.persistent_dir / "model-policy.json").exists())
+        self.assertTrue((self.persistent_dir / "skip-policy.json").exists())
+        self.assertTrue((self.persistent_dir / "effectiveness-scores.json").exists())
 
     def test_task_artifact_challenge_rollout_runs(self) -> None:
         self.run_py("calibrate.py", "init-registry", "--root", str(self.root))

--- a/tests/test_policy_json.py
+++ b/tests/test_policy_json.py
@@ -275,67 +275,6 @@ class TestRoutePolicyJsonGeneration(unittest.TestCase):
             self.assertIsInstance(value["composite_score"], (int, float))
 
 
-class TestJsonMatchesMarkdown(unittest.TestCase):
-    """AC 4: JSON and markdown are generated from the same data."""
-
-    def setUp(self) -> None:
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.root = Path(self.tempdir.name)
-        self.orig_dynos_home = os.environ.get("DYNOS_HOME")
-        os.environ["DYNOS_HOME"] = str(self.root / ".dynos-home")
-
-    def tearDown(self) -> None:
-        if self.orig_dynos_home is None:
-            os.environ.pop("DYNOS_HOME", None)
-        else:
-            os.environ["DYNOS_HOME"] = self.orig_dynos_home
-        self.tempdir.cleanup()
-
-    def test_model_policy_json_keys_match_markdown_rows(self) -> None:
-        """Every role:task_type in model-policy.json has a matching markdown table row."""
-        from patterns import write_patterns, local_patterns_path
-        from lib import _persistent_project_dir
-
-        retros = [
-            _make_retrospective(
-                "task-001", "feature",
-                quality_score=0.9,
-                models={"backend-executor": "opus"},
-            ),
-            _make_retrospective(
-                "task-002", "feature",
-                quality_score=0.85,
-                models={"backend-executor": "opus"},
-            ),
-        ]
-        _setup_project(self.root, retrospectives=retros)
-
-        write_patterns(self.root)
-
-        model_policy_path = _persistent_project_dir(self.root) / "model-policy.json"
-        data = json.loads(model_policy_path.read_text())
-
-        # Read markdown and extract model policy rows
-        md_path = local_patterns_path(self.root)
-        md_content = md_path.read_text()
-        md_rows = set()
-        in_model = False
-        for line in md_content.splitlines():
-            if "## Model Policy" in line:
-                in_model = True
-                continue
-            if in_model and line.startswith("## "):
-                break
-            if not in_model or not line.startswith("|") or "---" in line or "Role" in line:
-                continue
-            parts = [p.strip() for p in line.split("|") if p.strip()]
-            if len(parts) >= 3:
-                md_rows.add(f"{parts[0]}:{parts[1]}")
-
-        # Every key in the JSON with a non-default model should exist in the markdown
-        for key in data:
-            self.assertIn(key, md_rows, f"JSON key {key} should have a matching markdown row")
-
 
 class TestResolveModelJsonFirst(unittest.TestCase):
     """AC 5: resolve_model() reads model-policy.json first, falls back to markdown."""
@@ -602,26 +541,6 @@ class TestBackwardCompatFallback(unittest.TestCase):
             os.environ["DYNOS_HOME"] = self.orig_dynos_home
         self.tempdir.cleanup()
 
-    def test_resolve_model_falls_back_to_markdown_when_no_json(self) -> None:
-        """Without model-policy.json, resolve_model() reads from markdown."""
-        from lib import _persistent_project_dir, write_json
-        from router import resolve_model
-
-        persistent = _persistent_project_dir(self.root)
-        # No model-policy.json, only markdown
-        (persistent / "dynos_patterns.md").write_text(
-            "## Model Policy\n\n"
-            "| Role | Task Type | Recommended Model |\n"
-            "|------|-----------|-------------------|\n"
-            "| backend-executor | feature | sonnet |\n"
-        )
-        write_json(persistent / "policy.json", {"exploration_epsilon": 0})
-
-        result = resolve_model(self.root, "backend-executor", "feature")
-        self.assertEqual(result["model"], "sonnet")
-        # Source should reflect fallback
-        self.assertIn(result["source"], ("policy", "learned_history", "default"))
-
     def test_resolve_model_returns_default_when_no_json_no_markdown(self) -> None:
         """Without both JSON and markdown, resolve_model() returns default."""
         from lib import _persistent_project_dir, write_json
@@ -633,22 +552,6 @@ class TestBackwardCompatFallback(unittest.TestCase):
 
         result = resolve_model(self.root, "backend-executor", "feature")
         self.assertEqual(result["source"], "default")
-
-    def test_skip_threshold_falls_back_to_markdown_when_no_json(self) -> None:
-        """Without skip-policy.json, _get_skip_threshold() reads from markdown."""
-        from lib import _persistent_project_dir
-        from router import _get_skip_threshold
-
-        persistent = _persistent_project_dir(self.root)
-        (persistent / "dynos_patterns.md").write_text(
-            "## Skip Policy\n\n"
-            "| Auditor | Skip Threshold | Confidence |\n"
-            "|---------|----------------|------------|\n"
-            "| ui-auditor | 4 | 0.80 |\n"
-        )
-
-        threshold = _get_skip_threshold(self.root, "ui-auditor")
-        self.assertEqual(threshold, 4)
 
     def test_skip_threshold_returns_default_when_no_json_no_markdown(self) -> None:
         """Without both JSON and markdown, _get_skip_threshold() returns DEFAULT_SKIP_THRESHOLD."""


### PR DESCRIPTION
## Summary

`dynos_patterns.md` was written to Claude's memory path and injected into the context window on every session. It contained ~60 lines of EMA effectiveness scores, model policy tables, and skip policy tables that only the Python router reads — wasted context tokens.

### Before
```
dynos_patterns.md (88 lines) → Claude context window
  - Prevention Rules (3 lines) ← useful to LLM
  - Gold Standard Instances (5 lines) ← useful to LLM
  - Effectiveness Scores (16 lines) ← only router reads
  - Model Policy (14 lines) ← only router reads
  - Skip Policy (4 lines) ← only router reads
  - Agent Routing (14 lines) ← only router reads
```

### After
```
dynos_patterns.md (~20 lines) → Claude context window
  - Prevention Rules ← LLM reads as executor instructions
  - Gold Standard Instances ← LLM reads as examples

effectiveness-scores.json (new) → router reads for UCB1
model-policy.json → router reads for model selection
skip-policy.json → router reads for skip decisions
```

Router updated to read from JSON instead of parsing markdown. Removed markdown fallback tiers (redundant).

891 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)