### PR TITLE
fix(worktree): fold worktree slug to main + safe migrate CLI

### DIFF
--- a/bin/dynos
+++ b/bin/dynos
@@ -261,6 +261,7 @@ print('no')
   ctl)        exec python3 "${HOOKS_DIR}/ctl.py" "$@" ;;
   postmortem) exec python3 "${HOOKS_DIR}/postmortem.py" "$@" ;;
   calibration|evolve) exec python3 "${MEMORY_DIR}/agent_generator.py" "$@" ;;
+  worktree)   exec python3 "${HOOKS_DIR}/worktree.py" "$@" ;;
   memory)     exec python3 "${HOOKS_DIR}/patterns.py" "$@" ;;
   trajectory) exec python3 "${HOOKS_DIR}/trajectory.py" "$@" ;;
   bench)      exec python3 "${HOOKS_DIR}/bench.py" "$@" ;;

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import fcntl
+import functools
 import json
 import os
+import subprocess
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -166,16 +168,78 @@ def require(path: Path) -> str:
 # Persistent project directory
 # ---------------------------------------------------------------------------
 
+@functools.lru_cache(maxsize=256)
+def _resolve_git_toplevel(root_str: str) -> Optional[str]:
+    """Return the absolute path of the main working tree if `root_str` is
+    inside a git repository — otherwise None.
+
+    For git worktrees, `git rev-parse --show-toplevel` returns the WORKTREE's
+    toplevel (not the main repo). That's the wrong target for us; we want all
+    worktrees to fold back to ONE canonical slug. We get that by asking for
+    `--git-common-dir` (the `.git/` directory shared across worktrees) and
+    taking its parent: the path that directory lives in is the main working
+    tree.
+
+    Cached per-process on the input string so repeated _persistent_project_dir
+    calls don't re-shell-out. The cache key is the raw input path (not the
+    resolved toplevel) because different input paths can legitimately map to
+    different toplevels if the process crosses repo boundaries.
+
+    Returns None on any of: git not installed, path not inside a repo,
+    git command returns non-zero, output is empty. Callers fall back to the
+    legacy slug-from-absolute-path behavior.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", root_str, "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    common_dir = result.stdout.strip()
+    if not common_dir:
+        return None
+    # --git-common-dir returns a path that may be relative to root_str.
+    # Resolve it to absolute, then take its parent (the main working tree).
+    common_path = Path(common_dir)
+    if not common_path.is_absolute():
+        common_path = (Path(root_str) / common_path).resolve()
+    else:
+        common_path = common_path.resolve()
+    # Bare repos (no working tree) return `.git` or the repo root itself as
+    # --git-common-dir. If we're in a bare repo there's no "main working
+    # tree" to canonicalize to; fall back.
+    if common_path.name != ".git":
+        return None
+    main_worktree = common_path.parent
+    return str(main_worktree)
+
+
 def _persistent_project_dir(root: Path) -> Path:
     """Returns ~/.dynos/projects/{slug}/ for persistent project state.
 
     Pure path resolution — NO side effects. Does NOT create directories.
     Callers that need the directory to exist should call
     ensure_persistent_project_dir() instead.
