### PR TITLE
fix three pipeline regressions: registry data loss, fast-track stage walk, post-completion receipt

### DIFF
--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -285,20 +285,36 @@ def drain(root: Path, max_iterations: int = 10) -> dict:
     # Cleanup old events
     cleanup_old_events(root)
 
-    # Write post-completion receipt for EACH completed task
+    # Write post-completion receipt for EACH completed task.
+    #
+    # The receipt records which handlers ran and whether two specific outcomes
+    # were achieved: the project's pattern store was updated, and a postmortem
+    # was written for this task. The previous derivation read these from
+    # `calibration-completed` and `memory-completed` summary buckets that no
+    # longer exist (the eventbus chain was flattened to task-completed only,
+    # and postmortem moved to the audit skill). The values were silently False.
+    #
+    # Current derivation:
+    # - patterns_updated: from policy_engine handler in the task-completed
+    #   bucket (the renamed equivalent of the old patterns handler).
+    # - postmortem_written: per-task disk check, since postmortem now runs in
+    #   the audit skill (Step 5a) and writes to the persistent project dir.
     if "task-completed" in summary and completed_task_dirs:
         handlers_run = []
         for evt_type, results in summary.items():
             for r in results:
                 name, status = r.split(":", 1)
                 handlers_run.append({"name": name, "success": status == "ok", "event": evt_type})
-        postmortem_ok = any(r.startswith("postmortem:ok") for r in summary.get("calibration-completed", []))
-        patterns_ok = any(r.startswith("patterns:ok") for r in summary.get("memory-completed", []))
+        patterns_ok = any(r.startswith("policy_engine:ok") for r in summary.get("task-completed", []))
+        from lib_core import _persistent_project_dir
+        postmortems_dir = _persistent_project_dir(root) / "postmortems"
         for td in completed_task_dirs:
             try:
                 from lib_receipts import receipt_post_completion
                 task_dir = Path(td)
                 if task_dir.exists():
