### PR TITLE
flatten eventbus: 4 handlers, 1 event, 1 drain

### DIFF
--- a/cli/assets/hooks/eventbus.py
+++ b/cli/assets/hooks/eventbus.py
@@ -52,35 +52,8 @@ def _run(cmd: list[str], root: Path) -> bool:
         return False
 
 
-def run_memory(root: Path, _payload: dict) -> bool:
-    """Aggregate retrospectives into project memory (deterministic Python)."""
-    # patterns.py does everything the learn skill does:
-    # EMA effectiveness scores, model policy, skip policy, baseline policy,
-    # agent routing table, prevention rules — all written to dynos_patterns.md
-    return _run(
-        ["python3", str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
-        root,
-    )
-
-
-def run_trajectory(root: Path, _payload: dict) -> bool:
-    """Rebuild trajectory store from all retrospectives."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "trajectory.py"), "rebuild", "--root", str(root)],
-        root,
-    )
-
-
-def run_calibration(root: Path, _payload: dict) -> bool:
-    """Deterministic project-specific agent generation."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "calibrate.py"), "auto", "--root", str(root)],
-        root,
-    )
-
-
-def run_patterns(root: Path, _payload: dict) -> bool:
-    """Refresh patterns file from live runtime state."""
+def run_policy_engine(root: Path, _payload: dict) -> bool:
+    """Compute EMA scores and write routing policies from retrospectives."""
     return _run(
         ["python3", str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
         root,
@@ -88,25 +61,9 @@ def run_patterns(root: Path, _payload: dict) -> bool:
 
 
 def run_postmortem(root: Path, _payload: dict) -> bool:
-    """Generate automatic postmortem."""
+    """Generate human-readable postmortem report."""
     return _run(
         ["python3", str(SCRIPT_DIR / "postmortem.py"), "generate", "--root", str(root)],
-        root,
-    )
-
-
-def run_improve(root: Path, _payload: dict) -> bool:
-    """Run improvement cycle (project-local only)."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "postmortem.py"), "improve", "--root", str(root)],
-        root,
-    )
-
-
-def run_benchmark(root: Path, _payload: dict) -> bool:
-    """Auto-benchmark shadow challengers."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "auto.py"), "run", "--root", str(root)],
         root,
     )
 
@@ -130,37 +87,24 @@ def run_register(root: Path, _payload: dict) -> bool:
 # ---------------------------------------------------------------------------
 # Handler registry
 # ---------------------------------------------------------------------------
-# Each event type maps to a list of (consumer_name, handler_fn).
-# Follow-on events are defined separately in the FOLLOW_ON dict.
+# Flat chain: all handlers fire on task-completed. No intermediate events.
+# Previously this was a 4-hop chain (task-completed → memory-completed →
+# calibration-completed → benchmark-completed) with 10 handlers and 6 no-ops.
+# Flattened because the learning pipeline is sandboxed.
 
 HandlerEntry = tuple[str, Callable[[Path, dict], bool]]
 
 HANDLERS: dict[str, list[HandlerEntry]] = {
     "task-completed": [
-        ("memory", run_memory),
-        ("trajectory", run_trajectory),
-    ],
-    "memory-completed": [
-        ("calibration", run_calibration),
-        ("patterns", run_patterns),
-    ],
-    "calibration-completed": [
+        ("policy_engine", run_policy_engine),
         ("postmortem", run_postmortem),
-        ("improve", run_improve),
-        ("benchmark", run_benchmark),
-    ],
-    "benchmark-completed": [
         ("dashboard", run_dashboard),
         ("register", run_register),
     ],
 }
 
-# Maps event type to the follow-on event emitted when handlers complete
-FOLLOW_ON: dict[str, str] = {
-    "task-completed": "memory-completed",
-    "memory-completed": "calibration-completed",
-    "calibration-completed": "benchmark-completed",
-}
+# No follow-on events needed — everything fires from task-completed directly.
+FOLLOW_ON: dict[str, str] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -179,11 +123,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
 
     from lib_core import is_learning_enabled
     learning = is_learning_enabled(root)
-    # Handlers that are part of the learning layer — skipped when learning is disabled.
-    # Note: only the handler FUNCTIONS are skipped. The event types still flow through
-    # so that non-learning handlers in downstream events (dashboard, register, postmortem)
-    # still fire. A skipped handler counts as succeeded for follow-on gating.
-    _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
+    # policy_engine is the only learning handler — skipped when learning is disabled.
+    # postmortem, dashboard, register always run regardless.
+    _LEARNING_HANDLERS = {"policy_engine"}
 
     # Track consumers that failed during this drain call — don't retry them
     # in subsequent iterations. Retries happen on the NEXT drain() invocation.

--- a/cli/assets/hooks/lib_core.py
+++ b/cli/assets/hooks/lib_core.py
@@ -424,10 +424,10 @@ def _auto_log(task_dir: Path, from_stage: str, to_stage: str, forced: bool) -> N
 
 
 def _fire_task_completed(task_dir: Path) -> None:
-    """Run the post-completion pipeline: event emit → drain (learn, postmortem, evolve, etc).
+    """Run the post-completion pipeline: emit event → drain (policy engine, postmortem, dashboard, register).
 
-    This is the ONLY place that fires the pipeline. Never swallow errors silently
-    — print them but don't block the transition.
+    This is the ONLY trigger for the pipeline. The bash TaskCompleted hook
+    only handles auto-commit — it no longer emits events or drains.
     """
     import subprocess
 
@@ -449,7 +449,7 @@ def _fire_task_completed(task_dir: Path) -> None:
     except Exception as exc:
         print(f"[dynos] event emit failed: {exc}")
 
-    # Step 2: Drain all events (learn → trajectory → evolve → postmortem → improve)
+    # Step 2: Drain (flat chain: policy_engine, postmortem, dashboard, register)
     try:
         result = subprocess.run(
             ["python3", str(hooks_dir / "eventbus.py"), "drain",

--- a/cli/assets/hooks/lib_events.py
+++ b/cli/assets/hooks/lib_events.py
@@ -22,9 +22,6 @@ from lib_core import load_json, now_iso, write_json
 
 EVENT_TYPES: set[str] = {
     "task-completed",
-    "memory-completed",
-    "calibration-completed",
-    "benchmark-completed",
 }
 
 VALID_PIPELINES: set[str] = {"task", "memory", "observability", "eventbus"}

--- a/cli/assets/hooks/task-completed
+++ b/cli/assets/hooks/task-completed
@@ -1,49 +1,16 @@
 #!/usr/bin/env bash
 # Hook: TaskCompleted
-# Runs after every task completion.
-#
-# Pipeline: event-driven via eventbus.py
-# The drain runner processes: learn → trajectory → evolve → patterns →
-# postmortem → improve → auto-benchmark → dashboard → register
-#
-# Every handler swallows errors so failures never block the session.
+# Fires after every Claude Code conversation turn (NOT just dynos-work task completion).
+# The actual post-completion pipeline (policy engine, postmortem, dashboard) is handled
+# by _fire_task_completed() inline in transition_task("DONE"). This hook only does
+# the conditional auto-commit.
 
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# --- Step 1: Find the most recently completed task and emit with identity ---
-TASK_DIR=$(PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 -c "
-import json, sys
-from pathlib import Path
-dynos = Path('${PROJECT_ROOT}') / '.dynos'
-best = None
-for mp in sorted(dynos.glob('task-*/manifest.json'), reverse=True):
-    try:
-        m = json.loads(mp.read_text())
-        if m.get('stage') == 'DONE':
-            print(str(mp.parent)); sys.exit(0)
-    except: pass
-" 2>/dev/null)
-
-PAYLOAD="{}"
-if [ -n "${TASK_DIR:-}" ]; then
-  TASK_ID=$(basename "$TASK_DIR")
-  PAYLOAD="{\"task_id\": \"${TASK_ID}\", \"task_dir\": \"${TASK_DIR}\"}"
-fi
-
-PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/lib_events.py" emit \
-  --root "${PROJECT_ROOT}" \
-  --type task-completed \
-  --source task \
-  --payload "$PAYLOAD" || true
-
-# --- Step 2: Drain all events (learn → evolve → benchmark → dashboard) ---
-PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/eventbus.py" drain \
-  --root "${PROJECT_ROOT}" || true
-
-# --- Step 3: Conditional auto-commit ---
+# --- Conditional auto-commit ---
 PROJECT_DIR=$(echo "${PROJECT_ROOT}" | sed 's|/|-|g')
 SETTINGS="$HOME/.claude/projects/$PROJECT_DIR/settings.json"
 if [ -f "$SETTINGS" ] && grep -q '"dynos_auto_commit".*true' "$SETTINGS" 2>/dev/null; then

--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -52,35 +52,8 @@ def _run(cmd: list[str], root: Path) -> bool:
         return False
 
 
-def run_memory(root: Path, _payload: dict) -> bool:
-    """Aggregate retrospectives into project memory (deterministic Python)."""
-    # patterns.py does everything the learn skill does:
-    # EMA effectiveness scores, model policy, skip policy, baseline policy,
-    # agent routing table, prevention rules — all written to dynos_patterns.md
-    return _run(
-        ["python3", str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
-        root,
-    )
-
-
-def run_trajectory(root: Path, _payload: dict) -> bool:
-    """Rebuild trajectory store from all retrospectives."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "trajectory.py"), "rebuild", "--root", str(root)],
-        root,
-    )
-
-
-def run_calibration(root: Path, _payload: dict) -> bool:
-    """Deterministic project-specific agent generation."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "calibrate.py"), "auto", "--root", str(root)],
-        root,
-    )
-
-
-def run_patterns(root: Path, _payload: dict) -> bool:
-    """Refresh patterns file from live runtime state."""
+def run_policy_engine(root: Path, _payload: dict) -> bool:
+    """Compute EMA scores and write routing policies from retrospectives."""
     return _run(
         ["python3", str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
         root,
@@ -88,25 +61,9 @@ def run_patterns(root: Path, _payload: dict) -> bool:
 
 
 def run_postmortem(root: Path, _payload: dict) -> bool:
-    """Generate automatic postmortem."""
+    """Generate human-readable postmortem report."""
     return _run(
         ["python3", str(SCRIPT_DIR / "postmortem.py"), "generate", "--root", str(root)],
-        root,
-    )
-
-
-def run_improve(root: Path, _payload: dict) -> bool:
-    """Run improvement cycle (project-local only)."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "postmortem.py"), "improve", "--root", str(root)],
-        root,
-    )
-
-
-def run_benchmark(root: Path, _payload: dict) -> bool:
-    """Auto-benchmark shadow challengers."""
-    return _run(
-        ["python3", str(SCRIPT_DIR / "auto.py"), "run", "--root", str(root)],
         root,
     )
 
