### PR TITLE
global dashboard: live updates via regen-on-fetch + JS polling

### DIFF
--- a/telemetry/global_dashboard.py
+++ b/telemetry/global_dashboard.py
@@ -8,6 +8,8 @@ import json
 import os
 import signal
 import sys
+import threading
+import time
 from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -2011,6 +2013,61 @@ GLOBAL_HTML_TEMPLATE = """<!DOCTYPE html>
       document.body.classList.add('loaded');
     }})();
   </script>
+  <script>
+    /* Live-update poller: refetch data JSON every 5s and re-render data-bearing
+       sections in place. Plain ES2017; no libraries. Graceful degradation: if
+       JS is disabled or fetch fails, the server-rendered snapshot remains.
+       Wrapped in try/catch so a render error keeps the prior good DOM. */
+    (function () {{
+      const POLL_INTERVAL_MS = 5000;
+      const ENDPOINT = '/global-dashboard-data.json';
+
+      function fmtCount(v) {{ return (v == null) ? '—' : String(v); }}
+
+      function renderUpdated(data) {{
+        const el = document.getElementById('updated');
+        if (el && data && data.generated_at) {{
+          el.textContent = data.generated_at;
+        }}
+      }}
+
+      function renderStats(data) {{
+        const el = document.getElementById('stats');
+        if (!el || !data) return;
+        const agg = data.aggregates || {{}};
+        const parts = [
+          'tasks: ' + fmtCount(agg.total_tasks),
+          'avg_quality: ' + fmtCount(agg.avg_quality),
+          'learned routes: ' + fmtCount(agg.total_learned_routes),
+          'active: ' + fmtCount(agg.active_count),
+          'benchmarks: ' + fmtCount(agg.total_benchmark_runs),
+          'findings: ' + fmtCount(agg.total_findings),
+          'cost USD: ' + fmtCount(agg.total_autofix_cost_usd),
+        ];
+        el.textContent = parts.join('  •  ');
+      }}
+
+      async function refresh() {{
+        try {{
+          const r = await fetch(ENDPOINT, {{ cache: 'no-store' }});
+          if (!r.ok) return;
+          const data = await r.json();
+          renderUpdated(data);
+          renderStats(data);
+        }} catch (err) {{
+          /* Network blip or render error — keep the existing DOM. */
+          if (window && window.console) console.warn('dashboard refresh failed', err);
+        }}
+      }}
+
+      /* Kick off polling once the DOM is ready. */
+      if (document.readyState === 'loading') {{
+        document.addEventListener('DOMContentLoaded', () => setInterval(refresh, POLL_INTERVAL_MS));
+      }} else {{
+        setInterval(refresh, POLL_INTERVAL_MS);
+      }}
+    }})();
+  </script>
 </body>
 </html>
 """
@@ -2066,6 +2123,60 @@ def write_global_dashboard(payload: dict) -> dict:
 
 _ALLOWED_SERVE_FILES = {"global-dashboard.html", "global-dashboard-data.json"}
 
