### PR TITLE
wire benchmark scheduler to eventbus

### DIFF
--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -177,7 +177,7 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     learning = is_learning_enabled(root)
     # policy_engine is the only learning handler — skipped when learning is disabled.
     # postmortem, dashboard, register always run regardless.
-    _LEARNING_HANDLERS = {"policy_engine", "improve", "agent_generator"}
+    _LEARNING_HANDLERS = {"policy_engine", "improve", "agent_generator", "benchmark_scheduler"}
 
     # Track consumers that failed during this drain call — don't retry them
     # in subsequent iterations. Retries happen on the NEXT drain() invocation.

--- a/hooks/handlers/benchmark_scheduler.py
+++ b/hooks/handlers/benchmark_scheduler.py
@@ -1,0 +1,34 @@
+"""Auto-trigger benchmark scheduler after task completion.
+
+Runs at most one benchmark per task-completed event. The scheduler's
+windowing logic (shadow_rebenchmark_task_window) prevents over-firing.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+EVENT_TYPE = "task-completed"
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+AUTO_PY = SCRIPT_DIR.parent / "sandbox" / "calibration" / "auto.py"
+
+
+def run(root, payload):
+    if not AUTO_PY.exists():
+        return True  # nothing to do, not an error
+    env = {**os.environ, "PYTHONPATH": f"{SCRIPT_DIR}:{os.environ.get('PYTHONPATH', '')}"}
+    try:
+        result = subprocess.run(
+            ["python3", str(AUTO_PY), "run", "--root", str(root), "--limit", "1"],
+            cwd=str(root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode != 0 and result.stderr:
+            print(f"  [warn] benchmark_scheduler: {result.stderr[:200]}", file=__import__('sys').stderr)
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError, FileNotFoundError) as e:
+        print(f"  [warn] benchmark_scheduler: {e}", file=__import__('sys').stderr)
+        return False


### PR DESCRIPTION
## Summary
- Adds `hooks/handlers/benchmark_scheduler.py` — auto-discovered eventbus handler
- Fires on `task-completed`, runs `auto.py run --root . --limit 1`
- Connects shadow agents (from agent_generator) to the bench/eval promotion pipeline
- Windowing logic in auto.py prevents over-firing
- Skipped when `learning_enabled=false`

## What this enables
Shadow agents can now be automatically benchmarked and promoted:
```
agent_generator creates shadow agent → benchmark_scheduler triggers auto.py →
auto.py discovers job → bench.py runs fixture → eval.py promotes to alongside/replace →
router starts using the learned agent
```

## Test plan
- [x] 915 tests pass
- [ ] `dynos bus handlers` shows `benchmark_scheduler` in the list
- [ ] Handler gracefully returns True if auto.py doesn't exist
- [ ] Handler runs auto.py with `--limit 1` to bound latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)