@@ -130,37 +87,24 @@ def run_register(root: Path, _payload: dict) -> bool:
 # ---------------------------------------------------------------------------
 # Handler registry
 # ---------------------------------------------------------------------------
-# Each event type maps to a list of (consumer_name, handler_fn).
-# Follow-on events are defined separately in the FOLLOW_ON dict.
+# Flat chain: all handlers fire on task-completed. No intermediate events.
+# Previously this was a 4-hop chain (task-completed → memory-completed →
+# calibration-completed → benchmark-completed) with 10 handlers and 6 no-ops.
+# Flattened because the learning pipeline is sandboxed.
 
 HandlerEntry = tuple[str, Callable[[Path, dict], bool]]
 
 HANDLERS: dict[str, list[HandlerEntry]] = {
     "task-completed": [
-        ("memory", run_memory),
-        ("trajectory", run_trajectory),
-    ],
-    "memory-completed": [
-        ("calibration", run_calibration),
-        ("patterns", run_patterns),
-    ],
-    "calibration-completed": [
+        ("policy_engine", run_policy_engine),
         ("postmortem", run_postmortem),
-        ("improve", run_improve),
-        ("benchmark", run_benchmark),
-    ],
-    "benchmark-completed": [
         ("dashboard", run_dashboard),
         ("register", run_register),
     ],
 }
 