+
+    Slug derivation:
+    - If `root` is inside a git repository, the slug is derived from the MAIN
+      working tree (via `git rev-parse --git-common-dir`). All git worktrees
+      for the same repo therefore share one persistent dir with main —
+      learning state doesn't fragment per-branch.
+    - Otherwise (not a git repo, git not installed, bare repo) the slug is
+      derived from `str(root.resolve())` as it was historically.
     """
-    resolved = str(root.resolve())
     dynos_home = Path(os.environ.get("DYNOS_HOME", str(Path.home() / ".dynos")))
-    slug = resolved.strip("/").replace("/", "-")
+    resolved_str = str(root.resolve())
+    canonical = _resolve_git_toplevel(resolved_str)
+    base = canonical if canonical is not None else resolved_str
+    slug = base.strip("/").replace("/", "-")
     return dynos_home / "projects" / slug
 
 

--- a/hooks/worktree.py
+++ b/hooks/worktree.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""dynos worktree — migrate orphaned worktree persistent state into main.
+
+Git worktrees used to get their own ~/.dynos/projects/{slug}/ directory
+because _persistent_project_dir derived the slug from the absolute path of
+the checkout. After the slug-normalization fix, worktrees fold back to the
+main repo's slug — but existing split state is orphaned. This CLI
+consolidates that state into main.
+
+Subcommands:
+  migrate <source-slug-path> [--execute]
+      Move postmortems, prevention-rules, and learned-agents data from a
+      worktree-slug persistent dir into the corresponding main-slug dir.
+      Dry-run by default. --execute performs the migration.
+
+  list-orphans
+      Scan ~/.dynos/projects/* for dirs whose original path no longer
+      exists OR whose git-resolved slug differs from the current dir name.
+      Print a report. Non-destructive.
+
+Usage:
+  dynos worktree migrate /Users/me/.dynos/projects/my-project-worktree
+  dynos worktree migrate /Users/me/.dynos/projects/my-project-worktree --execute
+  dynos worktree list-orphans
+"""
+from __future__ import annotations
+import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent))
+
+import argparse
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from lib_core import (
+    _persistent_project_dir,
+    _resolve_git_toplevel,
+    load_json,
+    now_iso,
+    write_json,
+)
+
+
+def _home() -> Path:
+    import os
+    return Path(__import__("os").environ.get("DYNOS_HOME", str(Path.home() / ".dynos")))
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _slugify(p: str) -> str:
+    return p.strip("/").replace("/", "-")
+
+
+def _read_global_registry() -> dict[str, Any]:
+    """Load the global registry. Returns {"projects": []} on any error."""
+    reg_path = _home() / "registry.json"
+    if not reg_path.exists():
+        return {"projects": []}
+    try:
+        return load_json(reg_path)
+    except (json.JSONDecodeError, OSError):
+        return {"projects": []}
+
+
+def _original_path_for_slug(slug: str) -> Path | None:
+    """Find the original checkout path for a persistent-dir slug.
+
+    Resolution is ONLY via the global registry (`~/.dynos/registry.json`).
+    Previously a "naive reverse" fallback replaced `-` with `/` and checked
+    existence. That was unsafe: an attacker-crafted slug like `etc-passwd`
+    would resolve to `/etc/passwd`, and the CLI would happily feed that path
+    to subprocesses (patterns.py, registry.py unregister). Removed the
+    fallback entirely. Unregistered projects are not migratable by slug;
+    callers must register first or point at the source dir directly.
+    """
+    reg = _read_global_registry()
+    for entry in reg.get("projects", []):
+        p = entry.get("path")
+        if not isinstance(p, str):
+            continue
+        if _slugify(str(Path(p).resolve())) == slug:
+            return Path(p)
+    return None
+
+
+def _assert_source_contained(source: Path) -> None:
+    """Reject source paths that resolve outside `~/.dynos/projects/`.
+
+    Defense against a crafted symlink or typo that would let `--execute`
+    `rm -rf` arbitrary directories. Also rejects symlinked source paths
+    (we don't want to follow the link and operate on the target).
+    """
+    if source.is_symlink():
+        raise ValueError(f"source is a symlink; refuse to migrate: {source}")
+    projects_root = (_home() / "projects").resolve()
+    source_resolved = source.resolve()
+    try:
+        source_resolved.relative_to(projects_root)
+    except ValueError:
+        raise ValueError(
+            f"source must live under {projects_root}, got {source_resolved}"
+        )
+    # Also reject if source is projects_root itself or shallower
+    if source_resolved == projects_root:
+        raise ValueError("source must not be the projects root itself")
+
+
+def _resolve_main_slug_for_source(source_dir: Path) -> str | None:
+    """Given a persistent dir like ~/.dynos/projects/foo-bar-baz, find which
+    ORIGINAL checkout path it represents (via the global registry), then ask
+    git for that checkout's main-worktree path. Return the main slug, or None
+    if we can't resolve.
+    """
+    slug = source_dir.name
+    original = _original_path_for_slug(slug)
+    if original is None or not original.exists():
+        return None
+    resolved = _resolve_git_toplevel(str(original))
+    if resolved is None:
+        return None
+    return _slugify(resolved)
+
+
+def _plan_migration(source: Path, target: Path) -> dict[str, Any]:
+    """Compute what a migration would do — called by both dry-run and --execute."""
+    plan: dict[str, Any] = {
+        "source": str(source),
+        "target": str(target),
+        "postmortems_to_copy": [],
+        "prevention_rules_new": [],
+        "learned_agents_new": [],
+        "benchmarks_new": [],
+        "not_migrated": [],
+        "warnings": [],
+    }
+
+    # Postmortems
+    src_pm = source / "postmortems"
+    tgt_pm = target / "postmortems"
+    if src_pm.is_dir():
+        for pm_file in sorted(src_pm.glob("*.json")):
+            tgt_file = tgt_pm / pm_file.name
+            if tgt_file.exists():
+                plan["warnings"].append(f"postmortem {pm_file.name} already exists in target; skipping")
+            else:
+                plan["postmortems_to_copy"].append(pm_file.name)
+        for pm_file in sorted(src_pm.glob("*.md")):
+            tgt_file = tgt_pm / pm_file.name
+            if tgt_file.exists():
+                continue
+            plan["postmortems_to_copy"].append(pm_file.name)
+
+    # Prevention rules — dedup on (source_task, source_finding, rule)
+    src_rules_path = source / "prevention-rules.json"
+    tgt_rules_path = target / "prevention-rules.json"
+    if src_rules_path.exists():
+        src_data = load_json(src_rules_path)
+        tgt_data: dict[str, Any] = {}
+        if tgt_rules_path.exists():
+            try:
+                tgt_data = load_json(tgt_rules_path)
+            except (json.JSONDecodeError, OSError):
+                tgt_data = {}
+        seen = {
+            (r.get("source_task"), r.get("source_finding"), r.get("rule"))
+            for r in tgt_data.get("rules", [])
+        }
+        for r in src_data.get("rules", []):
+            k = (r.get("source_task"), r.get("source_finding"), r.get("rule"))
+            if k not in seen:
+                plan["prevention_rules_new"].append(r.get("rule", "?"))
+
+    # Learned agents — empty in the observed case; note path rewriting requirement
+    src_reg = source / "learned-agents" / "registry.json"
+    if src_reg.exists():
+        try:
+            src_reg_data = load_json(src_reg)
+        except (json.JSONDecodeError, OSError):
+            src_reg_data = {}
+        agents = src_reg_data.get("agents", [])
+        if agents:
+            for a in agents:
+                plan["learned_agents_new"].append(a.get("agent_name", "?"))
+            plan["warnings"].append(
+                "learned-agents present in source — paths inside registry.json will be rewritten "
+                "from the source slug to the target slug"
+            )
+
+    # Benchmarks history — dedup on run_id
+    src_hist = source / "benchmarks" / "history.json"
+    if src_hist.exists():
+        try:
+            src_hist_data = load_json(src_hist)
+        except (json.JSONDecodeError, OSError):
+            src_hist_data = {}
+        tgt_hist_path = target / "benchmarks" / "history.json"
+        tgt_hist_data: dict = {}
+        if tgt_hist_path.exists():
+            try:
+                tgt_hist_data = load_json(tgt_hist_path)
+            except (json.JSONDecodeError, OSError):
+                tgt_hist_data = {}
+        seen_runs = {r.get("run_id") for r in tgt_hist_data.get("runs", []) if isinstance(r, dict)}
+        for r in src_hist_data.get("runs", []):
+            if isinstance(r, dict) and r.get("run_id") not in seen_runs:
+                plan["benchmarks_new"].append(r.get("run_id", "?"))
+
+    # Explicitly not migrated
+    for skip_name in ("policy.json", "route-policy.json", "skip-policy.json",
+                      "model-policy.json", "effectiveness-scores.json",
+                      "project_rules.md"):
+        if (source / skip_name).exists():
+            plan["not_migrated"].append(skip_name)
+
+    return plan
+
+
+def _execute_migration(source: Path, target: Path, main_root: Path) -> dict[str, Any]:
+    """Actually perform the migration. Backs up both dirs first.
+
+    Backups and copies use symlinks=True so planted symlinks inside the
+    source dir are preserved AS symlinks (not followed). Migration then
+    skips symlinked files explicitly to avoid ingesting arbitrary content
+    into prevention-rules / postmortems / registry.
+    """
+    # Backup (preserve symlinks; do not follow them into the filesystem)
+    ts = _timestamp()
+    source_bak = source.with_name(source.name + f".bak-{ts}")
+    target_bak = target.with_name(target.name + f".bak-{ts}")
+    shutil.copytree(source, source_bak, symlinks=True)
+    if target.exists():
+        shutil.copytree(target, target_bak, symlinks=True)
+    target.mkdir(parents=True, exist_ok=True)
+
+    applied: dict[str, Any] = {
+        "backups": {"source": str(source_bak), "target": str(target_bak)},
+        "postmortems_copied": 0,
+        "prevention_rules_added": 0,
+        "learned_agents_added": 0,
+        "benchmarks_added": 0,
+    }
+
+    # Postmortems — skip symlinks explicitly; we don't want to ingest
+    # arbitrary file content into the target's postmortem dir.
+    src_pm = source / "postmortems"
+    tgt_pm = target / "postmortems"
+    if src_pm.is_dir() and not src_pm.is_symlink():
+        tgt_pm.mkdir(parents=True, exist_ok=True)
+        for pm_file in sorted(src_pm.iterdir()):
+            if pm_file.is_symlink():
+                applied.setdefault("warnings", []).append(
+                    f"skipped symlinked source: {pm_file.name}"
+                )
+                continue
+            tgt_file = tgt_pm / pm_file.name
+            if pm_file.is_file() and not tgt_file.exists():
+                shutil.copy2(pm_file, tgt_file, follow_symlinks=False)
+                applied["postmortems_copied"] += 1
+
+    # Prevention rules JSON-merge (refuse symlinked source)
+    src_rules = source / "prevention-rules.json"
+    tgt_rules = target / "prevention-rules.json"
+    if src_rules.exists() and not src_rules.is_symlink():
+        src_data = load_json(src_rules)
+        tgt_data: dict[str, Any] = {"rules": []}
+        if tgt_rules.exists():
+            try:
+                tgt_data = load_json(tgt_rules)
+            except (json.JSONDecodeError, OSError):
+                tgt_data = {"rules": []}
+        seen = {
+            (r.get("source_task"), r.get("source_finding"), r.get("rule"))
+            for r in tgt_data.get("rules", [])
+        }
+        added_rules = 0
+        for r in src_data.get("rules", []):
+            k = (r.get("source_task"), r.get("source_finding"), r.get("rule"))
+            if k not in seen:
+                tgt_data.setdefault("rules", []).append(r)
+                seen.add(k)
+                added_rules += 1
+        if added_rules:
+            tgt_data["updated_at"] = now_iso()
+            write_json(tgt_rules, tgt_data)
+        applied["prevention_rules_added"] = added_rules
+
+    # Learned agents — copy .md files, merge registry.json with path rewrite.
+    # Reject symlinked dirs/files throughout.
+    src_la_dir = source / "learned-agents"
+    tgt_la_dir = target / "learned-agents"
+    if src_la_dir.is_dir() and not src_la_dir.is_symlink():
+        for subdir in ("executors", "auditors", "skills"):
+            src_sub = src_la_dir / subdir
+            if src_sub.is_dir() and not src_sub.is_symlink():
+                tgt_sub = tgt_la_dir / subdir
+                tgt_sub.mkdir(parents=True, exist_ok=True)
+                for md in src_sub.glob("*.md"):
+                    if md.is_symlink():
+                        continue
+                    tgt_md = tgt_sub / md.name
+                    if not tgt_md.exists():
+                        shutil.copy2(md, tgt_md, follow_symlinks=False)
+        # Merge registry.json with path rewrites
+        src_reg = src_la_dir / "registry.json"
+        if src_reg.exists() and not src_reg.is_symlink():
+            src_reg_data = load_json(src_reg)
+            tgt_reg_path = tgt_la_dir / "registry.json"
+            tgt_reg_data: dict[str, Any] = {"version": 1, "agents": [], "benchmarks": []}
+            if tgt_reg_path.exists():
+                try:
+                    tgt_reg_data = load_json(tgt_reg_path)
+                except (json.JSONDecodeError, OSError):
+                    pass
+            source_slug = source.name
+            target_slug = target.name
+            existing_keys = {
+                (a.get("agent_name"), a.get("role"), a.get("task_type"),
+                 a.get("item_kind", "agent"))
+                for a in tgt_reg_data.get("agents", [])
+            }
+            added_agents = 0
+            for agent in src_reg_data.get("agents", []):
+                key = (agent.get("agent_name"), agent.get("role"), agent.get("task_type"),
+                       agent.get("item_kind", "agent"))
+                if key in existing_keys:
+                    continue
+                # Rewrite embedded absolute paths
+                rewritten = dict(agent)
+                for pk in ("path", "fixture_path"):
+                    v = rewritten.get(pk)
+                    if isinstance(v, str) and source_slug in v:
+                        rewritten[pk] = v.replace(source_slug, target_slug)
+                # Repo-rooted paths (fixture_path) — rewrite if they embed the source repo's resolved path
+                tgt_reg_data.setdefault("agents", []).append(rewritten)
+                existing_keys.add(key)
+                added_agents += 1
+            if added_agents:
+                tgt_reg_data["updated_at"] = now_iso()
+                tgt_la_dir.mkdir(parents=True, exist_ok=True)
+                write_json(tgt_reg_path, tgt_reg_data)
+            applied["learned_agents_added"] = added_agents
+
+    # Benchmarks history
+    src_hist = source / "benchmarks" / "history.json"
+    if src_hist.exists() and not src_hist.is_symlink():
+        src_hist_data = load_json(src_hist)
+        tgt_hist_path = target / "benchmarks" / "history.json"
+        tgt_hist_data: dict[str, Any] = {"runs": []}
+        if tgt_hist_path.exists():
+            try:
+                tgt_hist_data = load_json(tgt_hist_path)
+            except (json.JSONDecodeError, OSError):
+                tgt_hist_data = {"runs": []}
+        seen_runs = {r.get("run_id") for r in tgt_hist_data.get("runs", []) if isinstance(r, dict)}
+        added_hist = 0
+        for r in src_hist_data.get("runs", []):
+            if isinstance(r, dict) and r.get("run_id") not in seen_runs:
+                tgt_hist_data.setdefault("runs", []).append(r)
+                seen_runs.add(r.get("run_id"))
+                added_hist += 1
+        if added_hist:
+            tgt_hist_path.parent.mkdir(parents=True, exist_ok=True)
+            write_json(tgt_hist_path, tgt_hist_data)
+        applied["benchmarks_added"] = added_hist
+
+    return applied
+
+
+def cmd_migrate(args: argparse.Namespace) -> int:
+    source_arg = Path(args.source)
+    if not source_arg.exists():
+        print(json.dumps({"ok": False, "error": f"source does not exist: {source_arg}"}))
+        return 2
+    # Containment + symlink guard MUST happen before resolve() on a symlink
+    # would otherwise follow the link and let us operate on the target.
+    try:
+        _assert_source_contained(source_arg)
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 2
+    source = source_arg.resolve()
+    if not source.is_dir():
+        print(json.dumps({"ok": False, "error": f"source is not a directory: {source}"}))
+        return 2
+
+    # Infer the main slug from the source slug
+    target_slug = _resolve_main_slug_for_source(source)
+    if target_slug is None:
+        print(json.dumps({
+            "ok": False,
+            "error": (
+                f"could not resolve source slug '{source.name}' to a main repo. "
+                "The original checkout path may be missing, or not inside a git repo."
+            )
+        }))
+        return 2
+
+    target = _home() / "projects" / target_slug
+    if target_slug == source.name:
+        print(json.dumps({
+            "ok": False,
+            "error": f"source and target resolve to the same slug ({target_slug}); nothing to migrate"
+        }))
+        return 1
+
+    plan = _plan_migration(source, target)
+
+    if not args.execute:
+        plan["dry_run"] = True
+        print(json.dumps(plan, indent=2))
+        return 0
+
+    # Execute
+    main_root = _original_path_for_slug(target_slug)
+    applied = _execute_migration(source, target, main_root or target)
+
+    # Regenerate project_rules.md on target (if main_root exists)
+    if main_root and main_root.exists():
+        patterns_py = Path(__file__).parent / "patterns.py"
+        if patterns_py.exists():
+            try:
+                subprocess.run(
+                    ["python3", str(patterns_py), "--root", str(main_root)],
+                    check=False, capture_output=True, text=True, timeout=60,
+                )
+                applied["project_rules_regenerated"] = True
+            except (subprocess.TimeoutExpired, OSError):
+                applied["project_rules_regenerated"] = False
+
+    # Unregister source from global registry (the original checkout path)
+    source_original_path = _original_path_for_slug(source.name)
+    if source_original_path is not None:
+        registry_py = Path(__file__).parent / "registry.py"
+        if registry_py.exists():
+            subprocess.run(
+                ["python3", str(registry_py), "unregister", str(source_original_path)],
+                check=False, capture_output=True, text=True, timeout=10,
+            )
+            applied["registry_unregistered"] = str(source_original_path)
+
+    # Remove source dir (backup was taken)
+    shutil.rmtree(source)
+    applied["source_removed"] = str(source)
+
+    print(json.dumps({"ok": True, "applied": applied}, indent=2))
+    return 0
+
+
+def cmd_list_orphans(args: argparse.Namespace) -> int:
+    """List persistent-dir slugs that don't match their git-resolved slug."""
+    home = _home()
+    projects_root = home / "projects"
+    if not projects_root.is_dir():
+        print(json.dumps({"orphans": [], "note": "no projects dir yet"}))
+        return 0
+
+    orphans = []
+    for slug_dir in sorted(projects_root.iterdir()):
+        if not slug_dir.is_dir():
+            continue
+        if slug_dir.name.endswith(".bak") or ".bak-" in slug_dir.name:
+            continue
+        resolved_main = _resolve_main_slug_for_source(slug_dir)
+        if resolved_main is None:
+            orphans.append({
+                "slug": slug_dir.name,
+                "reason": "original checkout path missing; cannot git-resolve",
+            })
+        elif resolved_main != slug_dir.name:
+            orphans.append({
+                "slug": slug_dir.name,
+                "resolved_main_slug": resolved_main,
+                "reason": "git-resolved slug differs — this dir is a worktree remnant",
+                "suggested_migrate_cmd": f"dynos worktree migrate {slug_dir}",
+            })
+
+    print(json.dumps({"orphans": orphans, "count": len(orphans)}, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Migrate orphaned worktree persistent state into main")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    m = sub.add_parser("migrate", help="Migrate a worktree-slug persistent dir into main")
+    m.add_argument("source", help="Path to the worktree's persistent dir (e.g. ~/.dynos/projects/foo-bar)")
+    m.add_argument("--execute", action="store_true",
+                   help="Perform the migration. Default is dry-run (print plan only).")
+    m.set_defaults(func=cmd_migrate)
+
+    l = sub.add_parser("list-orphans", help="List persistent-dir slugs that don't match their git-resolved slug")
+    l.set_defaults(func=cmd_list_orphans)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent)); _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent / "hooks"))
 
 import argparse