+# --- Live-update throttle ---
+# The dashboard regenerates its payload on each fetch of the data JSON,
+# capped at one ATTEMPT per _REGEN_TTL_SECONDS. The lock makes it safe
+# under ThreadingHTTPServer (concurrent requests). The mutable list
+# wrapper lets the inner handler update the timestamp without a `global`
+# declaration.
+#
+# Two timestamps for two purposes:
+# - _LAST_REGEN_ATTEMPT_AT bounds CPU. Advanced UNCONDITIONALLY whether
+#   the regen succeeded or failed. This prevents a DoS amplifier where a
+#   persistent registry-walk failure would otherwise let every concurrent
+#   request pay the full failing cost, since the prior "don't advance on
+#   failure" policy effectively disabled the throttle in exactly the
+#   failure mode the throttle is meant to defend against.
+# - _LAST_SUCCESS_AT records when a fresh artifact was last produced.
+#   Currently informational; future code (e.g., a "stale data" warning
+#   in the served HTML) can read it.
+#
+# write_json (lib_core) is atomic (tempfile + os.rename + fsync), so a
+# concurrent reader cannot observe a torn file even mid-regen.
+_REGEN_TTL_SECONDS = 2.0
+_LAST_REGEN_ATTEMPT_AT = [0.0]
+_LAST_SUCCESS_AT = [0.0]
+_REGEN_LOCK = threading.Lock()
+_DATA_FILES = {"global-dashboard-data.json"}
+
+
+def _maybe_regen() -> None:
+    """Regenerate the global dashboard JSON+HTML if the throttle TTL has
+    elapsed since the last regen ATTEMPT. Safe to call from concurrent
+    request threads — the lock serializes the check-and-regen window.
+    Failures are swallowed (logged to stderr); the prior on-disk
+    snapshot remains served as a fallback so a transient registry read
+    failure does not break the live page. The throttle still advances
+    on failure so that DoS protection is preserved."""
+    now = time.time()
+    if (now - _LAST_REGEN_ATTEMPT_AT[0]) < _REGEN_TTL_SECONDS:
+        return
+    with _REGEN_LOCK:
+        # Re-check inside the lock — another thread may have just regen'd.
+        now = time.time()
+        if (now - _LAST_REGEN_ATTEMPT_AT[0]) < _REGEN_TTL_SECONDS:
+            return
+        # Advance the attempt timestamp BEFORE the work so subsequent
+        # concurrent requests see the throttle even if this attempt
+        # raises midway. This is the load-bearing DoS protection.
+        _LAST_REGEN_ATTEMPT_AT[0] = now
+        try:
+            payload = build_global_payload()
+            write_global_dashboard(payload)
+            _LAST_SUCCESS_AT[0] = now
+        except Exception as exc:
+            print(f"[dashboard] regen failed: {exc}", file=sys.stderr)
+
 
 def _make_restricted_handler(serve_dir: str) -> type:
     """Create a handler class bound to a specific directory."""
@@ -2079,6 +2190,11 @@ def _make_restricted_handler(serve_dir: str) -> type:
             if path not in _ALLOWED_SERVE_FILES:
                 self.send_error(HTTPStatus.FORBIDDEN, "Access denied")
                 return
+            # Throttled regen on data-JSON fetch so the polling page sees fresh
+            # data without restarting the server. Regen for HTML too so the
+            # initial load also reflects current state.
+            if path in _DATA_FILES or path == "global-dashboard.html":
+                _maybe_regen()
             super().do_GET()
 
         def log_message(self, format: str, *args: object) -> None:

--- a/tests/test_global_dashboard_live.py
+++ b/tests/test_global_dashboard_live.py
@@ -1,0 +1,239 @@
+"""Tests for the live (self-updating) global dashboard.
+
+Covers:
+- Throttle correctness: rapid-fire calls coalesce to one regen; calls
+  spaced past the TTL produce fresh regenerations.
+- Allowlist still enforced (sanity, regression guard).
+- HTML output contains the polling script with the expected endpoint
+  and interval.
+- validate_generated_html still passes against the new HTML output
+  (no required element id was inadvertently removed by the script
+  injection).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "telemetry"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle_state():
+    """Reset throttle timestamps before each test so tests don't bleed state."""
+    import global_dashboard
+    global_dashboard._LAST_REGEN_ATTEMPT_AT[0] = 0.0
+    global_dashboard._LAST_SUCCESS_AT[0] = 0.0
+    yield
+    global_dashboard._LAST_REGEN_ATTEMPT_AT[0] = 0.0
+    global_dashboard._LAST_SUCCESS_AT[0] = 0.0
+
+
+class TestRegenThrottle:
+    def test_first_call_regens(self):
+        """The very first _maybe_regen call should always regen
+        (last=0.0, TTL has effectively elapsed)."""
+        import global_dashboard
+        with mock.patch("global_dashboard.build_global_payload") as mock_build, \
+             mock.patch("global_dashboard.write_global_dashboard") as mock_write:
+            mock_build.return_value = {"generated_at": "T1"}
+            global_dashboard._maybe_regen()
+        assert mock_build.call_count == 1
+        assert mock_write.call_count == 1
+        assert global_dashboard._LAST_REGEN_ATTEMPT_AT[0] > 0
+        assert global_dashboard._LAST_SUCCESS_AT[0] > 0
+
+    def test_back_to_back_calls_coalesce(self):
+        """Two calls within the throttle TTL should produce exactly one regen."""
+        import global_dashboard
+        with mock.patch("global_dashboard.build_global_payload") as mock_build, \
+             mock.patch("global_dashboard.write_global_dashboard") as mock_write:
+            mock_build.return_value = {"generated_at": "T1"}
+            global_dashboard._maybe_regen()
+            global_dashboard._maybe_regen()
+            global_dashboard._maybe_regen()
+        assert mock_build.call_count == 1, (
+            "throttle should coalesce 3 rapid calls into 1 regen"
+        )
+
+    def test_calls_past_ttl_regen_again(self, monkeypatch):
+        """Two calls separated by more than the TTL should each regen."""
+        import global_dashboard
+        # Shorten TTL for the test so we don't actually sleep 2 seconds.
+        monkeypatch.setattr(global_dashboard, "_REGEN_TTL_SECONDS", 0.1)
+        with mock.patch("global_dashboard.build_global_payload") as mock_build, \
+             mock.patch("global_dashboard.write_global_dashboard") as mock_write:
+            mock_build.return_value = {"generated_at": "T1"}
+            global_dashboard._maybe_regen()
+            time.sleep(0.15)  # exceed TTL
+            global_dashboard._maybe_regen()
+        assert mock_build.call_count == 2, (
+            "two calls past the TTL should each trigger a regen"
+        )
+
+    def test_failed_regen_advances_attempt_throttle_for_dos_protection(self):
+        """A persistent registry walk failure must not let every concurrent
+        request pay the full failing cost. The attempt timestamp advances
+        unconditionally so the throttle bounds CPU under failure too. The
+        success timestamp stays at zero so consumers can detect staleness.
+        """
+        import global_dashboard
+        with mock.patch("global_dashboard.build_global_payload") as mock_build, \
+             mock.patch("global_dashboard.write_global_dashboard"):
+            mock_build.side_effect = RuntimeError("registry corrupt")
+            global_dashboard._maybe_regen()
+            global_dashboard._maybe_regen()  # second call — should be throttled
+            global_dashboard._maybe_regen()  # third call — should be throttled
+        assert mock_build.call_count == 1, (
+            f"persistent failure within TTL must not amplify; got {mock_build.call_count} build calls"
+        )
+        assert global_dashboard._LAST_REGEN_ATTEMPT_AT[0] > 0, (
+            "attempt throttle must advance even on failure (DoS protection)"
+        )
+        assert global_dashboard._LAST_SUCCESS_AT[0] == 0.0, (
+            "success timestamp must stay at zero — no successful regen happened"
+        )
+
+    def test_throttle_thread_safe(self):
+        """ThreadingHTTPServer can dispatch concurrent requests. The lock must
+        prevent duplicate regens even when multiple threads enter at once.
+
+        Strategy: synchronize thread starts with a Barrier so they all race
+        into _maybe_regen at roughly the same instant. The first thread to
+        acquire the lock builds; the rest see _LAST_REGEN_AT was just
+        advanced and exit early. Result: exactly one build call.
+        """
+        import global_dashboard
+        import threading
+        N = 5
+        call_counter = {"n": 0}
+        counter_lock = threading.Lock()
+
+        def slow_build():
+            # Brief work inside the lock so the other threads have time to
+            # arrive at the lock and bounce off the re-check.
+            with counter_lock:
+                call_counter["n"] += 1
+            time.sleep(0.05)
+            return {"generated_at": "T"}
+
+        start_barrier = threading.Barrier(N)
+
+        def worker():
+            start_barrier.wait()  # synchronize starts OUTSIDE the lock
+            global_dashboard._maybe_regen()
+
+        with mock.patch("global_dashboard.build_global_payload", side_effect=slow_build), \
+             mock.patch("global_dashboard.write_global_dashboard"):
+            threads = [threading.Thread(target=worker) for _ in range(N)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+                assert not t.is_alive(), "worker thread deadlocked"
+        assert call_counter["n"] == 1, (
+            f"{N} concurrent _maybe_regen calls should produce 1 build, got {call_counter['n']}"
+        )
+
+
+class TestAllowlistRegression:
+    def test_disallowed_path_returns_403(self, tmp_path):
+        """Sanity: the new handler still rejects paths outside the allowlist."""
+        import global_dashboard
+        Handler = global_dashboard._make_restricted_handler(str(tmp_path))
+        # Build a stub that captures the call to send_error
+        captured = {}
+        class Stub(Handler):
+            def __init__(self, path):
+                self.path = path
+            def send_error(self, code, msg=None):
+                captured["code"] = code
+                captured["msg"] = msg
+            # noop so super().do_GET() does not actually run
+            def _ignore(self, *a, **k): pass
+
+        # We can't easily instantiate the real socket-based handler, so just
+        # call do_GET() with a constructed instance.
+        stub = Stub.__new__(Stub)
+        stub.path = "/etc/passwd"
+        # Use the actual do_GET defined on Handler
+        Handler.do_GET(stub)
+        assert captured.get("code") == 403, (
+            f"non-allowlisted path should return 403, got {captured}"
+        )
+
+
+class TestRenderedHtml:
+    def test_html_contains_polling_script(self):
+        """The rendered HTML must include the polling script with
+        the expected endpoint and interval — these are the contract
+        for live updating."""
+        import global_dashboard
+        # Use a minimal payload to exercise template rendering.
+        payload = {
+            "generated_at": "2026-04-18T06:00:00Z",
+            "daemon": {"running": False, "pid": None, "last_sweep_at": None, "sweep_count": 0},
+            "active_projects": [],
+            "inactive_projects": [],
+            "aggregates": {
+                "total_tasks": 0, "avg_quality": 0.0, "total_learned_routes": 0,
+                "active_count": 0, "total_benchmark_runs": 0, "total_findings": 0,
+                "total_autofix_cost_usd": 0.0, "total_learned_components": 0,
+                "total_shadow_components": 0, "total_demoted_components": 0,
+                "total_tracked_fixtures": 0, "total_coverage_gaps": 0,
+                "total_automation_queue": 0, "total_autofix_open_prs": 0,
+                "total_autofix_merged": 0, "total_autofix_suppressions": 0,
+            },
+        }
+        html = global_dashboard.GLOBAL_HTML_TEMPLATE.format(
+            **global_dashboard._template_substitutions(payload)
+        ) if hasattr(global_dashboard, "_template_substitutions") else None
+
+        # Fallback: just inspect the raw template string for the contract.
+        # The polling script lives in the template itself, so the rendered
+        # output will always contain it as long as the template has it.
+        tpl = global_dashboard.GLOBAL_HTML_TEMPLATE
+        assert "POLL_INTERVAL_MS" in tpl
+        assert "/global-dashboard-data.json" in tpl
+        assert "setInterval" in tpl
+        assert "5000" in tpl, "default poll interval should be 5000 ms"
+
+    def test_html_passes_validate_generated_html(self, tmp_path):
+        """The required element ids must remain present after the script
+        injection (regression guard against the linter at
+        hooks/lib_validate.py:validate_generated_html)."""
+        import global_dashboard
+        from lib_validate import validate_generated_html
+
+        payload = {
+            "generated_at": "2026-04-18T06:00:00Z",
+            "daemon": {"running": False, "pid": None, "last_sweep_at": None, "sweep_count": 0},
+            "active_projects": [],
+            "inactive_projects": [],
+            "aggregates": {
+                "total_tasks": 0, "avg_quality": 0.0, "total_learned_routes": 0,
+                "active_count": 0, "total_benchmark_runs": 0, "total_findings": 0,
+                "total_autofix_cost_usd": 0.0, "total_learned_components": 0,
+                "total_shadow_components": 0, "total_demoted_components": 0,
+                "total_tracked_fixtures": 0, "total_coverage_gaps": 0,
+                "total_automation_queue": 0, "total_autofix_open_prs": 0,
+                "total_autofix_merged": 0, "total_autofix_suppressions": 0,
+            },
+        }
+        # Write a real HTML file via the public path. write_global_dashboard
+        # imports global_home/ensure_global_dirs from `registry` lazily, so
+        # patch them at their source.
+        from pathlib import Path as _P
+        with mock.patch("registry.global_home", return_value=tmp_path), \
+             mock.patch("registry.ensure_global_dirs"):
+            result = global_dashboard.write_global_dashboard(payload)
+        html_path = _P(result["html_path"])
+        assert html_path.exists()
+        errors = validate_generated_html(html_path)
+        assert errors == [], f"validate_generated_html reported errors: {errors}"


### PR DESCRIPTION
## Summary
The cross-repo global dashboard (`dynos dashboard`) was a frozen snapshot — `build_global_payload()` ran once at server startup and the same HTML/JSON was served forever. To see fresh data you had to `dynos dashboard restart`.

This makes it self-updating with no restart and no client refresh:

1. **Server side**: `_make_restricted_handler`'s `do_GET` calls a new `_maybe_regen()` helper before serving `/global-dashboard.html` or `/global-dashboard-data.json`. The helper regenerates the payload + writes new HTML/JSON, throttled to one attempt per `_REGEN_TTL_SECONDS = 2.0` seconds via double-check-locking under `ThreadingHTTPServer`.

2. **Client side**: the served HTML appends a polling `<script>` block that calls `fetch('/global-dashboard-data.json', {cache: 'no-store'})` every 5 seconds and updates `#updated` and `#stats` in place. Plain ES2017, no libraries.

3. **Graceful degradation**: JS-disabled clients still see the server-rendered snapshot at page load — the script is purely additive.

## Behavior verified end-to-end
```
fetch1 generated_at=2026-04-18T06:24:13Z  (at t+1.515s)
fetch2 generated_at=2026-04-18T06:24:13Z  (at t+1.517s)   ← cache hit (2ms gap)
fetch3 generated_at=2026-04-18T06:24:17Z  (at t+5.516s)   ← regen (after 2.5s wait past TTL)
```

## Security review caught two real issues during the audit (both repaired)
- **DoS amplifier** (sec-1): the original design didn't advance `_LAST_REGEN_AT` on failure, so a persistent registry-walk failure would let every concurrent request pay the full failing cost. Fix: split into `_LAST_REGEN_ATTEMPT_AT` (advances unconditionally inside the lock, BEFORE the work — bounds CPU under failure) and `_LAST_SUCCESS_AT` (informational, advances on success only).
- **Torn JSON race** (sec-2): investigated; mitigated by infrastructure — `write_json` (in `lib_core`) is already atomic (tempfile + `os.rename` + `fsync`). Documented inline.

## Test plan
- [x] 8 new tests in `tests/test_global_dashboard_live.py`:
  - First call regens; back-to-back coalesces; past-TTL re-regens; failure advances attempt throttle (DoS protection); thread-safe under 5 concurrent threads.
  - Allowlist regression: non-allowlisted path still returns 403.
  - HTML contains polling script with expected interval and endpoint.
  - `validate_generated_html` still passes after script injection.
- [x] Full suite: 958/958 (was 950 + 8 new).
- [x] Manual end-to-end: started `dynos dashboard serve --port 8767`, fetched JSON twice within 2ms (same `generated_at`), then once after 2.5s (fresh `generated_at`).

## How to verify locally
```bash
git checkout feat-live-dashboard
bin/dynos dashboard restart
# Open http://127.0.0.1:8766/global-dashboard.html — leave it open
# Complete a task in any registered project (or just touch ~/.dynos/registry.json's mtime)
# The page should reflect updated data within ~5 seconds without you reloading
```

## Worktree note
This work was done in a separate git worktree at `../dynos-work-live-dashboard` per user request. Worktree can be removed after merge with `git worktree remove ../dynos-work-live-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)