-# Maps event type to the follow-on event emitted when handlers complete
-FOLLOW_ON: dict[str, str] = {
-    "task-completed": "memory-completed",
-    "memory-completed": "calibration-completed",
-    "calibration-completed": "benchmark-completed",
-}
+# No follow-on events needed — everything fires from task-completed directly.
+FOLLOW_ON: dict[str, str] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -179,11 +123,9 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
 
     from lib_core import is_learning_enabled
     learning = is_learning_enabled(root)
-    # Handlers that are part of the learning layer — skipped when learning is disabled.
-    # Note: only the handler FUNCTIONS are skipped. The event types still flow through
-    # so that non-learning handlers in downstream events (dashboard, register, postmortem)
-    # still fire. A skipped handler counts as succeeded for follow-on gating.
-    _LEARNING_HANDLERS = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
+    # policy_engine is the only learning handler — skipped when learning is disabled.
+    # postmortem, dashboard, register always run regardless.
+    _LEARNING_HANDLERS = {"policy_engine"}
 
     # Track consumers that failed during this drain call — don't retry them
     # in subsequent iterations. Retries happen on the NEXT drain() invocation.

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -424,10 +424,10 @@ def _auto_log(task_dir: Path, from_stage: str, to_stage: str, forced: bool) -> N
 
 
 def _fire_task_completed(task_dir: Path) -> None:
-    """Run the post-completion pipeline: event emit → drain (memory, postmortem, calibration, etc).
+    """Run the post-completion pipeline: emit event → drain (policy engine, postmortem, dashboard, register).
 
-    This is the ONLY place that fires the pipeline. Never swallow errors silently
-    — print them but don't block the transition.
+    This is the ONLY trigger for the pipeline. The bash TaskCompleted hook
+    only handles auto-commit — it no longer emits events or drains.
     """
     import subprocess
 
@@ -449,7 +449,7 @@ def _fire_task_completed(task_dir: Path) -> None:
     except Exception as exc:
         print(f"[dynos] event emit failed: {exc}")
 
-    # Step 2: Drain all events (memory → trajectory → calibration → postmortem → improve)
+    # Step 2: Drain (flat chain: policy_engine, postmortem, dashboard, register)
     try:
         result = subprocess.run(
             ["python3", str(hooks_dir / "eventbus.py"), "drain",

--- a/hooks/lib_events.py
+++ b/hooks/lib_events.py
@@ -22,9 +22,6 @@ from lib_core import load_json, now_iso, write_json
 
 EVENT_TYPES: set[str] = {
     "task-completed",
-    "memory-completed",
-    "calibration-completed",
-    "benchmark-completed",
 }
 
 VALID_PIPELINES: set[str] = {"task", "memory", "observability", "eventbus"}

--- a/hooks/task-completed
+++ b/hooks/task-completed
@@ -1,49 +1,16 @@
 #!/usr/bin/env bash
 # Hook: TaskCompleted
-# Runs after every task completion.
-#
-# Pipeline: event-driven via eventbus.py
-# The drain runner processes: learn → trajectory → evolve → patterns →
-# postmortem → improve → auto-benchmark → dashboard → register
-#
-# Every handler swallows errors so failures never block the session.
+# Fires after every Claude Code conversation turn (NOT just dynos-work task completion).
+# The actual post-completion pipeline (policy engine, postmortem, dashboard) is handled
+# by _fire_task_completed() inline in transition_task("DONE"). This hook only does
+# the conditional auto-commit.
 
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# --- Step 1: Find the most recently completed task and emit with identity ---
-TASK_DIR=$(PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 -c "
-import json, sys
-from pathlib import Path
-dynos = Path('${PROJECT_ROOT}') / '.dynos'
-best = None
-for mp in sorted(dynos.glob('task-*/manifest.json'), reverse=True):
-    try:
-        m = json.loads(mp.read_text())
-        if m.get('stage') == 'DONE':
-            print(str(mp.parent)); sys.exit(0)
-    except: pass
-" 2>/dev/null)
-
-PAYLOAD="{}"
-if [ -n "${TASK_DIR:-}" ]; then
-  TASK_ID=$(basename "$TASK_DIR")
-  PAYLOAD="{\"task_id\": \"${TASK_ID}\", \"task_dir\": \"${TASK_DIR}\"}"
-fi
-
-PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/lib_events.py" emit \
-  --root "${PROJECT_ROOT}" \
-  --type task-completed \
-  --source task \
-  --payload "$PAYLOAD" || true
-
-# --- Step 2: Drain all events (learn → evolve → benchmark → dashboard) ---
-PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}" python3 "${SCRIPT_DIR}/eventbus.py" drain \
-  --root "${PROJECT_ROOT}" || true
-
-# --- Step 3: Conditional auto-commit ---
+# --- Conditional auto-commit ---
 PROJECT_DIR=$(echo "${PROJECT_ROOT}" | sed 's|/|-|g')
 SETTINGS="$HOME/.claude/projects/$PROJECT_DIR/settings.json"
 if [ -f "$SETTINGS" ] && grep -q '"dynos_auto_commit".*true' "$SETTINGS" 2>/dev/null; then

--- a/tests/test_eventbus_drain.py
+++ b/tests/test_eventbus_drain.py
@@ -1,11 +1,7 @@
 """Integration tests for eventbus.drain() behavior.
 