+import fcntl
 import json
+import os
 from pathlib import Path
 
 from lib_core import (
@@ -481,37 +483,56 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
         return {"task_id": task_id, "rules_added": 0, "analysis_written": True}
 
     rules_path = persistent / "prevention-rules.json"
-    existing: dict = {}
-    try:
-        existing = load_json(rules_path)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        existing = {}
-
-    current_rules = existing.get("rules", [])
-    existing_rule_texts = {r.get("rule", "").lower() for r in current_rules}
-
+    # Lost-update protection: two processes (e.g., two worktrees, or one
+    # task completing while another is mid-analysis) can both call
+    # apply_analysis concurrently. write_json is atomic (tempfile + rename)
+    # so neither reader observes a torn file, but without this lock the
+    # read-modify-write window can drop rules — reader A and reader B both
+    # see the same pre-merge state, each appends its rules, and the later
+    # writer overwrites the earlier one with only its own additions.
+    #
+    # fcntl.LOCK_EX on the rules file (or a sibling .lock if the file
+    # doesn't exist yet) serializes the RMW. Unix-only; dynos is
+    # Unix-only throughout.
+    persistent.mkdir(parents=True, exist_ok=True)
+    lock_path = rules_path.with_suffix(rules_path.suffix + ".lock")
     added = 0
-    for rule in new_rules:
-        if not isinstance(rule, dict):
-            continue
-        text = rule.get("rule", "").strip()
-        if not text or text.lower() in existing_rule_texts:
-            continue
-        current_rules.append({
-            "executor": rule.get("executor", "all"),
-            "category": rule.get("category", "unknown"),
-            "rule": text,
-            "source_task": task_id,
-            "source_finding": rule.get("source_finding", ""),
-            "rationale": rule.get("rationale", ""),
-            "enforcement": rule.get("enforcement", "prompt-constraint"),
-            "added_at": now_iso(),
-        })
-        existing_rule_texts.add(text.lower())
-        added += 1
+    lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(lock_fd, "w") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            existing: dict = {}
+            try:
+                existing = load_json(rules_path)
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                existing = {}
 
-    if added:
-        write_json(rules_path, {"rules": current_rules, "updated_at": now_iso()})
+            current_rules = existing.get("rules", [])
+            existing_rule_texts = {r.get("rule", "").lower() for r in current_rules}
+
+            for rule in new_rules:
+                if not isinstance(rule, dict):
+                    continue
+                text = rule.get("rule", "").strip()
+                if not text or text.lower() in existing_rule_texts:
+                    continue
+                current_rules.append({
+                    "executor": rule.get("executor", "all"),
+                    "category": rule.get("category", "unknown"),
+                    "rule": text,
+                    "source_task": task_id,
+                    "source_finding": rule.get("source_finding", ""),
+                    "rationale": rule.get("rationale", ""),
+                    "enforcement": rule.get("enforcement", "prompt-constraint"),
+                    "added_at": now_iso(),
+                })
+                existing_rule_texts.add(text.lower())
+                added += 1
+
+            if added:
+                write_json(rules_path, {"rules": current_rules, "updated_at": now_iso()})
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 
     return {"task_id": task_id, "rules_added": added, "analysis_written": True}
 

--- a/sandbox/calibration/lib_registry.py
+++ b/sandbox/calibration/lib_registry.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent)); _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent.parent / "hooks"))
 
