### PR TITLE
fix performance_check: use indent stack for quadratic loop detection

### DIFF
--- a/hooks/performance_check.py
+++ b/hooks/performance_check.py
@@ -180,35 +180,46 @@ def _detect_unbounded_query(content: str, filepath: str) -> list[dict[str, Any]]
 
 
 def _detect_quadratic(content: str, filepath: str) -> list[dict[str, Any]]:
-    """Detect O(n^2) nested loop patterns."""
+    """Detect O(n^2) nested loop patterns via an indentation stack.
+
+    Tracks each open loop as (indent, line_number). Before considering
+    a new line, pops entries whose indent is >= the current line's indent
+    (i.e. the loop body has ended). A loop is "nested" only when the
+    stack is non-empty at the moment of match.
+
+    JS array methods (.forEach / .map / .filter / .some / .every) are not
+    counted as loops — they are method calls, not syntactic blocks.
+    Sequential chains like `.filter(...).map(...)` are flat, not nested.
+    If a callback inside such a chain contains a real for/while, the
+    stack-based detector catches that on its own.
+    """
     findings: list[dict[str, Any]] = []
     lines = content.splitlines()
-    loop_re = re.compile(r"^\s*(for |while |\.forEach|\.map\(|\.filter\(|\.some\(|\.every\()")
+    loop_re = re.compile(r"^\s*(for |while )")
 
-    loop_depth = 0
-    loop_lines: list[int] = []
+    loop_stack: list[tuple[int, int]] = []  # (indent, line_number)
 
     for i, line in enumerate(lines, 1):
-        if loop_re.search(line):
-            loop_depth += 1
-            loop_lines.append(i)
-            if loop_depth >= 2:
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith(("#", "//", "*", "/*")):
+            continue
+        indent = len(line) - len(stripped)
+
+        # Pop any loops whose body has ended (indent no longer inside them).
+        while loop_stack and indent <= loop_stack[-1][0]:
+            loop_stack.pop()
+
+        if loop_re.match(line):
+            depth = len(loop_stack) + 1
+            if depth >= 2:
                 findings.append({
                     "pattern": "quadratic_loop",
                     "location": f"{filepath}:{i}",
                     "line": line.strip()[:120],
                     "severity": "major",
-                    "description": f"Nested loop (depth {loop_depth}) — potential O(n^2) or worse. Outer loop at line {loop_lines[0]}",
+                    "description": f"Nested loop (depth {depth}) — potential O(n^2) or worse. Outer loop at line {loop_stack[0][1]}",
                 })
-        # Very rough scope tracking — reset on dedent to function level
-        if line.strip() and not line.strip().startswith(("#", "//", "*", "/*")):
-            stripped = line.lstrip()
-            indent = len(line) - len(stripped)
-            if indent == 0 and (stripped.startswith("def ") or stripped.startswith("func ") or
-                                stripped.startswith("function ") or stripped.startswith("class ") or
-                                stripped.startswith("export ")):
-                loop_depth = 0
-                loop_lines = []
+            loop_stack.append((indent, i))
 
     return findings
 

--- a/tests/test_performance_typecheck.py
+++ b/tests/test_performance_typecheck.py
@@ -86,6 +86,50 @@ class TestPerformanceCheck:
         patterns = [f["pattern"] for f in result["findings"]]
         assert "quadratic_loop" in patterns
 
+    def test_no_quadratic_on_sibling_loops(self, tmp_path: Path):
+        """Two sibling (sequential) for-loops are flat, not nested."""
+        from performance_check import scan_files
+        (tmp_path / "sibs.py").write_text(
+            "def run(items):\n"
+            "    for a in items:\n"
+            "        use(a)\n"
+            "    for b in items:\n"
+            "        use(b)\n"
+        )
+        result = scan_files(tmp_path)
+        quad = [f for f in result["findings"] if f["pattern"] == "quadratic_loop"]
+        assert len(quad) == 0
+
+    def test_no_quadratic_on_js_array_methods(self, tmp_path: Path):
+        """Chains like .filter().map() are flat method calls, not nested loops."""
+        from performance_check import scan_files
+        (tmp_path / "app.ts").write_text(
+            "function run(items) {\n"
+            "  const out = items.filter((x) => x > 0).map((x) => x * 2);\n"
+            "  return out;\n"
+            "}\n"
+        )
+        result = scan_files(tmp_path)
+        quad = [f for f in result["findings"] if f["pattern"] == "quadratic_loop"]
+        assert len(quad) == 0
+
+    def test_no_quadratic_across_sibling_js_handlers(self, tmp_path: Path):
+        """Two sibling route handlers in one exported function are not nested."""
+        from performance_check import scan_files
+        (tmp_path / "app.ts").write_text(
+            "export function api() {\n"
+            "  function handlerA() {\n"
+            "    for (const a of as) { use(a); }\n"
+            "  }\n"
+            "  function handlerB() {\n"
+            "    for (const b of bs) { use(b); }\n"
+            "  }\n"
+            "}\n"
+        )
+        result = scan_files(tmp_path)
+        quad = [f for f in result["findings"] if f["pattern"] == "quadratic_loop"]
+        assert len(quad) == 0
+
     def test_detects_connection_leak(self, tmp_path: Path):
         from performance_check import scan_files
         (tmp_path / "db.py").write_text("conn = psycopg2.connect(db_url)\ncursor = conn.cursor()\ncursor.execute(query)\n")


### PR DESCRIPTION
## Summary

The previous `_detect_quadratic` used a monotonic counter that was **never decremented** — only reset when a top-level `def`/`func`/`function`/`class`/`export` was encountered at indent 0. In a monolithic exported function (e.g., `hooks/dashboard-ui/src/vite-plugin/dynos-api.ts`, lines 478-1648 are one function body), the counter climbed 0→33 across the file and cited every loop after the second as "nested at depth N" under an arbitrary "outer" line hundreds of lines away.

The loop regex also matched JS array methods (`.forEach`, `.map(`, `.filter(`, `.some(`, `.every(`). A flat chain like `arr.filter(...).map(...)` was counted as nested iteration.

### Two fixes

1. **Indentation stack.** Track each open loop as `(indent, line_number)`. Before matching each new line, pop entries whose indent is ≥ the current line's indent (the loop body has ended). A match is "nested" only when the stack is non-empty at that moment. Works for both Python and JS/TS since both use consistent indentation in practice.
2. **Drop JS array methods from `loop_re`.** `.forEach`/`.map(`/`.filter(`/`.some(`/`.every(` are method calls, not syntactic loops. If their callback contains a real `for`/`while`, the stack catches that correctly.

### Result

- `tests/test_performance_typecheck.py` — **34/34 passing** (3 regression tests added for sibling loops, `.filter().map()` chains, sibling route handlers)
- On this repo: quadratic findings drop from **814 → 146**. The remaining 146 correspond to real nested loops (e.g. `for retro in retros: for role in models`), which is the intended signal.

## Test plan

- [x] `test_detects_quadratic_loop` still passes (true nested case)
- [x] `test_no_quadratic_on_sibling_loops` — two sequential `for`s are flat
- [x] `test_no_quadratic_on_js_array_methods` — `.filter().map()` chain is flat
- [x] `test_no_quadratic_across_sibling_js_handlers` — two handlers in one exported function aren't nested
- [x] Full `tests/` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)