### PR TITLE
fix start skill: add PYTHONPATH for apply_fast_track import

### DIFF
--- a/cli/assets/templates/base/start.md
+++ b/cli/assets/templates/base/start.md
@@ -207,7 +207,7 @@ python3 hooks/dynosctl.py transition .dynos/task-{id} SPEC_NORMALIZATION
 After classification, determine fast-track eligibility **deterministically** by running:
 
 ```text
-python3 -c "from dynoslib import apply_fast_track; from pathlib import Path; print(apply_fast_track(Path('.dynos/task-{id}')))"
+PYTHONPATH="{{HOOKS_PATH}}:${PYTHONPATH:-}" python3 -c "from lib import apply_fast_track; from pathlib import Path; print(apply_fast_track(Path('.dynos/task-{id}')))"
 ```
 
 This checks: `risk_level == "low"` AND exactly 1 domain. It writes `"fast_track": true` or `"fast_track": false` to `manifest.json`. If the command is not available, manually check the conditions and write the field.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -224,7 +224,7 @@ python3 hooks/ctl.py transition .dynos/task-{id} SPEC_NORMALIZATION
 After classification, determine fast-track eligibility **deterministically** by running:
 
 ```text
-python3 -c "from lib import apply_fast_track; from pathlib import Path; print(apply_fast_track(Path('.dynos/task-{id}')))"
+PYTHONPATH="hooks:${PYTHONPATH:-}" python3 -c "from lib import apply_fast_track; from pathlib import Path; print(apply_fast_track(Path('.dynos/task-{id}')))"
 ```
 
 This checks: `risk_level == "low"` AND exactly 1 domain. It writes `"fast_track": true` or `"fast_track": false` to `manifest.json`. If the command is not available, manually check the conditions and write the field.


### PR DESCRIPTION
## Summary

- The fast-track gate invocation in `skills/start/SKILL.md` was `python3 -c "from lib import apply_fast_track; ..."`, but `lib` lives under `hooks/` — so the import fails unless the caller already has PYTHONPATH set. Add the explicit `PYTHONPATH="hooks:${PYTHONPATH:-}"` prefix so the snippet runs standalone.
- Same fix in `cli/assets/templates/base/start.md`, using the `{{HOOKS_PATH}}` template placeholder. Also corrects `dynoslib` → `lib` — leftover reference to the pre-rename module name that was missed when the module was renamed elsewhere.

## Test plan

- [x] The new snippet runs correctly from any cwd that contains a `hooks/` directory
- [x] Template placeholder `{{HOOKS_PATH}}` is consistent with other template substitutions in the same file
- [ ] After merge: verify `/dynos-work:start` fast-track gate invocation works end-to-end on a fresh task

🤖 Generated with [Claude Code](https://claude.com/claude-code)