### PR TITLE
fix performance_check: stop flagging dict.get() as N+1 queries

### DIFF
--- a/hooks/performance_check.py
+++ b/hooks/performance_check.py
@@ -25,21 +25,50 @@ CODE_EXTENSIONS = {
 
 SKIP_DIRS = {".git", "node_modules", ".dynos", "__pycache__", "dist", "build", "vendor"}
 
+# Files only scan for N+1 / unbounded-query patterns if they import a real DB
+# driver or ORM. Without this gate the detector fires on `dict.get()` and
+# similar in-memory field access, which is the dominant pattern in
+# JSON-processing codebases.
+_DB_IMPORT_RE = re.compile(
+    r"\b(?:import|from)\s+("
+    r"sqlite3|psycopg2|psycopg|pymongo|sqlalchemy|MySQLdb|mysql\.connector|"
+    r"asyncpg|aiomysql|aiosqlite|motor|peewee|tortoise|databases|redis|"
+    r"django\.db|flask_sqlalchemy|google\.cloud\.(?:firestore|bigquery|datastore|spanner)"
+    r")\b"
+)
+
+
+def _file_uses_db(content: str) -> bool:
+    """Return True when the file imports a known DB driver or ORM."""
+    return bool(_DB_IMPORT_RE.search(content))
+
 
 # ---------------------------------------------------------------------------
 # Pattern detectors
 # ---------------------------------------------------------------------------
 
 def _detect_n_plus_one(content: str, filepath: str) -> list[dict[str, Any]]:
-    """Detect N+1 query patterns: DB calls inside loops."""
+    """Detect N+1 query patterns: DB calls inside loops.
+
+    Only fires when (a) the file imports a known DB driver/ORM, AND
+    (b) the call has a receiver name that looks like a DB handle. This
+    avoids flagging `dict.get()` and similar in-memory access.
+    """
+    if not _file_uses_db(content):
+        return []
+
     findings: list[dict[str, Any]] = []
     lines = content.splitlines()
     in_loop = False
     loop_start = 0
 
-    # Python: for/while loop containing .query, .execute, .get, .filter, .find
+    # Match <db-handle>.<query-method>( — receiver must be DB-shaped.
     db_call_re = re.compile(
-        r"\.(query|execute|find|findOne|findAll|get|filter|select|fetch|where|raw|all)\s*\(", re.IGNORECASE
+        r"\b(cursor|conn|connection|session|db|database|client|query|queryset|"
+        r"repo|repository|objects|Model|Entity)\.(query|execute|find|findOne|"
+        r"findAll|filter|select|fetch|where|raw|all|get|first|last|count|"
+        r"exists)\s*\(",
+        re.IGNORECASE,
     )
     loop_re = re.compile(r"^\s*(for |while |\.forEach|\.map\(|\.each\b)")
 
@@ -98,7 +127,26 @@ def _detect_missing_timeout(content: str, filepath: str) -> list[dict[str, Any]]
 
 
 def _detect_unbounded_query(content: str, filepath: str) -> list[dict[str, Any]]:
-    """Detect queries that return all rows without LIMIT/pagination."""
+    """Detect queries that return all rows without LIMIT/pagination.
+
+    Only fires when the file imports a known DB driver/ORM — the
+    `.all()`/`.findAll()` pattern otherwise matches list operations.
+    """
+    if not _file_uses_db(content):
+        # Allow raw SQL strings in any file — those are unambiguous.
+        findings: list[dict[str, Any]] = []
+        select_re = re.compile(r"SELECT\s+.*\s+FROM\s+", re.IGNORECASE)
+        for i, line in enumerate(content.splitlines(), 1):
+            if select_re.search(line) and "LIMIT" not in line.upper() and "COUNT" not in line.upper():
+                findings.append({
+                    "pattern": "unbounded_query",
+                    "location": f"{filepath}:{i}",
+                    "line": line.strip()[:120],
+                    "severity": "major",
+                    "description": "Query without LIMIT — may return unbounded rows",
+                })
+        return findings
+
     findings: list[dict[str, Any]] = []
     lines = content.splitlines()
 

--- a/tests/test_performance_typecheck.py
+++ b/tests/test_performance_typecheck.py
@@ -28,11 +28,32 @@ class TestPerformanceCheck:
     def test_detects_n_plus_one(self, tmp_path: Path):
         from performance_check import scan_files
         (tmp_path / "app.py").write_text(
+            "import sqlite3\n"
             "for user in users:\n    db.query(f'SELECT * FROM orders WHERE user_id={user.id}')\n"
         )
         result = scan_files(tmp_path)
         patterns = [f["pattern"] for f in result["findings"]]
         assert "n_plus_one" in patterns
+
+    def test_no_n_plus_one_on_dict_get(self, tmp_path: Path):
+        """dict.get() inside a loop in a file with no DB driver is not an N+1."""
+        from performance_check import scan_files
+        (tmp_path / "process.py").write_text(
+            "for item in items:\n    name = item.get('name', 'unknown')\n"
+        )
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "n_plus_one" not in patterns
+
+    def test_no_n_plus_one_without_db_import(self, tmp_path: Path):
+        """Even with db.query(), a file with no DB driver import is not flagged."""
+        from performance_check import scan_files
+        (tmp_path / "fake.py").write_text(
+            "for x in xs:\n    db.query(x)\n"
+        )
+        result = scan_files(tmp_path)
+        patterns = [f["pattern"] for f in result["findings"]]
+        assert "n_plus_one" not in patterns
 
     def test_detects_missing_timeout(self, tmp_path: Path):
         from performance_check import scan_files
@@ -50,7 +71,10 @@ class TestPerformanceCheck:
 
     def test_detects_unbounded_query(self, tmp_path: Path):
         from performance_check import scan_files
-        (tmp_path / "repo.py").write_text("rows = db.execute('SELECT * FROM users')\n")
+        (tmp_path / "repo.py").write_text(
+            "import sqlite3\n"
+            "rows = db.execute('SELECT * FROM users')\n"
+        )
         result = scan_files(tmp_path)
         patterns = [f["pattern"] for f in result["findings"]]
         assert "unbounded_query" in patterns


### PR DESCRIPTION
## Summary

The N+1 and unbounded-query detectors in `hooks/performance_check.py` used a regex that matched any method named `get`, `find`, `filter`, `all`, `select`, etc. — regardless of the receiver. In a JSON-processing codebase where `dict.get()` is the dominant field-access idiom, this produced thousands of false positives (1,221 on this repo alone, 94% of them against `dict.get`).

Two gates added:

1. **Per-file DB-import check** — `_detect_n_plus_one` and `_detect_unbounded_query` return early when the file imports no known DB driver or ORM (`sqlite3`, `psycopg2`, `pymongo`, `sqlalchemy`, `MySQLdb`, `asyncpg`, `motor`, `peewee`, `django.db`, etc.). Raw `SELECT ... FROM` string literals are still flagged in any file since those are unambiguous.
2. **Narrowed regex** — the DB-call pattern now requires a DB-shaped receiver (`cursor`, `conn`, `session`, `db`, `client`, `queryset`, `objects`, `Model`, ...) before matching the method name. Plain `dict.get()` is no longer a candidate.

## Result on this repo

- **N+1 findings: 1,221 → 0** (no file imports a DB driver, so nothing matches — correct)
- **Unbounded-query: many → 2**, both of which are literal `SELECT` strings inside the detector's own test fixtures

## Test plan

- [x] Existing `test_detects_n_plus_one` and `test_detects_unbounded_query` fixtures updated to include `import sqlite3` so the detector fires on them (reflects real-world code)
- [x] Two regression tests added: `test_no_n_plus_one_on_dict_get` and `test_no_n_plus_one_without_db_import`
- [x] Full `tests/test_performance_typecheck.py` — 31/31 passing
- [x] Full `tests/` suite — passes (no regressions elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)