-Covers the drain semantics that were previously untested:
-  - Failed handlers leave events available for retry
-  - Follow-on events only fire when ALL handlers succeed
-  - learning_enabled=false still runs non-learning downstream handlers
-  - Multiple queued events: failure on one blocks follow-on (AND semantics)
-  - Duplicate follow-on prevention across iterations
+Flat chain: all handlers fire on task-completed directly.
+No intermediate events.
 """
 from __future__ import annotations
 
@@ -20,12 +16,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def _setup(tmp_path: Path) -> Path:
-    """Create minimal .dynos/events/ for drain testing."""
     (tmp_path / ".dynos" / "events").mkdir(parents=True)
     (tmp_path / ".dynos" / "events.jsonl").touch()
     return tmp_path
@@ -45,19 +36,11 @@ def _processed_by(event_path: Path) -> list[str]:
 
 
 def _make_handlers(overrides: dict):
-    """Build a test HANDLERS dict with controllable return values.
-
-    overrides: {consumer_name: bool_or_callable}
-    Missing consumers default to True.
-    """
     import eventbus
-
     def _make_fn(result):
         if callable(result):
             return result
         return lambda root, payload: result
-
-    # Start from the real handler structure but replace functions
     test_handlers = {}
     for event_type, handlers in eventbus.HANDLERS.items():
         test_handlers[event_type] = []
@@ -67,16 +50,56 @@ def _make_handlers(overrides: dict):
     return test_handlers
 
 
-# ---------------------------------------------------------------------------
-# Failed handlers: retry on next drain
-# ---------------------------------------------------------------------------
+class TestFlatChain:
+    def test_all_handlers_fire_on_task_completed(self, tmp_path: Path):
+        root = _setup(tmp_path)
+        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
+
+        called = set()
+        def track(name):
+            def fn(root, payload):
+                called.add(name)
+                return True
+            return fn
+
+        handlers = _make_handlers({
+            "policy_engine": track("policy_engine"),
+            "postmortem": track("postmortem"),
+            "dashboard": track("dashboard"),
+            "register": track("register"),
+        })
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"):
+            from eventbus import drain
+            drain(root, max_iterations=1)
+
+        assert called == {"policy_engine", "postmortem", "dashboard", "register"}
+
+    def test_no_follow_on_events(self, tmp_path: Path):
+        root = _setup(tmp_path)
+        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
+
+        handlers = _make_handlers({})
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"):
+            from eventbus import drain
+            drain(root, max_iterations=5)
+
+        # No intermediate events should exist
+        events_dir = root / ".dynos" / "events"
+        all_events = list(events_dir.glob("*.json"))
+        event_types = {json.loads(f.read_text()).get("event_type") for f in all_events}
+        assert event_types == {"task-completed"}
+
 
 class TestFailedHandlerRetry:
-    def test_failed_handler_event_not_marked_processed(self, tmp_path: Path):
+    def test_failed_handler_not_marked_processed(self, tmp_path: Path):
         root = _setup(tmp_path)
         ep = _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
 
-        handlers = _make_handlers({"memory": False, "trajectory": True})
+        handlers = _make_handlers({"policy_engine": False, "postmortem": True})
         with mock.patch("eventbus.HANDLERS", handlers), \
              mock.patch("lib_core.is_learning_enabled", return_value=True), \
              mock.patch("eventbus.log_event"):
@@ -84,8 +107,8 @@ class TestFailedHandlerRetry:
             drain(root, max_iterations=1)
 
         processed = _processed_by(ep)
-        assert "trajectory" in processed
-        assert "memory" not in processed
+        assert "postmortem" in processed
+        assert "policy_engine" not in processed
 
     def test_failed_handler_retried_on_second_drain(self, tmp_path: Path):
         root = _setup(tmp_path)
@@ -96,7 +119,7 @@ class TestFailedHandlerRetry:
             calls["n"] += 1
             return calls["n"] > 1
 
-        handlers = _make_handlers({"memory": fail_then_succeed, "trajectory": True})
+        handlers = _make_handlers({"policy_engine": fail_then_succeed})
         with mock.patch("eventbus.HANDLERS", handlers), \
              mock.patch("lib_core.is_learning_enabled", return_value=True), \
              mock.patch("eventbus.log_event"):
@@ -107,118 +130,33 @@ class TestFailedHandlerRetry:
             assert calls["n"] == 2
 
 
-# ---------------------------------------------------------------------------
-# Follow-on gating: ALL handlers must succeed
-# ---------------------------------------------------------------------------
-
-class TestFollowOnGating:
-    def test_blocked_when_one_handler_fails(self, tmp_path: Path):
-        root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-
-        handlers = _make_handlers({"memory": False, "trajectory": True})
-        with mock.patch("eventbus.HANDLERS", handlers), \
-             mock.patch("lib_core.is_learning_enabled", return_value=True), \
-             mock.patch("eventbus.log_event"):
-            from eventbus import drain
-            drain(root, max_iterations=1)
-
-        assert _count_events(root, "memory-completed") == 0
-
-    def test_emitted_when_all_succeed(self, tmp_path: Path):
-        root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-
-        handlers = _make_handlers({})  # all default to True
-        with mock.patch("eventbus.HANDLERS", handlers), \
-             mock.patch("lib_core.is_learning_enabled", return_value=True), \
-             mock.patch("eventbus.log_event"):
-            from eventbus import drain
-            drain(root, max_iterations=1)
-
-        assert _count_events(root, "memory-completed") == 1
-
-    def test_no_duplicates_across_iterations(self, tmp_path: Path):
-        root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-
-        handlers = _make_handlers({})
-        with mock.patch("eventbus.HANDLERS", handlers), \
-             mock.patch("lib_core.is_learning_enabled", return_value=True), \
-             mock.patch("eventbus.log_event"):
-            from eventbus import drain
-            drain(root, max_iterations=5)
-
-        assert _count_events(root, "memory-completed") == 1
-        assert _count_events(root, "calibration-completed") == 1
-        assert _count_events(root, "benchmark-completed") == 1
-
-
-# ---------------------------------------------------------------------------
-# learning_enabled=false: non-learning handlers still fire
-# ---------------------------------------------------------------------------
-
 class TestLearningDisabled:
-    def test_skipped_handlers_mark_events_processed(self, tmp_path: Path):
+    def test_policy_engine_skipped_when_learning_off(self, tmp_path: Path):
         root = _setup(tmp_path)
-        ep = _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
+        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
 
-        handlers = _make_handlers({})
+        pe_called = {"v": False}
+        dash_called = {"v": False}
+        def track_pe(root, payload):
+            pe_called["v"] = True
+            return True
+        def track_dash(root, payload):
+            dash_called["v"] = True
+            return True
+
+        handlers = _make_handlers({"policy_engine": track_pe, "dashboard": track_dash})
         with mock.patch("eventbus.HANDLERS", handlers), \
              mock.patch("lib_core.is_learning_enabled", return_value=False), \
              mock.patch("eventbus.log_event"):
             from eventbus import drain
             drain(root, max_iterations=1)
 
-        processed = _processed_by(ep)
-        assert "memory" in processed
-        assert "trajectory" in processed
+        assert not pe_called["v"], "policy_engine should NOT run with learning off"
+        assert dash_called["v"], "dashboard should run with learning off"
 
-    def test_chain_reaches_dashboard(self, tmp_path: Path):
-        root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-
-        dashboard_called = {"v": False}
-        def track_dashboard(root, payload):
-            dashboard_called["v"] = True
-            return True
-
-        handlers = _make_handlers({"dashboard": track_dashboard})
-        with mock.patch("eventbus.HANDLERS", handlers), \
-             mock.patch("lib_core.is_learning_enabled", return_value=False), \
-             mock.patch("eventbus.log_event"):
-            from eventbus import drain
-            drain(root, max_iterations=5)
-
-        assert dashboard_called["v"], "dashboard should run with learning off"
-
-    def test_learning_handlers_not_executed(self, tmp_path: Path):
-        root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-
-        memory_called = {"v": False}
-        def track_memory(root, payload):
-            memory_called["v"] = True
-            return True
-
-        handlers = _make_handlers({"memory": track_memory})
-        with mock.patch("eventbus.HANDLERS", handlers), \
-             mock.patch("lib_core.is_learning_enabled", return_value=False), \
-             mock.patch("eventbus.log_event"):
-            from eventbus import drain
-            drain(root, max_iterations=5)
-
-        assert not memory_called["v"], "memory should NOT execute with learning off"
-
-
-# ---------------------------------------------------------------------------
-# No tight-loop retry within a single drain call
-# ---------------------------------------------------------------------------
 
 class TestNoTightRetry:
     def test_permanently_failing_handler_runs_once_per_drain(self, tmp_path: Path):
-        """A handler that always fails should run exactly once per drain(),
-        not once per iteration (which would be 10 times with max_iterations=10)."""
         root = _setup(tmp_path)
         _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
 
@@ -227,36 +165,35 @@ class TestNoTightRetry:
             calls["n"] += 1
             return False
 
-        handlers = _make_handlers({"memory": always_fail, "trajectory": True})
+        handlers = _make_handlers({"policy_engine": always_fail})
         with mock.patch("eventbus.HANDLERS", handlers), \
              mock.patch("lib_core.is_learning_enabled", return_value=True), \
              mock.patch("eventbus.log_event"):
             from eventbus import drain
             drain(root, max_iterations=10)
 
-        assert calls["n"] == 1, f"permanently failing handler ran {calls['n']} times, expected 1"
+        assert calls["n"] == 1
 
 
-# ---------------------------------------------------------------------------
-# Multiple queued events: AND semantics
-# ---------------------------------------------------------------------------
-
-class TestMultiEventAND:
-    def test_failure_on_one_event_blocks_follow_on(self, tmp_path: Path):
+class TestMultiTaskReceipts:
+    def test_receipts_for_multiple_tasks(self, tmp_path: Path):
         root = _setup(tmp_path)
-        _emit(root, "task-completed", {"task_id": "t1", "task_dir": str(tmp_path)})
-        _emit(root, "task-completed", {"task_id": "t2", "task_dir": str(tmp_path)})
+        task1 = tmp_path / ".dynos" / "task-1"
+        task2 = tmp_path / ".dynos" / "task-2"
+        task1.mkdir(parents=True)
+        task2.mkdir(parents=True)
 
-        calls = {"n": 0}
-        def fail_first(root, payload):
-            calls["n"] += 1
-            return calls["n"] > 1
+        _emit(root, "task-completed", {"task_id": "task-1", "task_dir": str(task1)})
+        _emit(root, "task-completed", {"task_id": "task-2", "task_dir": str(task2)})
 
-        handlers = _make_handlers({"memory": fail_first, "trajectory": True})
+        handlers = _make_handlers({})
         with mock.patch("eventbus.HANDLERS", handlers), \
              mock.patch("lib_core.is_learning_enabled", return_value=True), \
-             mock.patch("eventbus.log_event"):
+             mock.patch("eventbus.log_event"), \
+             mock.patch("lib_receipts.receipt_post_completion") as mock_receipt:
             from eventbus import drain
-            drain(root, max_iterations=1)
+            drain(root, max_iterations=5)
 
-        assert _count_events(root, "memory-completed") == 0
+        call_dirs = [str(call.args[0]) for call in mock_receipt.call_args_list]
+        assert str(task1) in call_dirs
+        assert str(task2) in call_dirs

--- a/tests/test_learning_enabled_flag.py
+++ b/tests/test_learning_enabled_flag.py
@@ -153,16 +153,16 @@ class TestResolveSkipWithLearning:
 class TestEventBusLearningGate:
     def test_learning_handlers_identified(self):
         """Verify the learning handler set covers the right handlers."""
-        learning_handlers = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
+        learning_handlers = {"policy_engine"}
         observability_handlers = {"dashboard", "register", "postmortem"}
-        # Postmortem is in calibration-completed along with improve and benchmark
+        # policy_engine is the only learning handler
         # but postmortem writes retrospective improvements — it's borderline
         # For now it's NOT in the learning set (it runs even without learning)
         assert learning_handlers & observability_handlers == set()
 
     def test_learning_handler_names_exist_in_registry(self):
         """Verify all learning handler names exist in the HANDLERS registry."""
-        expected = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
+        expected = {"policy_engine"}
         from eventbus import HANDLERS
         all_handler_names = set()
         for handlers in HANDLERS.values():
@@ -172,7 +172,7 @@ class TestEventBusLearningGate:
 
     def test_observability_handlers_not_in_learning_set(self):
         """Dashboard, register, postmortem should run even with learning off."""
-        learning_handlers = {"memory", "trajectory", "calibration", "patterns", "improve", "benchmark"}
+        learning_handlers = {"policy_engine"}
         assert "dashboard" not in learning_handlers
         assert "register" not in learning_handlers
         assert "postmortem" not in learning_handlers


### PR DESCRIPTION
## Summary

The post-completion eventbus chain was a 4-hop pipeline running 10 handlers to reach 4 useful operations. Policy engine ran 4 times per task completion due to duplicate handlers and double-drain.

### Before
```
task-completed → run_memory (patterns.py) + run_trajectory (no-op)
  → memory-completed → run_calibration (no-op) + run_patterns (DUPLICATE patterns.py)
    → calibration-completed → run_postmortem + run_improve (no-op) + run_benchmark (no-op)
      → benchmark-completed → run_dashboard + run_register
```
Plus bash hook emits a second event and drains again = 4x policy engine calls.

### After
```
task-completed → policy_engine + postmortem + dashboard + register
```
One event. One drain. Four handlers. Zero duplicates.

### Other fixes
- Bash TaskCompleted hook stripped to auto-commit only (it fires on every conversation turn, not just DONE transitions)
- _LEARNING_HANDLERS reduced to just policy_engine
- EVENT_TYPES reduced to just task-completed
- FOLLOW_ON dict is empty

880 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)