+import fcntl
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -56,40 +58,57 @@ def register_learned_agent(
     source: str = "learned",
     item_kind: str = "agent",
 ) -> dict:
-    """Register a new learned agent in the registry."""
-    registry = ensure_learned_registry(root)
-    agents = registry.setdefault("agents", [])
-    existing = next(
-        (
-            agent
-            for agent in agents
-            if agent.get("agent_name") == agent_name
-            and agent.get("role") == role
-            and agent.get("task_type") == task_type
-            and agent.get("item_kind", "agent") == item_kind
-        ),
-        None,
-    )
-    record = {
-        "item_kind": item_kind,
-        "agent_name": agent_name,
-        "role": role,
-        "task_type": task_type,
-        "source": source,
-        "path": path,
-        "generated_from": generated_from,
-        "generated_at": now_iso(),
-        "mode": "shadow",
-        "status": "active",
-        "benchmark_summary": dict(_EMPTY_BENCHMARK_SUMMARY),
-    }
-    if existing:
-        existing.update(record)
-    else:
-        agents.append(record)
-    registry["updated_at"] = now_iso()
-    write_json(learned_registry_path(root), registry)
-    return registry
+    """Register a new learned agent in the registry.
+
+    Serialized with fcntl.LOCK_EX to prevent lost updates when two concurrent
+    processes register different agents at the same instant (e.g. two task
+    completions for different shadow agents firing agent_generator in
+    parallel drains). Without the lock, both readers see the same pre-merge
+    registry, each appends its entry, and the later writer's atomic write
+    loses the first writer's entry.
+    """
+    reg_path = learned_registry_path(root)
+    reg_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = reg_path.with_suffix(reg_path.suffix + ".lock")
+    lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(lock_fd, "w") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            registry = ensure_learned_registry(root)
+            agents = registry.setdefault("agents", [])
+            existing = next(
+                (
+                    agent
+                    for agent in agents
+                    if agent.get("agent_name") == agent_name
+                    and agent.get("role") == role
+                    and agent.get("task_type") == task_type
+                    and agent.get("item_kind", "agent") == item_kind
+                ),
+                None,
+            )
+            record = {
+                "item_kind": item_kind,
+                "agent_name": agent_name,
+                "role": role,
+                "task_type": task_type,
+                "source": source,
+                "path": path,
+                "generated_from": generated_from,
+                "generated_at": now_iso(),
+                "mode": "shadow",
+                "status": "active",
+                "benchmark_summary": dict(_EMPTY_BENCHMARK_SUMMARY),
+            }
+            if existing:
+                existing.update(record)
+            else:
+                agents.append(record)
+            registry["updated_at"] = now_iso()
+            write_json(reg_path, registry)
+            return registry
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 
 
 def apply_evaluation_to_registry(

--- a/tests/test_refactor_decomposition.py
+++ b/tests/test_refactor_decomposition.py
@@ -608,6 +608,10 @@ class TestBinDynosUnchanged:
         "remove",
         "pause",
         "resume",
+        "autofix",
+        "proactive",
+        "daemon",
+        "worktree",
     ]
 
     def test_bin_dynos_exists(self) -> None:

--- a/tests/test_rmw_concurrency.py
+++ b/tests/test_rmw_concurrency.py
@@ -1,0 +1,165 @@
+"""Tests for file-lock protection of read-modify-write JSON mutators.
+
+Once worktrees share main's persistent dir (the slug-normalization fix),
+concurrent writes from multiple checkouts become possible. The existing
+atomic write_json protects against torn reads, but not against lost
+updates in the RMW pattern:
+    A: read → merge(new_A) → write    (doesn't see B's changes)
+    B: read → merge(new_B) → write    (overwrites A's result)
+Result: only B's new rule survives. A's update is lost.
+
+The fix wraps RMW sequences in fcntl.LOCK_EX. These tests use real
+multiprocessing forks to prove concurrent writers don't lose rules.
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "memory"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sandbox" / "calibration"))
+
+
+def _worker_apply_analysis(task_dir_str: str, rule_text: str, delay: float = 0.0):
+    """Child process entry point for concurrent apply_analysis."""
+    import sys as _s
+    _s.path.insert(0, str(Path(task_dir_str).parent.parent.parent / "hooks"))
+    _s.path.insert(0, str(Path(task_dir_str).parent.parent.parent / "memory"))
+    from postmortem_analysis import apply_analysis
+    if delay:
+        time.sleep(delay)
+    apply_analysis(Path(task_dir_str), {
+        "summary": f"worker applying {rule_text}",
+        "prevention_rules": [{
+            "executor": "all",
+            "category": "sec",
+            "rule": rule_text,
+            "source_finding": f"finding-for-{rule_text}",
+            "rationale": "test",
+            "enforcement": "prompt-constraint",
+        }],
+    })
+
+
+def _make_task_dir(tmp_path: Path, task_id: str) -> Path:
+    task_dir = tmp_path / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "task-retrospective.json").write_text(json.dumps({
+        "task_id": task_id, "task_outcome": "DONE",
+        "findings_by_auditor": {}, "repair_cycle_count": 0,
+    }))
+    return task_dir
+
+
+class TestPreventionRulesLock:
+    def test_sequential_apply_accumulates(self, tmp_path: Path, monkeypatch):
+        """Sanity baseline: sequential calls obviously accumulate."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        task_dir = _make_task_dir(tmp_path, "task-A")
+        from postmortem_analysis import apply_analysis
+        apply_analysis(task_dir, {"summary": "t", "prevention_rules": [
+            {"executor": "all", "category": "sec", "rule": "rule-A",
+             "source_finding": "f-A", "rationale": "r", "enforcement": "prompt-constraint"}
+        ]})
+        apply_analysis(task_dir, {"summary": "t", "prevention_rules": [
+            {"executor": "all", "category": "sec", "rule": "rule-B",
+             "source_finding": "f-B", "rationale": "r", "enforcement": "prompt-constraint"}
+        ]})
+        # Find the rules file
+        from lib_core import _persistent_project_dir
+        rules_path = _persistent_project_dir(tmp_path) / "prevention-rules.json"
+        data = json.loads(rules_path.read_text())
+        rule_texts = [r["rule"] for r in data["rules"]]
+        assert "rule-A" in rule_texts
+        assert "rule-B" in rule_texts
+
+    def test_concurrent_apply_does_not_lose_updates(self, tmp_path: Path, monkeypatch):
+        """The load-bearing test: two concurrent apply_analysis calls with
+        disjoint rule sets. Without the file lock, one rule is lost. With
+        the lock, both survive."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        task_dir = _make_task_dir(tmp_path, "task-concurrent")
+        # Make the child processes inherit DYNOS_HOME
+        os.environ["DYNOS_HOME"] = str(tmp_path / "home")
+
+        ctx = multiprocessing.get_context("spawn")
+        procs = [
+            ctx.Process(target=_worker_apply_analysis, args=(str(task_dir), f"concurrent-rule-{i}", 0.01 * i))
+            for i in range(8)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+            assert not p.is_alive(), "worker hung"
+            assert p.exitcode == 0, f"worker exited {p.exitcode}"
+
+        from lib_core import _persistent_project_dir
+        rules_path = _persistent_project_dir(tmp_path) / "prevention-rules.json"
+        data = json.loads(rules_path.read_text())
+        rule_texts = {r["rule"] for r in data["rules"]}
+        expected = {f"concurrent-rule-{i}" for i in range(8)}
+        assert expected.issubset(rule_texts), (
+            f"lost updates: expected {expected}, got {rule_texts}. "
+            f"Missing: {expected - rule_texts}"
+        )
+
+
+def _worker_register_agent(root_str: str, agent_name: str, delay: float = 0.0):
+    """Child process entry point for concurrent register_learned_agent."""
+    import sys as _s
+    _s.path.insert(0, str(Path(root_str) / "hooks"))
+    _s.path.insert(0, str(Path(root_str) / "sandbox" / "calibration"))
+    from lib_registry import register_learned_agent
+    if delay:
+        time.sleep(delay)
+    register_learned_agent(
+        Path(root_str),
+        agent_name=agent_name,
+        role="backend-executor",
+        task_type="refactor",
+        path=f"/tmp/{agent_name}.md",
+        generated_from=f"task-{agent_name}",
+    )
+
+
+class TestLearnedAgentRegistryLock:
+    def test_concurrent_register_does_not_lose_agents(self, tmp_path: Path, monkeypatch):
+        """Concurrent register_learned_agent calls with different agent
+        names must produce a registry containing ALL agents. Without the
+        lock, the slower writer's entry overwrites the faster's."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        os.environ["DYNOS_HOME"] = str(tmp_path / "home")
+        # Give the root a real filesystem existence
+        root = tmp_path / "fake-repo"
+        root.mkdir()
+
+        ctx = multiprocessing.get_context("spawn")
+        N = 6
+        procs = [
+            ctx.Process(target=_worker_register_agent, args=(str(root), f"agent-{i}", 0.01 * i))
+            for i in range(N)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+            assert not p.is_alive()
+            assert p.exitcode == 0
+
+        from lib_core import _persistent_project_dir
+        reg_path = _persistent_project_dir(root) / "learned-agents" / "registry.json"
+        data = json.loads(reg_path.read_text())
+        names = {a["agent_name"] for a in data.get("agents", [])}
+        expected = {f"agent-{i}" for i in range(N)}
+        assert expected == names, (
+            f"lost agents: expected {expected}, got {names}. Missing: {expected - names}"
+        )

--- a/tests/test_worktree_cli.py
+++ b/tests/test_worktree_cli.py
@@ -1,0 +1,218 @@
+"""Tests for the `dynos worktree` CLI.
+
+Covers:
+- migrate dry-run prints plan without mutating anything
+- migrate --execute performs the migration, creates backups
+- list-orphans detects worktree-remnant slugs
+- migrate with same source/target slug refuses
+- migrate with missing source errors cleanly
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+
+def _seed_registry(home: Path, *paths: Path):
+    """Seed the global registry so worktree CLI can resolve slug → original path."""
+    home.mkdir(parents=True, exist_ok=True)
+    reg_path = home / "registry.json"
+    reg = {"version": 1, "projects": [
+        {"path": str(p.resolve()), "registered_at": "2026-01-01T00:00:00Z",
+         "last_active_at": "2026-01-01T00:00:00Z", "status": "active"}
+        for p in paths
+    ], "checksum": ""}
+    # Compute checksum like registry.py does
+    import hashlib
+    copy = dict(reg)
+    copy.pop("checksum", None)
+    blob = json.dumps(copy, sort_keys=True, separators=(",", ":"))
+    reg["checksum"] = hashlib.sha256(blob.encode()).hexdigest()
+    reg_path.write_text(json.dumps(reg))
+
+
+def _seed_split_state(home: Path, main_slug: str, wt_slug: str):
+    """Create a fake worktree-slug persistent dir with some state to migrate."""
+    projects = home / "projects"
+    projects.mkdir(parents=True, exist_ok=True)
+
+    main = projects / main_slug
+    main.mkdir(parents=True, exist_ok=True)
+    (main / "postmortems").mkdir()
+    (main / "postmortems" / "task-A.json").write_text('{"task_id": "task-A"}')
+    (main / "prevention-rules.json").write_text(json.dumps({
+        "rules": [{"executor": "all", "category": "sec", "rule": "existing-main-rule",
+                   "source_task": "task-A", "source_finding": "fA"}],
+        "updated_at": "2026-01-01T00:00:00Z",
+    }))
+
+    wt = projects / wt_slug
+    wt.mkdir(parents=True, exist_ok=True)
+    (wt / "postmortems").mkdir()
+    (wt / "postmortems" / "task-B.json").write_text('{"task_id": "task-B"}')
+    (wt / "postmortems" / "task-B.md").write_text("# task-B postmortem")
+    (wt / "prevention-rules.json").write_text(json.dumps({
+        "rules": [
+            {"executor": "all", "category": "sec", "rule": "wt-rule-1",
+             "source_task": "task-B", "source_finding": "fB1"},
+            {"executor": "all", "category": "sec", "rule": "wt-rule-2",
+             "source_task": "task-B", "source_finding": "fB2"},
+        ],
+    }))
+    (wt / "policy.json").write_text(json.dumps({"freshness_task_window": 1}))
+    return main, wt
+
+
+def _git(cwd: Path, *args: str):
+    subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True,
+        env={**os.environ, "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t"},
+    )
+
+
+def _make_git_repo_and_worktree(tmp_path: Path):
+    """Create a real git repo + worktree so the CLI can git-resolve the slug."""
+    main_repo = tmp_path / "my-repo"
+    main_repo.mkdir()
+    _git(main_repo, "init", "-b", "main")
+    (main_repo / "README.md").write_text("hi")
+    _git(main_repo, "add", ".")
+    _git(main_repo, "commit", "-m", "init")
+    wt_path = tmp_path / "my-repo-feature"
+    _git(main_repo, "worktree", "add", str(wt_path), "-b", "feature")
+    return main_repo, wt_path
+
+
+def _run_cli(tmp_path: Path, *args: str):
+    """Invoke hooks/worktree.py with the given args; return (exit, stdout, stderr)."""
+    hooks_dir = Path(__file__).resolve().parent.parent / "hooks"
+    result = subprocess.run(
+        ["python3", str(hooks_dir / "worktree.py"), *args],
+        capture_output=True, text=True, timeout=30,
+        env={**os.environ, "DYNOS_HOME": str(tmp_path / "home")},
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestMigrate:
+    def test_dry_run_prints_plan_without_mutating(self, tmp_path: Path):
+        main_repo, wt_path = _make_git_repo_and_worktree(tmp_path)
+        home = tmp_path / "home"
+        main_slug = str(main_repo.resolve()).strip("/").replace("/", "-")
+        wt_slug = str(wt_path.resolve()).strip("/").replace("/", "-")
+        main_dir, wt_dir = _seed_split_state(home, main_slug, wt_slug)
+        _seed_registry(home, main_repo, wt_path)
+
+        wt_marker_before = list((wt_dir / "postmortems").iterdir())
+        main_marker_before = list((main_dir / "postmortems").iterdir())
+
+        exit_code, stdout, stderr = _run_cli(tmp_path, "migrate", str(wt_dir))
+        assert exit_code == 0, f"stderr: {stderr}"
+        plan = json.loads(stdout)
+        assert plan.get("dry_run") is True
+        assert "task-B.json" in plan["postmortems_to_copy"]
+        assert "wt-rule-1" in plan["prevention_rules_new"]
+        assert "wt-rule-2" in plan["prevention_rules_new"]
+        assert "policy.json" in plan["not_migrated"]
+
+        # Dry run must not have touched anything
+        assert list((wt_dir / "postmortems").iterdir()) == wt_marker_before
+        assert list((main_dir / "postmortems").iterdir()) == main_marker_before
+
+    def test_execute_performs_migration_and_creates_backups(self, tmp_path: Path):
+        main_repo, wt_path = _make_git_repo_and_worktree(tmp_path)
+        home = tmp_path / "home"
+        main_slug = str(main_repo.resolve()).strip("/").replace("/", "-")
+        wt_slug = str(wt_path.resolve()).strip("/").replace("/", "-")
+        main_dir, wt_dir = _seed_split_state(home, main_slug, wt_slug)
+        _seed_registry(home, main_repo, wt_path)
+
+        exit_code, stdout, stderr = _run_cli(tmp_path, "migrate", str(wt_dir), "--execute")
+        assert exit_code == 0, f"stderr: {stderr}"
+        result = json.loads(stdout)
+        assert result["ok"] is True
+        assert result["applied"]["postmortems_copied"] == 2  # task-B.json + task-B.md
+        assert result["applied"]["prevention_rules_added"] == 2
+
+        # Target now has both original and new postmortems
+        assert (main_dir / "postmortems" / "task-A.json").exists()
+        assert (main_dir / "postmortems" / "task-B.json").exists()
+        assert (main_dir / "postmortems" / "task-B.md").exists()
+
+        # Prevention rules merged
+        rules = json.loads((main_dir / "prevention-rules.json").read_text())
+        texts = {r["rule"] for r in rules["rules"]}
+        assert texts == {"existing-main-rule", "wt-rule-1", "wt-rule-2"}
+
+        # Source dir removed
+        assert not wt_dir.exists()
+
+        # Backups exist
+        bak_dirs = sorted((home / "projects").glob(f"{wt_slug}.bak-*"))
+        assert len(bak_dirs) == 1
+        bak_main = sorted((home / "projects").glob(f"{main_slug}.bak-*"))
+        assert len(bak_main) == 1
+
+    def test_same_source_and_target_refused(self, tmp_path: Path):
+        """If source slug == target slug (e.g., user accidentally runs on main's dir),
+        refuse."""
+        main_repo, _ = _make_git_repo_and_worktree(tmp_path)
+        home = tmp_path / "home"
+        main_slug = str(main_repo.resolve()).strip("/").replace("/", "-")
+        projects = home / "projects"
+        projects.mkdir(parents=True)
+        (projects / main_slug).mkdir()
+        _seed_registry(home, main_repo)
+
+        exit_code, stdout, stderr = _run_cli(tmp_path, "migrate", str(projects / main_slug))
+        assert exit_code == 1
+        result = json.loads(stdout)
+        assert "same slug" in result["error"]
+
+    def test_missing_source_errors(self, tmp_path: Path):
+        exit_code, stdout, stderr = _run_cli(tmp_path, "migrate", str(tmp_path / "nonexistent"))
+        assert exit_code == 2
+        result = json.loads(stdout)
+        assert "does not exist" in result["error"]
+
+
+class TestListOrphans:
+    def test_detects_worktree_remnant(self, tmp_path: Path):
+        """A persistent dir whose slug corresponds to a git worktree of an
+        existing main repo should be flagged as an orphan."""
+        main_repo, wt_path = _make_git_repo_and_worktree(tmp_path)
+        home = tmp_path / "home"
+        main_slug = str(main_repo.resolve()).strip("/").replace("/", "-")
+        wt_slug = str(wt_path.resolve()).strip("/").replace("/", "-")
+        _seed_split_state(home, main_slug, wt_slug)
+        _seed_registry(home, main_repo, wt_path)
+
+        exit_code, stdout, stderr = _run_cli(tmp_path, "list-orphans")
+        assert exit_code == 0, f"stderr: {stderr}"
+        result = json.loads(stdout)
+        orphan_slugs = [o["slug"] for o in result["orphans"]]
+        assert wt_slug in orphan_slugs
+        assert main_slug not in orphan_slugs  # main should NOT be flagged
+
+    def test_empty_when_no_projects_dir(self, tmp_path: Path):
+        exit_code, stdout, stderr = _run_cli(tmp_path, "list-orphans")
+        assert exit_code == 0, f"stderr: {stderr}"
+        result = json.loads(stdout)
+        assert result["orphans"] == []
+
+    def test_ignores_backup_dirs(self, tmp_path: Path):
+        """Dirs with .bak-{timestamp} suffix should not be flagged as orphans."""
+        home = tmp_path / "home"
+        (home / "projects" / "something.bak-20260101-120000").mkdir(parents=True)
+        exit_code, stdout, stderr = _run_cli(tmp_path, "list-orphans")
+        assert exit_code == 0, f"stderr: {stderr}"
+        result = json.loads(stdout)
+        assert result["orphans"] == []

--- a/tests/test_worktree_slug.py
+++ b/tests/test_worktree_slug.py
@@ -1,0 +1,195 @@
+"""Tests for git-worktree-aware _persistent_project_dir normalization.
+
+Before this fix: each git worktree got a distinct ~/.dynos/projects/{slug}/
+dir because the slug was derived from the absolute filesystem path of the
+checkout. Learning state (postmortems, prevention-rules, retrospectives,
+learned-agents) partitioned per-worktree, invisible to main. This test file
+locks in the fix: worktrees fold back to the main repo's slug.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+
+@pytest.fixture(autouse=True)
+def _clear_git_cache():
+    """The resolver is lru_cached; clear between tests so they don't bleed."""
+    from lib_core import _resolve_git_toplevel
+    _resolve_git_toplevel.cache_clear()
+    yield
+    _resolve_git_toplevel.cache_clear()
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run a git command, raising on failure."""
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            # Avoid GPG-signing config from host
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+        },
+    )
+
+
+class TestSlugNormalization:
+    def test_main_repo_slug_matches_absolute_path(self, tmp_path: Path, monkeypatch):
+        """A plain repo (no worktrees) uses its own toplevel as the slug source."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        (repo / "README.md").write_text("hi")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+
+        from lib_core import _persistent_project_dir
+        slug_dir = _persistent_project_dir(repo)
+        expected = str(repo.resolve()).strip("/").replace("/", "-")
+        assert slug_dir.name == expected, (
+            f"main repo slug should match absolute path; got {slug_dir.name}, expected {expected}"
+        )
+
+    def test_worktree_folds_back_to_main_slug(self, tmp_path: Path, monkeypatch):
+        """A git worktree must resolve to the MAIN repo's slug.
+        This is the load-bearing assertion — the fix exists for this."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        _git(main_repo, "init", "-b", "main")
+        (main_repo / "README.md").write_text("hi")
+        _git(main_repo, "add", ".")
+        _git(main_repo, "commit", "-m", "init")
+
+        wt_path = tmp_path / "worktree"
+        _git(main_repo, "worktree", "add", str(wt_path), "-b", "feature")
+
+        from lib_core import _persistent_project_dir, _resolve_git_toplevel
+        _resolve_git_toplevel.cache_clear()
+
+        main_slug = _persistent_project_dir(main_repo).name
+        wt_slug = _persistent_project_dir(wt_path).name
+
+        assert wt_slug == main_slug, (
+            f"worktree ({wt_slug}) must fold to main ({main_slug}); "
+            f"if they differ, learning state is partitioning per-worktree again"
+        )
+
+    def test_nested_subdir_of_worktree_also_folds(self, tmp_path: Path, monkeypatch):
+        """A subdirectory inside a worktree still maps to main's slug."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        _git(main_repo, "init", "-b", "main")
+        (main_repo / "src").mkdir()
+        (main_repo / "src" / "a.py").write_text("pass\n")
+        _git(main_repo, "add", ".")
+        _git(main_repo, "commit", "-m", "init")
+
+        wt_path = tmp_path / "worktree"
+        _git(main_repo, "worktree", "add", str(wt_path), "-b", "feature")
+
+        from lib_core import _persistent_project_dir, _resolve_git_toplevel
+        _resolve_git_toplevel.cache_clear()
+
+        main_slug = _persistent_project_dir(main_repo).name
+        nested_slug = _persistent_project_dir(wt_path / "src").name
+        assert nested_slug == main_slug
+
+
+class TestFallbackBehavior:
+    def test_non_git_dir_falls_back_to_absolute_path_slug(self, tmp_path: Path, monkeypatch):
+        """A tmp dir that is NOT a git repo must preserve the old behavior:
+        slug = str(root.resolve()).strip('/').replace('/', '-'). Existing
+        tests that use tmp_path without git init depend on this."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        from lib_core import _persistent_project_dir
+        slug_dir = _persistent_project_dir(plain)
+        expected = str(plain.resolve()).strip("/").replace("/", "-")
+        assert slug_dir.name == expected
+
+    def test_git_missing_falls_back(self, tmp_path: Path, monkeypatch):
+        """If `git` isn't on PATH, fall back silently — do not raise."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("PATH", "/nonexistent-dir")
+        from lib_core import _persistent_project_dir, _resolve_git_toplevel
+        _resolve_git_toplevel.cache_clear()
+        # Should not raise
+        slug_dir = _persistent_project_dir(tmp_path)
+        assert slug_dir.name  # got a non-empty slug
+        assert "/" not in slug_dir.name  # slug is slugified
+
+    def test_git_rev_parse_nonzero_falls_back(self, tmp_path: Path, monkeypatch):
+        """A tmp dir that LOOKS like it might be a git repo but where
+        `git rev-parse` returns non-zero must fall back."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        # NOT a git init — plain dir
+        from lib_core import _persistent_project_dir
+        slug_dir = _persistent_project_dir(plain)
+        expected = str(plain.resolve()).strip("/").replace("/", "-")
+        assert slug_dir.name == expected
+
+
+class TestCaching:
+    def test_repeated_calls_cache_git_lookup(self, tmp_path: Path, monkeypatch):
+        """Per-process lru_cache must prevent repeated subprocess shell-outs."""
+        monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "home"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+
+        from lib_core import _persistent_project_dir, _resolve_git_toplevel
+        _resolve_git_toplevel.cache_clear()
+
+        with mock.patch("subprocess.run", wraps=subprocess.run) as mock_run:
+            _persistent_project_dir(repo)
+            _persistent_project_dir(repo)
+            _persistent_project_dir(repo)
+        # First call shells out once. Subsequent calls hit cache.
+        assert mock_run.call_count == 1, (
+            f"expected 1 subprocess.run call (cached), got {mock_run.call_count}"
+        )
+
+
+class TestBackwardsCompat:
+    def test_current_main_repo_slug_unchanged(self):
+        """Verify the REAL main repo (this checkout) still resolves to the
+        same slug it had before the fix. This test would fail if the fix
+        accidentally moved the slug for the main repo, which would orphan
+        everyone's existing learning state."""
+        from lib_core import _persistent_project_dir, _resolve_git_toplevel
+        _resolve_git_toplevel.cache_clear()
+        # Derive using the pre-fix logic explicitly
+        real_main = Path(__file__).resolve().parent.parent
+        # Pre-fix logic: slug from absolute path of `real_main`
+        # Post-fix: slug from git toplevel — should be identical for a non-worktree
+        pre = str(real_main.resolve()).strip("/").replace("/", "-")
+        post = _persistent_project_dir(real_main).name
+        # If this test is run from a worktree, the post slug will differ
+        # (legitimately — it folds to main). Skip the comparison in that case.
+        git_dir_marker = real_main / ".git"
+        if git_dir_marker.is_file():
+            pytest.skip("running from a worktree — slug fold is expected to change")
+        assert pre == post, (
+            f"main repo slug changed post-fix: pre={pre} post={post}. "
+            "This would orphan existing learning state for anyone who upgrades."
+        )


### PR DESCRIPTION
## Summary
- Fixes split-brain across worktrees — postmortems, prevention rules, and learned agents now converge on ONE persistent project dir keyed by the main working tree (via `git rev-parse --git-common-dir`).
- Adds fcntl.LOCK_EX + O_NOFOLLOW on RMW JSON mutators (prevention-rules, learned-agents registry) now that worktrees share one dir.
- New CLI `dynos worktree migrate <path>` (dry-run default) and `dynos worktree list-orphans` to reconcile existing split state.

## What broke
Before this fix: each worktree had its own `~/.dynos/projects/{slug}/` because slug was derived from the worktree's absolute path. A postmortem written from a worktree never reached main's learning pipeline. This was a systemic data-isolation bug across every concurrent task.

## Changes
- `hooks/lib_core.py` — `_persistent_project_dir()` resolves to `git common-dir`'s parent and slugifies that. Falls back to old behavior on non-git paths (backwards compat).
- `memory/postmortem_analysis.py`, `sandbox/calibration/lib_registry.py` — fcntl.LOCK_EX on RMW; lock files opened via `os.open(O_WRONLY|O_CREAT|O_NOFOLLOW, 0o600)`.
- `hooks/worktree.py` (new) — migrate CLI with containment check before `rm_tree`, registry-only slug reverse lookup, `follow_symlinks=False` on copies, `is_symlink()` guards.
- 18 new tests across `test_worktree_slug.py`, `test_rmw_concurrency.py`, `test_worktree_cli.py`.

## Audit outcome
- 2 repair cycles (7 initial + 2 re-audit security findings). All resolved.
- Full suite: 967 passed, 1 skipped (the 1 skip is the backwards-compat test that correctly skips inside a worktree).

## Test plan
- [x] `pytest tests/ -q` → 967/967 + 1 skip
- [x] Security audit re-run PASS after cycle 2
- [x] Slug-fix self-verified: postmortem for task-20260418-003 written to main's slug from this worktree (`~/.dynos/projects/Users-hassam-Documents-dynos-work/postmortems/`)
- [ ] After merge: run `dynos worktree list-orphans` locally to reconcile remaining split state
- [ ] After merge: clean up `../dynos-work-slug-fix` worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)