+                    task_id = task_dir.name
+                    postmortem_ok = (postmortems_dir / f"{task_id}.json").exists()
                     receipt_post_completion(
                         task_dir,
                         handlers_run=handlers_run,

--- a/hooks/registry.py
+++ b/hooks/registry.py
@@ -9,10 +9,20 @@ import hashlib
 import json
 import os
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
 from lib_core import load_json, now_iso, write_json
+
+
+class RegistryCorruptError(RuntimeError):
+    """Raised when the on-disk registry fails its checksum and cannot be quarantined.
+
+    The caller should treat this as a hard refusal to operate — propagating it
+    is preferable to silently overwriting the corrupt file with an empty one
+    and wiping every registered project on the next mutation.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -113,11 +123,33 @@ def load_registry() -> dict:
     stored = reg.get("checksum", "")
     expected = _compute_checksum(reg)
     if stored != expected:
+        # The previous behavior was to silently return _empty_registry(), which
+        # let the next register_project() call overwrite the on-disk file with
+        # a single-entry registry — wiping every other registered project.
+        # Quarantine the corrupt file (preserving its data for recovery) before
+        # returning the empty registry. If quarantine fails, refuse the load
+        # entirely rather than risk losing the corrupt copy too.
+        quarantine = path.with_name(f"{path.name}.corrupt-{int(time.time())}")
+        try:
+            path.rename(quarantine)
+        except OSError as exc:
+            log_global(
+                f"registry checksum mismatch: stored={stored[:12]}... "
+                f"expected={expected[:12]}... — quarantine to {quarantine.name} "
+                f"failed ({exc}); refusing to operate"
+            )
+            raise RegistryCorruptError(
+                f"registry at {path} failed checksum and could not be "
+                f"quarantined ({exc}); refusing to mutate"
+            ) from exc
         log_global(
             f"registry checksum mismatch: stored={stored[:12]}... "
-            f"expected={expected[:12]}... — refusing to operate on corrupted registry"
+            f"expected={expected[:12]}... — quarantined to {quarantine.name}; "
+            f"continuing with empty registry (run inspect on quarantine to recover)"
         )
-        return _empty_registry()
+        reg = _empty_registry()
+        reg["checksum"] = _compute_checksum(reg)
+        return reg
     return reg
 
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -252,7 +252,7 @@ If any condition is not met, proceed normally (no fast-track). Do not ask the us
 
 ## Step 3 — Spec Normalization
 
-**Fast-track combined spawn:** If `manifest.json` has `"fast_track": true`, skip the spawn and the spec validation. Spec is produced in Step 5 by the combined Spec + Plan planner spawn. Walk the manifest stage straight through `SPEC_NORMALIZATION → SPEC_REVIEW → PLANNING` (no work between transitions; this preserves the state-machine invariants while collapsing the LLM work into a single spawn). Log: `{timestamp} [SKIP] spec-normalization-spawn — fast_track combined planner`. Skip the rest of this step and proceed to Step 4.
+**Fast-track combined spawn:** If `manifest.json` has `"fast_track": true`, skip the spawn and the spec validation. Spec is produced in Step 5 by the combined Spec + Plan planner spawn. **Do NOT advance the manifest stage here** — leave it at `SPEC_NORMALIZATION`. Walking the stage forward before `spec.md` exists breaks the artifact invariant in `hooks/lib_validate.py` (`_SPEC_REQUIRED_AFTER` requires `spec.md` once stage is `SPEC_REVIEW` or beyond), and any `/dynos-work:status` or `/dynos-work:resume` invocation in the window between Step 3 and Step 5 completing would observe `stage=PLANNING` with no spec on disk. The stage walk happens in Step 5 after `spec.md` is written. Log: `{timestamp} [SKIP] spec-normalization-spawn — fast_track combined planner (stage walk deferred to Step 5)`. Skip the rest of this step and proceed to Step 4.
 
 **Normal path:** Spawn the Planner subagent with instruction:
 
@@ -322,7 +322,9 @@ Hierarchical flow:
 3. Merge outputs into final `plan.md` and `execution-graph.json`.
 
 Fast-track combined flow (when `fast_track: true`):
-1. Spawn Planner (Opus) ONCE with phase `Spec + Plan` to produce `spec.md`, `plan.md`, and `execution-graph.json` together. This replaces both Step 3 (Spec Normalization) and Step 5's normal planner spawn.
+1. **Stage precondition:** the manifest is still at `SPEC_NORMALIZATION` (Step 3 deferred the walk). Do NOT advance yet.
+2. Spawn Planner (Opus) ONCE with phase `Spec + Plan` to produce `spec.md`, `plan.md`, and `execution-graph.json` together. This replaces both Step 3 (Spec Normalization) and Step 5's normal planner spawn.
+3. After the spawn returns AND `validate_task_artifacts` passes (see below), walk the stage forward through `SPEC_NORMALIZATION → SPEC_REVIEW → PLANNING` (each transition is legal per `ALLOWED_STAGE_TRANSITIONS` in `hooks/lib_core.py`). Only advance once the artifacts that justify each stage exist on disk. Log each transition. Then continue with the post-validation flow below (which advances to `PLAN_REVIEW`).
 
 Standard flow:
 1. Spawn Planner (Opus) with instruction to generate `plan.md` and `execution-graph.json`.

--- a/tests/test_eventbus_drain.py
+++ b/tests/test_eventbus_drain.py
@@ -197,3 +197,96 @@ class TestMultiTaskReceipts:
         call_dirs = [str(call.args[0]) for call in mock_receipt.call_args_list]
         assert str(task1) in call_dirs
         assert str(task2) in call_dirs
+
+
+class TestPostCompletionReceiptFidelity:
+    """Regression tests for the eventbus:295 bug where postmortem_written and
+    patterns_updated were derived from `calibration-completed` and
+    `memory-completed` summary buckets that no longer exist after the chain
+    was flattened to task-completed only. Both fields were silently False
+    even when the underlying handlers ran successfully.
+    """
+
+    def test_patterns_updated_true_when_policy_engine_succeeds(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        root = _setup(tmp_path)
+        task = tmp_path / ".dynos" / "task-1"
+        task.mkdir(parents=True)
+        _emit(root, "task-completed", {"task_id": "task-1", "task_dir": str(task)})
+
+        handlers = _make_handlers({"policy_engine": True, "improve": True,
+                                    "dashboard": True, "register": True,
+                                    "agent_generator": True,
+                                    "benchmark_scheduler": True})
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"), \
+             mock.patch("lib_receipts.receipt_post_completion") as mock_receipt:
+            from eventbus import drain
+            drain(root, max_iterations=5)
+
+        assert mock_receipt.call_count == 1
+        kwargs = mock_receipt.call_args.kwargs
+        assert kwargs["patterns_updated"] is True, \
+            "patterns_updated should be True when policy_engine handler returns ok"
+
+    def test_patterns_updated_false_when_policy_engine_fails(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        root = _setup(tmp_path)
+        task = tmp_path / ".dynos" / "task-1"
+        task.mkdir(parents=True)
+        _emit(root, "task-completed", {"task_id": "task-1", "task_dir": str(task)})
+
+        handlers = _make_handlers({"policy_engine": False, "improve": True,
+                                    "dashboard": True, "register": True,
+                                    "agent_generator": True,
+                                    "benchmark_scheduler": True})
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"), \
+             mock.patch("lib_receipts.receipt_post_completion") as mock_receipt:
+            from eventbus import drain
+            drain(root, max_iterations=5)
+
+        kwargs = mock_receipt.call_args.kwargs
+        assert kwargs["patterns_updated"] is False, \
+            "patterns_updated should be False when policy_engine returns failure"
+
+    def test_postmortem_written_reflects_disk_state_per_task(self, tmp_path: Path, monkeypatch):
+        """postmortem_written must check the persistent project dir per task,
+        since the postmortem now runs in the audit skill (not as an eventbus
+        handler) and writes per-task .json under postmortems/."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
+        root = _setup(tmp_path)
+
+        task_with_pm = tmp_path / ".dynos" / "task-WITH"
+        task_without_pm = tmp_path / ".dynos" / "task-WITHOUT"
+        task_with_pm.mkdir(parents=True)
+        task_without_pm.mkdir(parents=True)
+
+        # Seed only one of the two tasks' postmortems on disk in the
+        # persistent project dir for `root`.
+        from lib_core import _persistent_project_dir
+        pm_dir = _persistent_project_dir(root) / "postmortems"
+        pm_dir.mkdir(parents=True, exist_ok=True)
+        (pm_dir / "task-WITH.json").write_text("{}")
+
+        _emit(root, "task-completed", {"task_id": "task-WITH", "task_dir": str(task_with_pm)})
+        _emit(root, "task-completed", {"task_id": "task-WITHOUT", "task_dir": str(task_without_pm)})
+
+        handlers = _make_handlers({})
+        with mock.patch("eventbus.HANDLERS", handlers), \
+             mock.patch("lib_core.is_learning_enabled", return_value=True), \
+             mock.patch("eventbus.log_event"), \
+             mock.patch("lib_receipts.receipt_post_completion") as mock_receipt:
+            from eventbus import drain
+            drain(root, max_iterations=5)
+
+        per_task = {
+            str(call.args[0]): call.kwargs["postmortem_written"]
+            for call in mock_receipt.call_args_list
+        }
+        assert per_task[str(task_with_pm)] is True, \
+            "task with on-disk postmortem must report postmortem_written=True"
+        assert per_task[str(task_without_pm)] is False, \
+            "task without on-disk postmortem must report postmortem_written=False"

--- a/tests/test_registry_corruption.py
+++ b/tests/test_registry_corruption.py
@@ -1,0 +1,128 @@
+"""Regression tests for registry corruption handling.
+
+Covers the data-loss bug where load_registry() returned an empty in-memory
+registry on checksum mismatch and the next register_project() call wrote
+that empty state back to disk, wiping every previously-registered project.
+
+The fix quarantines the corrupt file (renames to .corrupt-{ts}) before
+returning the empty registry, so the original data is preserved on disk
+and recoverable.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+
+def _seed_corrupt_registry(home: Path, projects: list[str]) -> Path:
+    """Write a registry with a deliberately wrong checksum."""
+    home.mkdir(parents=True, exist_ok=True)
+    reg = {
+        "version": 7,
+        "projects": [
+            {"path": p, "registered_at": "2026-04-01T00:00:00Z",
+             "last_active_at": "2026-04-01T00:00:00Z", "status": "active"}
+            for p in projects
+        ],
+        "checksum": "0" * 64,
+    }
+    path = home / "registry.json"
+    path.write_text(json.dumps(reg))
+    return path
+
+
+class TestQuarantineOnChecksumMismatch:
+    def test_load_registry_quarantines_corrupt_file(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        registry_path = _seed_corrupt_registry(
+            tmp_path, ["/old/project-a", "/old/project-b"]
+        )
+
+        from registry import load_registry
+        with mock.patch("registry.log_global"):
+            reg = load_registry()
+
+        assert reg["projects"] == [], "should return empty registry"
+        assert not registry_path.exists(), "original corrupt file should be moved"
+        quarantines = list(tmp_path.glob("registry.json.corrupt-*"))
+        assert len(quarantines) == 1, f"expected 1 quarantine file, got {quarantines}"
+        preserved = json.loads(quarantines[0].read_text())
+        preserved_paths = {p["path"] for p in preserved.get("projects", [])}
+        assert preserved_paths == {"/old/project-a", "/old/project-b"}, \
+            "quarantine must preserve the original project list"
+
+    def test_register_after_corruption_does_not_wipe_original_data(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The data-loss regression: register after a checksum mismatch must
+        NOT silently discard the original project list. The original data
+        must be recoverable from the quarantine file even though the live
+        registry is now a single-entry blob.
+        """
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        _seed_corrupt_registry(
+            tmp_path, ["/old/project-a", "/old/project-b", "/old/project-c"]
+        )
+        new_project = tmp_path / "new-project"
+        new_project.mkdir()
+
+        from registry import register_project
+        with mock.patch("registry.log_global"):
+            register_project(new_project)
+
+        live = json.loads((tmp_path / "registry.json").read_text())
+        live_paths = {p["path"] for p in live["projects"]}
+        assert live_paths == {str(new_project)}, \
+            "live registry should contain only the freshly registered project"
+
+        quarantines = sorted(tmp_path.glob("registry.json.corrupt-*"))
+        assert len(quarantines) == 1, "exactly one quarantine file expected"
+        preserved = json.loads(quarantines[0].read_text())
+        preserved_paths = {p["path"] for p in preserved["projects"]}
+        assert preserved_paths == {
+            "/old/project-a", "/old/project-b", "/old/project-c"
+        }, "quarantine must hold all 3 original projects (data loss otherwise)"
+
+    def test_clean_registry_is_unmodified(self, tmp_path: Path, monkeypatch):
+        """A registry with a valid checksum must not be quarantined."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        from registry import _compute_checksum
+        reg = {
+            "version": 1,
+            "projects": [{"path": "/x", "status": "active",
+                         "registered_at": "2026-04-01T00:00:00Z",
+                         "last_active_at": "2026-04-01T00:00:00Z"}],
+        }
+        reg["checksum"] = _compute_checksum(reg)
+        (tmp_path / "registry.json").write_text(json.dumps(reg))
+
+        from registry import load_registry
+        loaded = load_registry()
+        assert loaded["projects"] == reg["projects"]
+        assert list(tmp_path.glob("registry.json.corrupt-*")) == [], \
+            "clean registry must not produce a quarantine file"
+
+    def test_quarantine_failure_raises_rather_than_wipes(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """If the corrupt file cannot be moved (e.g. permission error), refuse
+        to operate rather than silently allowing the next mutation to overwrite
+        it. This is the safer failure mode."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path))
+        _seed_corrupt_registry(tmp_path, ["/preserved"])
+
+        from registry import RegistryCorruptError, load_registry
+        with mock.patch("pathlib.Path.rename", side_effect=OSError("EACCES")), \
+             mock.patch("registry.log_global"):
+            with pytest.raises(RegistryCorruptError):
+                load_registry()
+        assert (tmp_path / "registry.json").exists(), \
+            "corrupt file must remain on disk if quarantine fails"


### PR DESCRIPTION
## Summary
Three independent fixes from an investigation report. Each is a separate commit so they can be reviewed (or reverted) independently.

**1. Registry corruption no longer wipes data** (`eb76306`)
`load_registry()` returned an empty in-memory registry on checksum mismatch, and the next `register_project()` call (auto-fired by every dynos invocation in any project) wrote that empty state back to disk — wiping every previously registered project. Now: rename the corrupt file to `registry.json.corrupt-{ts}` before returning empty, so the original data is preserved on disk and recoverable. If the rename itself fails, raise the new `RegistryCorruptError` instead of overwriting.

**2. Fast-track stage walk deferred until artifacts exist** (`9c4e75d`)
Step 3's fast-track branch advanced the manifest stage to PLANNING before `spec.md` existed, breaking the artifact invariant in `lib_validate.py` (`_SPEC_REQUIRED_AFTER` includes PLANNING). Any `/dynos-work:status` or `/dynos-work:resume` running in the window between Step 3 and Step 5 completing would see `stage=PLANNING` with no spec on disk. Now: stage stays at `SPEC_NORMALIZATION` through Steps 3-4 (skipped) and only walks forward in Step 5 after the combined planner spawn writes `spec.md` and validation passes.

**3. Post-completion receipt fields derive from current pipeline** (`cfc4bcb`)
Receipt logic at `eventbus.py:295` read `postmortem_written` and `patterns_updated` from `calibration-completed` and `memory-completed` summary buckets that haven't existed since the chain was flattened. Both fields were silently `False` on every task. Now: `patterns_updated` derives from `policy_engine:ok` (the renamed handler), and `postmortem_written` checks the persistent project dir for `postmortems/{task_id}.json` per task (since postmortem now runs in the audit skill, not as an eventbus handler).

## Test plan
- [x] 7 new tests added (`tests/test_registry_corruption.py` + 3 in `test_eventbus_drain.py::TestPostCompletionReceiptFidelity`). Each test would have failed before its corresponding fix.
- [x] Full suite passes: 886/886 (was 879).
- [ ] Reviewer: confirm the start/SKILL.md change covers all places that read `manifest.stage` mid-flow (status skill, resume skill, daemon health checks). The change is documentation-only since the orchestrator implements the skill, but worth a sanity check that no Python code expects `stage=PLANNING` to imply spec.md exists at the moment of read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)