### PR TITLE
add deterministic rules engine + 6 templates + transition gates + migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ claude plugin marketplace add dynos-fit/dynos-work
 claude plugin install dynos-work
 ```
 
+## Install commit-time rules check
+
+After cloning, install the deterministic rules engine pre-commit hook:
+
+```bash
+python3 hooks/rules_engine.py install-hook
+```
+
+This writes a `.git/hooks/pre-commit` script that runs the dynos rules engine on staged files at commit time. The hook enforces project-specific prevention rules (defined in `~/.dynos/projects/{slug}/prevention-rules.json`) and refuses commits with errors. New clones MUST run this command — git does not version `.git/hooks/`. Bypass via `git commit --no-verify` is supported but discouraged.
+
 ## Use
 
 ```

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -517,6 +517,37 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                     f"expected={(expected or '')[:12]} actual={actual[:12]}"
                 )
 
+        def _check_rules_check_passed(
+            task_dir: Path, current_stage: str, next_stage: str
+        ) -> None:
+            """Refuse the current transition unless a ``rules-check-passed``
+            receipt exists and reports ``error_violations == 0``.
+
+            Fail-closed semantics: when the receipt is missing entirely the
+            count is reported as ``"missing"`` in the refusal message, and
+            when the ``error_violations`` key is absent from the receipt the
+            default value used is ``1`` so a malformed receipt still refuses
+            the transition.
+            """
+            from lib_receipts import read_receipt  # noqa: F811 — lazy re-import per spec
+
+            receipt_path = task_dir / "receipts" / "rules-check-passed.json"
+            receipt = read_receipt(task_dir, "rules-check-passed")
+            if receipt is None:
+                n = "missing"
+                _refuse(
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing or failed rules-check-passed receipt at "
+                    f"{receipt_path} (error_violations={n})"
+                )
+            if receipt.get("error_violations", 1) != 0:
+                n = receipt.get("error_violations", "missing")
+                _refuse(
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing or failed rules-check-passed receipt at "
+                    f"{receipt_path} (error_violations={n})"
+                )
+
         # ---- AC 3: SPEC_REVIEW -> PLANNING requires human-approval-SPEC_REVIEW
         # whose artifact_sha256 matches sha256(spec.md).
         if current_stage == "SPEC_REVIEW" and next_stage == "PLANNING":
@@ -625,6 +656,14 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                     f"Cannot transition {current_stage} -> {next_stage}: "
                     f"missing receipt calibration-applied at {ca_path}"
                 )
+
+        # AC 19: rules-check-passed receipt required at two transition points.
+        # Fires AFTER all other gate clauses so existing checks order is
+        # preserved. Bypassed by force=True (we are inside `if not force:`).
+        if next_stage == "TEST_EXECUTION":
+            _check_rules_check_passed(task_dir, current_stage, next_stage)
+        if current_stage == "CHECKPOINT_AUDIT" and next_stage == "DONE":
+            _check_rules_check_passed(task_dir, current_stage, next_stage)
 
         if gate_errors:
             raise ValueError(

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -86,6 +86,7 @@ __all__ = [
     "receipt_postmortem_analysis",
     "receipt_postmortem_skipped",
     "receipt_calibration_applied",
+    "receipt_rules_check_passed",
     "RECEIPT_CONTRACT_VERSION",
     "CALIBRATION_POLICY_FILES",
 ]
@@ -111,6 +112,7 @@ _LOG_MESSAGES: dict[str, str] = {
     "postmortem-analysis": "[DONE] postmortem analysis — rules_added={rules_added}",
     "postmortem-skipped": "[DONE] postmortem skipped — reason={reason}",
     "calibration-applied": "[DONE] calibration applied — retros={retros_consumed} scores={scores_updated}",
+    "rules-check-passed": "[DONE] rules check — {rules_evaluated} rules evaluated, {violations_count} violations",
 }
 
 
@@ -939,6 +941,72 @@ def receipt_calibration_applied(
         scores_updated=scores_updated,
         policy_sha256_before=policy_sha256_before,
         policy_sha256_after=policy_sha256_after,
+    )
+
+
+def receipt_rules_check_passed(
+    task_dir: Path,
+    rules_evaluated: int,
+    violations_count: int,
+    error_violations: int,
+    mode: str,
+    advisory_violations: int = 0,
+    rules_file_sha256: str = "none",
+) -> Path:
+    """Write receipt proving a rules-check pass (no error-severity violations).
+
+    This writer is a *passed-receipt by construction*: it REFUSES to write if
+    ``error_violations != 0``. The rules-check pipeline must take a different
+    path (failure path) when errors are present — this receipt proves the
+    clean outcome only.
+
+    Validates:
+      - All four counts are non-negative ints.
+      - ``error_violations <= violations_count``.
+      - ``error_violations == 0`` (else raises ValueError).
+      - ``mode`` is one of {"staged", "all"}.
+
+    ``engine_version`` is hardcoded to ``"1"`` to avoid importing rules_engine
+    (which may not exist yet during early bootstrap of this feature).
+    ``checked_at`` is stamped via ``now_iso()``.
+    """
+    if not isinstance(rules_evaluated, int) or isinstance(rules_evaluated, bool) or rules_evaluated < 0:
+        raise ValueError("rules_evaluated must be a non-negative int")
+    if not isinstance(violations_count, int) or isinstance(violations_count, bool) or violations_count < 0:
+        raise ValueError("violations_count must be a non-negative int")
+    if not isinstance(error_violations, int) or isinstance(error_violations, bool) or error_violations < 0:
+        raise ValueError("error_violations must be a non-negative int")
+    if not isinstance(advisory_violations, int) or isinstance(advisory_violations, bool) or advisory_violations < 0:
+        raise ValueError("advisory_violations must be a non-negative int")
+    if error_violations > violations_count:
+        raise ValueError(
+            f"error_violations ({error_violations}) must be <= violations_count "
+            f"({violations_count})"
+        )
+    if error_violations != 0:
+        raise ValueError(
+            f"receipt_rules_check_passed REFUSES to write: error_violations="
+            f"{error_violations} (must be 0 — this receipt is a passed-receipt "
+            f"by construction; use a failure-path receipt when errors exist)"
+        )
+    if mode not in ("staged", "all"):
+        raise ValueError(
+            f"mode must be 'staged' or 'all' (got mode={mode!r})"
+        )
+    if not isinstance(rules_file_sha256, str) or not rules_file_sha256:
+        raise ValueError("rules_file_sha256 must be a non-empty string")
+
+    return write_receipt(
+        task_dir,
+        "rules-check-passed",
+        rules_evaluated=rules_evaluated,
+        violations_count=violations_count,
+        error_violations=error_violations,
+        advisory_violations=advisory_violations,
+        engine_version="1",
+        rules_file_sha256=rules_file_sha256,
+        checked_at=now_iso(),
+        mode=mode,
     )
 
 

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -862,6 +862,7 @@ def build_executor_plan(
     segments: list[dict],
     *,
     ctx: RouterContext | None = None,
+    include_enforced: bool = False,
 ) -> dict:
     """Build a complete, deterministic execution spawn plan.
 
@@ -870,6 +871,21 @@ def build_executor_plan(
     When *ctx* is provided, its cached reads are reused. When *ctx* is None,
     a fresh RouterContext is constructed locally so external callers keep
     working unchanged.
+
+    Prevention-rule filtering (AC 13):
+        Rules with a structured `template` other than "advisory" are
+        considered "enforced" — they have a runtime / static-check
+        backstop and shipping their text into the executor prompt
+        wastes tokens. By default only `advisory` rules (and legacy
+        rules missing a `template` field, for backward-compat during
+        the migration window) reach the prompt.
+
+        Pass `include_enforced=True` to disable the filter and include
+        every rule, e.g. for diagnostics or for audits that want to
+        verify the LLM still sees enforced-rule rationale.
+
+        Each segment plan entry exposes `prevention_rules_omitted: int`
+        so callers can prove the filter ran.
     """
     ctx = ctx or RouterContext(root)
     all_rules = load_prevention_rules(root)
@@ -886,12 +902,32 @@ def build_executor_plan(
         model_decision = resolve_model(root, executor, task_type, ctx=ctx)
         route_decision = resolve_route(root, executor, task_type, ctx=ctx)
 
-        # Filter prevention rules relevant to this executor
-        executor_rules = [
-            r["rule"] for r in all_rules
+        # Step 1: filter to rules that target this executor (or all).
+        executor_scoped: list[dict] = [
+            r for r in all_rules
             if isinstance(r, dict) and r.get("rule")
             and (not r.get("executor") or r.get("executor") == executor)
         ]
+
+        # Step 2: AC 13 template filter. Advisory + missing-template
+        # stay; everything else is omitted unless include_enforced is set.
+        prevention_rules_omitted = 0
+        if include_enforced:
+            kept = executor_scoped
+        else:
+            kept = []
+            for r in executor_scoped:
+                tmpl = r.get("template")
+                # Missing template → backward-compat advisory; keep.
+                # Explicit "advisory" → keep.
+                # Anything else (every_name_in_X_satisfies_Y, signature_lock, ...)
+                # has a runtime/static backstop, so omit it from the prompt.
+                if tmpl is None or tmpl == "advisory":
+                    kept.append(r)
+                else:
+                    prevention_rules_omitted += 1
+
+        executor_rules = [r["rule"] for r in kept]
 
         plan["segments"].append({
             "segment_id": seg_id,
@@ -904,9 +940,10 @@ def build_executor_plan(
             "agent_name": route_decision["agent_name"],
             "composite_score": route_decision["composite_score"],
             "prevention_rules": executor_rules,
+            "prevention_rules_omitted": prevention_rules_omitted,
         })
 
-    log_event(root, "router_executor_plan", task_type=task_type, segment_count=len(plan["segments"]), segments=[{"segment_id": s["segment_id"], "executor": s["executor"], "model": s.get("model"), "model_source": s.get("model_source")} for s in plan["segments"]])
+    log_event(root, "router_executor_plan", task_type=task_type, segment_count=len(plan["segments"]), include_enforced=include_enforced, segments=[{"segment_id": s["segment_id"], "executor": s["executor"], "model": s.get("model"), "model_source": s.get("model_source"), "prevention_rules_omitted": s.get("prevention_rules_omitted", 0)} for s in plan["segments"]])
     return plan
 
 
@@ -1166,7 +1203,14 @@ def cmd_executor_plan(args: argparse.Namespace) -> int:
 
     # Build plan once. Write to the task-local cache so per-segment
     # `inject-prompt` invocations can reuse it without rebuilding.
-    plan = build_executor_plan(root, args.task_type, graph.get("segments", []))
+    # AC 13: --include-enforced overrides the template filter so audits
+    # / debugging can see every rule, not just advisory ones.
+    plan = build_executor_plan(
+        root,
+        args.task_type,
+        graph.get("segments", []),
+        include_enforced=getattr(args, "include_enforced", False),
+    )
 
     task_id = _task_id_from_graph_path(graph_path)
     if task_id:
@@ -1306,8 +1350,15 @@ def cmd_inject_prompt(args: argparse.Namespace) -> int:
                 cache_status = "fingerprint_drift"
 
     if plan_entry is None:
-        # Fallback: live build for this single segment
-        plan = build_executor_plan(root, args.task_type, [target_seg])
+        # Fallback: live build for this single segment.
+        # AC 13: respect --include-enforced so the fallback path agrees
+        # with what `executor-plan` would have produced.
+        plan = build_executor_plan(
+            root,
+            args.task_type,
+            [target_seg],
+            include_enforced=getattr(args, "include_enforced", False),
+        )
         if not plan["segments"]:
             print(json.dumps({"error": "no plan entry for segment"}))
             return 1
@@ -1566,6 +1617,16 @@ def build_parser() -> argparse.ArgumentParser:
     ep.add_argument("--root", default=".")
     ep.add_argument("--task-type", required=True)
     ep.add_argument("--graph", required=True)
+    ep.add_argument(
+        "--include-enforced",
+        action="store_true",
+        default=False,
+        help=(
+            "Include enforced (template != advisory) prevention rules in "
+            "executor prompts. Default: omit them, since they have a "
+            "runtime/static backstop."
+        ),
+    )
     ep.set_defaults(func=cmd_executor_plan)
 
     ip = subparsers.add_parser("inject-prompt", help="Inject learned agent rules into executor prompt")
@@ -1573,6 +1634,15 @@ def build_parser() -> argparse.ArgumentParser:
     ip.add_argument("--task-type", required=True)
     ip.add_argument("--graph", required=True)
     ip.add_argument("--segment-id", required=True)
+    ip.add_argument(
+        "--include-enforced",
+        action="store_true",
+        default=False,
+        help=(
+            "Include enforced (template != advisory) prevention rules in "
+            "the injected prompt. Default: omit them."
+        ),
+    )
     ip.set_defaults(func=cmd_inject_prompt)
 
     aip = subparsers.add_parser(

--- a/hooks/rules_engine.py
+++ b/hooks/rules_engine.py
@@ -1,0 +1,1341 @@
+#!/usr/bin/env python3
+"""Deterministic rules engine for dynos prevention-rules.json.
+
+Converts prevention rules from "advice injected into LLM prompts" into
+"code-evaluated gates at commit time and stage-transition time."
+
+Six enforcement templates plus a pass-through `advisory` template cover ~80%
+of existing rule shapes:
+
+- every_name_in_X_satisfies_Y — every element of a container in a module
+  satisfies a predicate (callable / hasattr / in_registry)
+- pattern_must_not_appear — regex + optional AST context filter
+- co_modification_required — if trigger glob changes, must-modify glob must too
+  (staged mode only)
+- signature_lock — exact ordered parameter names of a named function
+- caller_count_required — minimum number of call sites summed across a glob
+- import_constant_only — string literal allowed only in listed files
+- advisory — always returns [] (injected into prompts, not enforced by engine)
+
+Deterministic: same rules file + same tree → byte-identical output. Violations
+sorted by (file, line, rule_id). Handlers warn-and-skip on import/parse
+failure; never raise. No global state mutation in handlers. Pure Python except
+for `git rev-parse --show-toplevel` (install-hook) and
+`git diff --cached --name-only` (check --staged).
+
+CLI: check, describe, install-hook, validate-rules. Exit codes per spec AC 17.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import importlib
+import inspect
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional
+
+# lib_core lives in the same package (hooks/). When this file is executed as
+# a script rather than imported, the package context isn't set up, so we add
+# the hooks/ dir to sys.path before attempting the import.
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from lib_core import _persistent_project_dir  # noqa: E402
+
+
+__all__ = [
+    "RULES_ENGINE_VERSION",
+    "TEMPLATES",
+    "TEMPLATE_SCHEMAS",
+    "Rule",
+    "ScanScope",
+    "Violation",
+    "run_checks",
+    "main",
+]
+
+
+RULES_ENGINE_VERSION = "1"
+
+_HOOK_MARKER = "# dynos-rules-engine v1"
+_HOOK_BODY = (
+    "#!/usr/bin/env bash\n"
+    "# dynos-rules-engine v1\n"
+    'exec python3 "$(git rev-parse --show-toplevel)/hooks/rules_engine.py" check --staged\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Rule:
+    """One prevention rule loaded from prevention-rules.json."""
+
+    rule_id: str
+    template: str
+    params: dict
+    severity: str = "error"
+    source_finding: str = ""
+    rationale: str = ""
+    scope_override: Optional[dict] = None
+
+
+@dataclass(frozen=True)
+class ScanScope:
+    """Immutable scan scope handed to every template handler."""
+
+    root: Path
+    files: tuple[Path, ...]
+    mode: str
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"staged", "all"}:
+            raise ValueError(
+                f"ScanScope.mode must be 'staged' or 'all', got {self.mode!r}"
+            )
+
+
+@dataclass
+class Violation:
+    """One rule violation produced by a template handler."""
+
+    rule_id: str
+    template: str
+    file: str
+    line: int
+    message: str
+    severity: str
+
+    def to_dict(self) -> dict:
+        return {
+            "rule_id": self.rule_id,
+            "template": self.template,
+            "file": self.file,
+            "line": int(self.line),
+            "message": self.message,
+            "severity": self.severity,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Template schemas (for validate-rules CLI and postmortem validator)
+# ---------------------------------------------------------------------------
+
+TEMPLATE_SCHEMAS: dict[str, dict] = {
+    "every_name_in_X_satisfies_Y": {
+        "required": ["module", "container", "predicate"],
+        "enums": {"predicate": ["callable", "hasattr", "in_registry"]},
+        "types": {"module": str, "container": str, "predicate": str},
+    },
+    "pattern_must_not_appear": {
+        "required": ["regex", "scope"],
+        "types": {"regex": str, "scope": str},
+    },
+    "co_modification_required": {
+        "required": ["trigger_glob", "must_modify_glob"],
+        "types": {"trigger_glob": str, "must_modify_glob": str},
+    },
+    "signature_lock": {
+        "required": ["module", "function", "expected_params"],
+        "types": {"module": str, "function": str, "expected_params": list},
+    },
+    "caller_count_required": {
+        "required": ["symbol", "scope", "min_count"],
+        "types": {"symbol": str, "scope": str, "min_count": int},
+    },
+    "import_constant_only": {
+        "required": ["literal_pattern", "allowed_files"],
+        "types": {"literal_pattern": str, "allowed_files": list},
+    },
+    "advisory": {"required": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _warn(msg: str) -> None:
+    """Write a warning to stderr. Always flushes."""
+    try:
+        sys.stderr.write(msg + "\n")
+        sys.stderr.flush()
+    except Exception:
+        # Even stderr can fail (closed pipe during tests) — swallow.
+        pass
+
+
+# Mitigates SEC-001 (ReDoS): user-controlled regex from prevention-rules.json
+# could catastrophically backtrack. Python's re module cannot be cancelled
+# mid-match in-process, so we (a) statically flag known-pathological
+# nested-quantifier shapes, and (b) run a short canary search under
+# signal.alarm on Unix to catch the rest. Unix-only — dynos-work targets
+# macOS/Linux. On other platforms the static-shape check still runs.
+import signal as _signal
+
+_REGEX_CANARY = "a" * 64 + "!"
+_REGEX_BUDGET_S = 1  # 1s alarm budget (signal.alarm int-seconds only)
+
+# Static detector for common catastrophic-backtracking shapes.
+# Covers: (X+)+, (X*)*, (X+)*, (X*)+, and (X|Y)+ where X and Y overlap.
+# Not exhaustive — the runtime alarm catches what the static check misses.
+_REDOS_SHAPE_PATTERNS = [
+    re.compile(r"\([^)]*\+[^)]*\)\s*[+*]"),   # (...+...)+ / (...+...)*
+    re.compile(r"\([^)]*\*[^)]*\)\s*[+*]"),   # (...*...)+ / (...*...)*
+]
+
+
+def _regex_looks_pathological(pattern: str) -> bool:
+    """Cheap static check for known catastrophic-backtracking shapes."""
+    for shape in _REDOS_SHAPE_PATTERNS:
+        if shape.search(pattern):
+            return True
+    return False
+
+
+def _safe_compile_regex(pattern: str, rule_id: str, field: str) -> "re.Pattern | None":
+    """Compile a user-supplied regex with static + runtime ReDoS defences.
+
+    Returns compiled Pattern, or None on compile failure / pathological
+    shape / canary alarm. Never raises.
+    """
+    try:
+        compiled = re.compile(pattern)
+    except re.error as exc:
+        _warn(
+            f"[rules_engine] WARN rule={rule_id}: invalid {field} "
+            f"{pattern!r}: {exc}"
+        )
+        return None
+    if _regex_looks_pathological(pattern):
+        _warn(
+            f"[rules_engine] WARN rule={rule_id}: {field} {pattern!r} "
+            f"has catastrophic-backtracking shape (nested quantifiers); "
+            f"refusing to evaluate"
+        )
+        return None
+    # Runtime canary: run against adversarial input under a wall-clock alarm.
+    # signal.alarm is main-thread-only on Unix; skip on other platforms and
+    # rely on the static check alone.
+    if hasattr(_signal, "SIGALRM"):
+        def _on_alarm(signum, frame):
+            raise TimeoutError("regex canary exceeded budget")
+        prev_handler = _signal.signal(_signal.SIGALRM, _on_alarm)
+        _signal.alarm(_REGEX_BUDGET_S)
+        try:
+            compiled.search(_REGEX_CANARY)
+        except TimeoutError:
+            _warn(
+                f"[rules_engine] WARN rule={rule_id}: {field} {pattern!r} "
+                f"exceeded {_REGEX_BUDGET_S}s canary (suspected "
+                f"catastrophic backtracking); refusing to evaluate"
+            )
+            return None
+        except Exception:
+            # Pathological regex raising in search — treat as unsafe.
+            _warn(
+                f"[rules_engine] WARN rule={rule_id}: {field} canary raised; "
+                f"refusing to evaluate {pattern!r}"
+            )
+            return None
+        finally:
+            _signal.alarm(0)
+            _signal.signal(_signal.SIGALRM, prev_handler)
+    return compiled
+
+
+def _info(msg: str) -> None:
+    _warn(msg)
+
+
+def _truncate(text: str, limit: int = 80) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit]
+
+
+def _relative_path(root: Path, file: Path) -> str:
+    """Return file relative to root when possible; absolute otherwise."""
+    try:
+        return str(file.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(file)
+
+
+def _staged_files(root: Path) -> list[Path]:
+    """Return staged files as absolute paths via `git diff --cached --name-only`.
+
+    Returns [] on any git failure — never raises. Missing files (staged delete)
+    are filtered out; downstream handlers that read file contents would choke.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    out = []
+    for line in result.stdout.splitlines():
+        rel = line.strip()
+        if not rel:
+            continue
+        p = (root / rel)
+        if p.exists() and p.is_file():
+            out.append(p)
+    return out
+
+
+def _all_tracked_files(root: Path) -> list[Path]:
+    """Return all tracked files in the repo (git ls-files), fall back to walk.
+
+    Filters to files only. Never raises.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "ls-files"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0:
+            out = []
+            for line in result.stdout.splitlines():
+                rel = line.strip()
+                if not rel:
+                    continue
+                p = root / rel
+                if p.exists() and p.is_file():
+                    out.append(p)
+            if out:
+                return out
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        pass
+    # Fallback: walk the tree (used outside git repos, e.g. tests).
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Skip hidden dirs (.git, .venv, __pycache__, .dynos, etc.)
+        dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "__pycache__"]
+        for fn in filenames:
+            p = Path(dirpath) / fn
+            if p.is_file():
+                out.append(p)
+    return out
+
+
+def _resolve_files(root: Path, mode: str) -> tuple[Path, ...]:
+    """Resolve the file list for a scan scope. Deterministic (sorted)."""
+    if mode == "staged":
+        files = _staged_files(root)
+    else:
+        files = _all_tracked_files(root)
+    return tuple(sorted(files))
+
+
+def _glob_match(file: Path, root: Path, pattern: str) -> bool:
+    """Match a file against a repo-relative glob using fnmatch semantics."""
+    rel = _relative_path(root, file)
+    # fnmatch does not treat '/' specially; for glob-like behaviour we test
+    # against the relative path directly.
+    if fnmatch.fnmatch(rel, pattern):
+        return True
+    # Also match against the basename for simple patterns like "*.py".
+    if fnmatch.fnmatch(file.name, pattern):
+        return True
+    return False
+
+
+def _read_text(file: Path) -> Optional[str]:
+    """Read text from a file, returning None on any IO error."""
+    try:
+        return file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _inspect_source_location(obj: Any) -> tuple[str, int]:
+    """Return (file, line) for an object, tolerating None / failure."""
+    try:
+        src = inspect.getsourcefile(obj)
+    except TypeError:
+        src = None
+    file = src if src else "<unknown>"
+    try:
+        _, line = inspect.getsourcelines(obj)
+    except (TypeError, OSError):
+        line = 0
+    return file, line
+
+
+# ---------------------------------------------------------------------------
+# Template handlers
+# ---------------------------------------------------------------------------
+
+
+def check_every_name_in_X_satisfies_Y(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 4: every element of `container` in `module` satisfies `predicate`."""
+    params = rule.params or {}
+    module_name = params.get("module")
+    container_name = params.get("container")
+    predicate = params.get("predicate")
+    if not module_name or not container_name or not predicate:
+        return []
+
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception as exc:  # ImportError, SyntaxError, anything.
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: import of "
+            f"'{module_name}' failed: {exc}"
+        )
+        return []
+
+    if not hasattr(mod, container_name):
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: container "
+            f"'{container_name}' not found in module '{module_name}'"
+        )
+        return []
+
+    container = getattr(mod, container_name)
+    try:
+        elements = list(container)
+    except TypeError:
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: container "
+            f"'{module_name}.{container_name}' is not iterable"
+        )
+        return []
+
+    file_path, line_no = _inspect_source_location(mod)
+    severity = rule.severity
+
+    violations: list[Violation] = []
+
+    if predicate == "callable":
+        for name in elements:
+            try:
+                obj = getattr(mod, name, None)
+                ok = callable(obj)
+            except Exception:
+                ok = False
+            if not ok:
+                violations.append(
+                    Violation(
+                        rule_id=rule.rule_id,
+                        template=rule.template,
+                        file=file_path,
+                        line=line_no,
+                        message=(
+                            f"every_name_in_X_satisfies_Y: '{name}' in "
+                            f"{module_name}.{container_name} fails predicate "
+                            f"'{predicate}'"
+                        ),
+                        severity=severity,
+                    )
+                )
+    elif predicate == "hasattr":
+        attr = params.get("attr")
+        if not attr:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: predicate=hasattr "
+                f"requires 'attr' param"
+            )
+            return []
+        for name in elements:
+            try:
+                obj = getattr(mod, name, None)
+                ok = obj is not None and hasattr(obj, attr)
+            except Exception:
+                ok = False
+            if not ok:
+                violations.append(
+                    Violation(
+                        rule_id=rule.rule_id,
+                        template=rule.template,
+                        file=file_path,
+                        line=line_no,
+                        message=(
+                            f"every_name_in_X_satisfies_Y: '{name}' in "
+                            f"{module_name}.{container_name} fails predicate "
+                            f"'{predicate}'"
+                        ),
+                        severity=severity,
+                    )
+                )
+    elif predicate == "in_registry":
+        reg_mod_name = params.get("registry_module")
+        reg_attr_name = params.get("registry_attr")
+        if not reg_mod_name or not reg_attr_name:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: predicate=in_registry "
+                f"requires 'registry_module' and 'registry_attr' params"
+            )
+            return []
+        try:
+            reg_mod = importlib.import_module(reg_mod_name)
+        except Exception as exc:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: import of "
+                f"registry '{reg_mod_name}' failed: {exc}"
+            )
+            return []
+        registry = getattr(reg_mod, reg_attr_name, None)
+        if registry is None:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: registry "
+                f"'{reg_mod_name}.{reg_attr_name}' not found"
+            )
+            return []
+        try:
+            membership = set(registry) if not isinstance(registry, dict) else set(registry.keys())
+        except TypeError:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: registry "
+                f"'{reg_mod_name}.{reg_attr_name}' is not iterable"
+            )
+            return []
+        for name in elements:
+            if name not in membership:
+                violations.append(
+                    Violation(
+                        rule_id=rule.rule_id,
+                        template=rule.template,
+                        file=file_path,
+                        line=line_no,
+                        message=(
+                            f"every_name_in_X_satisfies_Y: '{name}' in "
+                            f"{module_name}.{container_name} fails predicate "
+                            f"'{predicate}'"
+                        ),
+                        severity=severity,
+                    )
+                )
+    else:
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: unknown predicate "
+            f"{predicate!r}; expected callable|hasattr|in_registry"
+        )
+        return []
+
+    return violations
+
+
+def check_pattern_must_not_appear(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 5: regex match with optional AST-context filter."""
+    params = rule.params or {}
+    regex_src = params.get("regex")
+    glob = params.get("scope")
+    context_required = params.get("context_required")
+    if not regex_src or not glob:
+        return []
+
+    regex = _safe_compile_regex(regex_src, rule.rule_id, "regex")
+    if regex is None:
+        return []
+
+    if context_required:
+        ctx_re = _safe_compile_regex(context_required, rule.rule_id, "context_required")
+        if ctx_re is None:
+            return []
+    else:
+        ctx_re = None
+
+    violations: list[Violation] = []
+    for file in scope.files:
+        if not _glob_match(file, scope.root, glob):
+            continue
+        text = _read_text(file)
+        if text is None:
+            continue
+
+        matches = list(regex.finditer(text))
+        if not matches:
+            continue
+
+        rel = _relative_path(scope.root, file)
+
+        if ctx_re is None:
+            for m in matches:
+                line_no = text.count("\n", 0, m.start()) + 1
+                matched_text = _truncate(m.group(0))
+                violations.append(
+                    Violation(
+                        rule_id=rule.rule_id,
+                        template=rule.template,
+                        file=rel,
+                        line=line_no,
+                        message=(
+                            f"pattern_must_not_appear: regex "
+                            f"{regex_src!r} matched in {rel}:{line_no} "
+                            f"(text: {matched_text!r})"
+                        ),
+                        severity=rule.severity,
+                    )
+                )
+            continue
+
+        # context_required: parse AST once per file with hits.
+        try:
+            tree = ast.parse(text, filename=str(file))
+        except SyntaxError as exc:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: syntax error "
+                f"parsing {rel}: {exc}; skipping"
+            )
+            continue
+
+        # Build a list of all nodes with line span info for containment search.
+        nodes_with_span = []
+        for node in ast.walk(tree):
+            if hasattr(node, "lineno"):
+                start = node.lineno
+                end = getattr(node, "end_lineno", start)
+                nodes_with_span.append((start, end, node))
+
+        for m in matches:
+            line_no = text.count("\n", 0, m.start()) + 1
+            # Find smallest enclosing node whose range contains line_no.
+            best = None
+            best_span = None
+            for start, end, node in nodes_with_span:
+                if start <= line_no <= end:
+                    span = end - start
+                    if best is None or span < best_span:
+                        best = node
+                        best_span = span
+            if best is None:
+                continue
+            try:
+                source_slice = ast.unparse(best)
+            except Exception:
+                continue
+            if not ctx_re.search(source_slice):
+                continue
+            matched_text = _truncate(m.group(0))
+            violations.append(
+                Violation(
+                    rule_id=rule.rule_id,
+                    template=rule.template,
+                    file=rel,
+                    line=line_no,
+                    message=(
+                        f"pattern_must_not_appear: regex {regex_src!r} "
+                        f"matched in {rel}:{line_no} "
+                        f"(text: {matched_text!r})"
+                    ),
+                    severity=rule.severity,
+                )
+            )
+
+    return violations
+
+
+def check_co_modification_required(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 6: trigger glob change implies must-modify glob change. Staged-only."""
+    params = rule.params or {}
+    trigger_glob = params.get("trigger_glob")
+    must_modify_glob = params.get("must_modify_glob")
+    if not trigger_glob or not must_modify_glob:
+        return []
+
+    if scope.mode == "all":
+        _info(
+            f"[rules_engine] INFO rule={rule.rule_id}: "
+            f"co_modification_required skipped in --all mode"
+        )
+        return []
+
+    trigger_files = sorted(
+        [f for f in scope.files if _glob_match(f, scope.root, trigger_glob)]
+    )
+    if not trigger_files:
+        return []
+
+    modified = [f for f in scope.files if _glob_match(f, scope.root, must_modify_glob)]
+    if modified:
+        return []
+
+    trigger_file = _relative_path(scope.root, trigger_files[0])
+    return [
+        Violation(
+            rule_id=rule.rule_id,
+            template=rule.template,
+            file=trigger_file,
+            line=0,
+            message=(
+                f"co_modification_required: {trigger_file} changed but "
+                f"no file matching '{must_modify_glob}' was modified"
+            ),
+            severity=rule.severity,
+        )
+    ]
+
+
+def check_signature_lock(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 7: function signature matches expected_params exactly."""
+    params = rule.params or {}
+    module_name = params.get("module")
+    function_name = params.get("function")
+    expected = params.get("expected_params")
+    if not module_name or not function_name or expected is None:
+        return []
+    if not isinstance(expected, list):
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: expected_params "
+            f"must be a list"
+        )
+        return []
+
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception as exc:
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: import of "
+            f"'{module_name}' failed: {exc}"
+        )
+        return []
+
+    try:
+        func = getattr(mod, function_name)
+    except AttributeError as exc:
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: attribute "
+            f"'{module_name}.{function_name}' not found: {exc}"
+        )
+        return []
+
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError) as exc:
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: signature of "
+            f"'{module_name}.{function_name}' unavailable: {exc}"
+        )
+        return []
+
+    actual = [p for p in sig.parameters.keys() if p != "self"]
+    if actual == list(expected):
+        return []
+
+    file, line = _inspect_source_location(func)
+    return [
+        Violation(
+            rule_id=rule.rule_id,
+            template=rule.template,
+            file=file,
+            line=line,
+            message=(
+                f"signature_lock: {module_name}.{function_name} "
+                f"params={actual!r} expected={list(expected)!r}"
+            ),
+            severity=rule.severity,
+        )
+    ]
+
+
+def check_caller_count_required(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 8: sum ast.Call sites for `symbol` across glob ≥ min_count."""
+    params = rule.params or {}
+    symbol = params.get("symbol")
+    glob = params.get("scope")
+    min_count = params.get("min_count")
+    if not symbol or not glob or min_count is None:
+        return []
+    if not isinstance(min_count, int):
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: min_count must be int"
+        )
+        return []
+
+    total = 0
+    for file in scope.files:
+        if not _glob_match(file, scope.root, glob):
+            continue
+        text = _read_text(file)
+        if text is None:
+            continue
+        try:
+            tree = ast.parse(text, filename=str(file))
+        except SyntaxError as exc:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: syntax error "
+                f"parsing {_relative_path(scope.root, file)}: {exc}; skipping"
+            )
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == symbol:
+                total += 1
+            elif isinstance(func, ast.Attribute) and func.attr == symbol:
+                total += 1
+
+    if total >= min_count:
+        return []
+
+    return [
+        Violation(
+            rule_id=rule.rule_id,
+            template=rule.template,
+            file="(repo-wide)",
+            line=0,
+            message=(
+                f"caller_count_required: '{symbol}' called {total} time(s) "
+                f"across {glob}, expected >= {min_count}"
+            ),
+            severity=rule.severity,
+        )
+    ]
+
+
+def check_import_constant_only(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 9: string literal matching pattern allowed only in listed files."""
+    params = rule.params or {}
+    literal_pattern = params.get("literal_pattern")
+    allowed_files = params.get("allowed_files")
+    if not literal_pattern or allowed_files is None:
+        return []
+    if not isinstance(allowed_files, list):
+        _warn(
+            f"[rules_engine] WARN rule={rule.rule_id}: allowed_files must be a list"
+        )
+        return []
+
+    pat = _safe_compile_regex(literal_pattern, rule.rule_id, "literal_pattern")
+    if pat is None:
+        return []
+
+    violations: list[Violation] = []
+    for file in scope.files:
+        if file.suffix != ".py":
+            continue
+        rel = _relative_path(scope.root, file)
+        # If file matches any allowed glob, skip (file is allowed).
+        if any(_glob_match(file, scope.root, g) for g in allowed_files):
+            continue
+        text = _read_text(file)
+        if text is None:
+            continue
+        try:
+            tree = ast.parse(text, filename=str(file))
+        except SyntaxError as exc:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: syntax error "
+                f"parsing {rel}: {exc}; skipping"
+            )
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant):
+                continue
+            value = node.value
+            if not isinstance(value, str):
+                continue
+            if not pat.search(value):
+                continue
+            line_no = getattr(node, "lineno", 0) or 0
+            literal_trunc = _truncate(value)
+            violations.append(
+                Violation(
+                    rule_id=rule.rule_id,
+                    template=rule.template,
+                    file=rel,
+                    line=line_no,
+                    message=(
+                        f"import_constant_only: literal {literal_trunc!r} "
+                        f"matching pattern {literal_pattern!r} appears in "
+                        f"{rel}:{line_no}; only allowed in: {allowed_files}"
+                    ),
+                    severity=rule.severity,
+                )
+            )
+
+    return violations
+
+
+def check_advisory(rule: Rule, scope: ScanScope) -> list[Violation]:
+    """AC 10: advisory rules are NEVER enforced by the engine."""
+    return []
+
+
+TEMPLATES: dict[str, Callable[[Rule, ScanScope], list[Violation]]] = {
+    "every_name_in_X_satisfies_Y": check_every_name_in_X_satisfies_Y,
+    "pattern_must_not_appear": check_pattern_must_not_appear,
+    "co_modification_required": check_co_modification_required,
+    "signature_lock": check_signature_lock,
+    "caller_count_required": check_caller_count_required,
+    "import_constant_only": check_import_constant_only,
+    "advisory": check_advisory,
+}
+
+
+# ---------------------------------------------------------------------------
+# Rule loading
+# ---------------------------------------------------------------------------
+
+
+def _load_rules_file(root: Path, rules_path: Optional[Path] = None) -> tuple[list[dict], Optional[Path]]:
+    """Load the raw rules list and return (list, path).
+
+    If rules_path not given, uses _persistent_project_dir(root) / prevention-rules.json.
+    Missing file → ([], path). Caller is responsible for exit-code semantics when
+    the JSON is malformed (we raise ValueError in that case).
+    """
+    if rules_path is None:
+        rules_path = _persistent_project_dir(root) / "prevention-rules.json"
+    if not rules_path.exists():
+        return [], rules_path
+    try:
+        with rules_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read prevention-rules at {rules_path}: {exc}") from exc
+    rules = data.get("rules") if isinstance(data, dict) else None
+    if rules is None:
+        return [], rules_path
+    if not isinstance(rules, list):
+        raise ValueError(
+            f"prevention-rules.json at {rules_path} has non-list 'rules' field"
+        )
+    return rules, rules_path
+
+
+def _rule_from_dict(d: dict) -> Optional[Rule]:
+    """Build a Rule from a raw dict; return None on missing required fields."""
+    if not isinstance(d, dict):
+        return None
+    rule_id = d.get("rule_id") or d.get("id")
+    template = d.get("template")
+    params = d.get("params") or {}
+    if not rule_id or not template:
+        return None
+    if not isinstance(params, dict):
+        return None
+    return Rule(
+        rule_id=str(rule_id),
+        template=str(template),
+        params=params,
+        severity=str(d.get("severity", "error")),
+        source_finding=str(d.get("source_finding", "")),
+        rationale=str(d.get("rationale", "")),
+        scope_override=d.get("scope_override"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level run_checks
+# ---------------------------------------------------------------------------
+
+
+def run_checks(
+    root: Path,
+    mode: Literal["staged", "all"],
+    rule_filter: Optional[str] = None,
+) -> list[Violation]:
+    """Load prevention-rules.json, dispatch each rule, return sorted violations.
+
+    Missing rules file → []. Unknown templates are skipped with a stderr warn.
+    Handlers themselves never raise; this function tolerates per-rule errors by
+    logging and moving on.
+
+    Output is sorted by (file, line, rule_id) for byte-identical determinism.
+    """
+    root = Path(root)
+    raw_rules, _ = _load_rules_file(root)
+    if not raw_rules:
+        return []
+
+    files = _resolve_files(root, mode)
+    scope = ScanScope(root=root.resolve(), files=files, mode=mode)
+
+    violations: list[Violation] = []
+    for raw in raw_rules:
+        rule = _rule_from_dict(raw)
+        if rule is None:
+            # Malformed rule entry; skip with warning. Do NOT raise — AC 17
+            # distinguishes malformed JSON (exit 2) from individual bad rule
+            # (skipped).
+            _warn(
+                f"[rules_engine] WARN: skipping malformed rule entry "
+                f"(missing rule_id or template): {raw!r}"
+            )
+            continue
+        if rule_filter is not None and rule.rule_id != rule_filter:
+            continue
+        handler = TEMPLATES.get(rule.template)
+        if handler is None:
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: unknown template "
+                f"{rule.template!r}; skipping"
+            )
+            continue
+        try:
+            result = handler(rule, scope)
+        except Exception as exc:
+            # Defensive: template handlers promise not to raise, but if one
+            # does, treat as warn-and-skip rather than exploding the engine.
+            _warn(
+                f"[rules_engine] WARN rule={rule.rule_id}: handler for "
+                f"{rule.template!r} raised {type(exc).__name__}: {exc}"
+            )
+            continue
+        if result:
+            violations.extend(result)
+
+    violations.sort(key=lambda v: (v.file, int(v.line), v.rule_id))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: check
+# ---------------------------------------------------------------------------
+
+
+def _format_violation_line(v: Violation) -> str:
+    # Spec AC 16: "{file}:{line}: [{severity}] {rule_id} ({template}) — {message}"
+    return (
+        f"{v.file}:{v.line}: [{v.severity}] {v.rule_id} "
+        f"({v.template}) \u2014 {v.message}"
+    )
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve() if args.root else Path.cwd()
+    mode = "all" if args.all else "staged"
+    try:
+        violations = run_checks(root, mode, rule_filter=args.rule)
+    except ValueError as exc:
+        _warn(f"[rules_engine] ERROR: {exc}")
+        return 2
+    except (OSError, json.JSONDecodeError) as exc:
+        _warn(f"[rules_engine] ERROR: {exc}")
+        return 2
+
+    # Emit per-violation lines to stdout.
+    for v in violations:
+        print(_format_violation_line(v))
+
+    # Summary to stderr. Count distinct rule ids across violations.
+    error_count = sum(1 for v in violations if v.severity == "error")
+    warn_count = sum(1 for v in violations if v.severity == "warn")
+    rule_ids = {v.rule_id for v in violations}
+    if violations:
+        _warn(
+            f"{len(violations)} violations "
+            f"({error_count} error, {warn_count} warn) "
+            f"across {len(rule_ids)} rules"
+        )
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return 1 if error_count > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: describe
+# ---------------------------------------------------------------------------
+
+
+def _enforcement_for_template(template: str) -> str:
+    if template == "advisory":
+        return "advisory"
+    if template in TEMPLATES:
+        return "enforced"
+    return "unknown"
+
+
+def _cmd_describe(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve() if args.root else Path.cwd()
+    try:
+        raw_rules, _ = _load_rules_file(root)
+    except ValueError as exc:
+        _warn(f"[rules_engine] ERROR: {exc}")
+        return 2
+
+    if not raw_rules:
+        # AC 3 / AC 17: no rules → exit 0, no output.
+        return 0
+
+    # Tab-separated header and rows.
+    header = "rule_id\ttemplate\tscope\tenforcement\tseverity\tsource_finding"
+    print(header)
+
+    rows = []
+    for idx, raw in enumerate(raw_rules):
+        if not isinstance(raw, dict):
+            continue
+        # Per AC 13 backward-compat: rules without a `template` field are
+        # treated as advisory. We surface them in describe output too so
+        # operators can see what the engine sees.
+        rule_id = raw.get("rule_id") or raw.get("id") or f"<unkeyed-{idx}>"
+        template = raw.get("template") or "advisory"
+        params = raw.get("params") or {}
+        if not isinstance(params, dict):
+            params = {}
+        scope_val = (
+            params.get("scope")
+            or params.get("trigger_glob")
+            or params.get("module")
+            or (raw.get("scope_override") or {}).get("scope")
+            or raw.get("scope", "")
+            or ""
+        )
+        severity = str(raw.get("severity", "error"))
+        source_finding = str(raw.get("source_finding", ""))
+        rows.append(
+            (
+                str(rule_id),
+                str(template),
+                str(scope_val),
+                _enforcement_for_template(str(template)),
+                severity,
+                source_finding,
+            )
+        )
+    rows.sort(key=lambda r: (r[0],))
+    for row in rows:
+        print("\t".join(row))
+    sys.stdout.flush()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: install-hook
+# ---------------------------------------------------------------------------
+
+
+def _repo_toplevel(root: Path) -> Optional[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    top = result.stdout.strip()
+    if not top:
+        return None
+    return Path(top)
+
+
+def _cmd_install_hook(args: argparse.Namespace) -> int:
+    cwd = Path.cwd()
+    toplevel = _repo_toplevel(cwd)
+    if toplevel is None:
+        _warn(
+            "[rules_engine] ERROR: not inside a git repository "
+            "(git rev-parse --show-toplevel failed)"
+        )
+        return 2
+
+    hooks_dir = toplevel / ".git" / "hooks"
+    try:
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _warn(f"[rules_engine] ERROR: cannot create hooks dir: {exc}")
+        return 2
+
+    hook_path = hooks_dir / "pre-commit"
+
+    # Idempotency / conflict check.
+    if hook_path.exists():
+        try:
+            head = hook_path.read_bytes()[:200]
+        except OSError as exc:
+            _warn(f"[rules_engine] ERROR: cannot read existing hook: {exc}")
+            return 2
+        if _HOOK_MARKER.encode("utf-8") in head:
+            # Our hook already — no-op.
+            return 0
+        if not args.force:
+            _warn(
+                f"[rules_engine] refusal: {hook_path} exists and is not a "
+                f"dynos-rules-engine hook. Re-run with --force to overwrite."
+            )
+            return 1
+
+    # Atomic write: tempfile in same dir, then os.replace.
+    tmp_path = hook_path.with_suffix(hook_path.suffix + ".tmp")
+    try:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o755,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(_HOOK_BODY)
+        except Exception:
+            # fdopen consumed fd; fall through to cleanup below.
+            raise
+        # Ensure exec bit on filesystems that mask O_CREAT mode.
+        os.chmod(tmp_path, 0o755)
+        os.replace(tmp_path, hook_path)
+    except OSError as exc:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        _warn(f"[rules_engine] ERROR: cannot install hook: {exc}")
+        return 2
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: validate-rules
+# ---------------------------------------------------------------------------
+
+
+def _validate_rule_entry(raw: Any) -> Optional[str]:
+    """Validate one raw rule entry against TEMPLATE_SCHEMAS.
+
+    Returns an error string on failure, None on success.
+    """
+    if not isinstance(raw, dict):
+        return "entry is not a dict"
+    rule_id = raw.get("rule_id") or raw.get("id")
+    if not rule_id:
+        return "missing rule_id"
+    template = raw.get("template")
+    if not template:
+        return f"rule {rule_id!r}: missing template"
+    schema = TEMPLATE_SCHEMAS.get(template)
+    if schema is None:
+        return f"rule {rule_id!r}: unknown template {template!r}"
+    params = raw.get("params") or {}
+    if not isinstance(params, dict):
+        return f"rule {rule_id!r}: params must be a dict"
+    for key in schema.get("required", []):
+        if key not in params:
+            return f"rule {rule_id!r}: missing required param {key!r}"
+    for key, enum_values in (schema.get("enums") or {}).items():
+        if key in params and params[key] not in enum_values:
+            return (
+                f"rule {rule_id!r}: param {key!r}={params[key]!r} "
+                f"not in enum {enum_values}"
+            )
+    for key, declared_type in (schema.get("types") or {}).items():
+        if key in params and not isinstance(params[key], declared_type):
+            return (
+                f"rule {rule_id!r}: param {key!r} must be "
+                f"{declared_type.__name__}, got {type(params[key]).__name__}"
+            )
+    return None
+
+
+def _cmd_validate_rules(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve() if args.root else Path.cwd()
+    rules_path = Path(args.rules_path) if args.rules_path else None
+    try:
+        raw_rules, resolved_path = _load_rules_file(root, rules_path)
+    except ValueError as exc:
+        _warn(f"[rules_engine] ERROR: {exc}")
+        return 2
+    except OSError as exc:
+        _warn(f"[rules_engine] ERROR: {exc}")
+        return 2
+
+    errors: list[str] = []
+    for raw in raw_rules:
+        err = _validate_rule_entry(raw)
+        if err:
+            errors.append(err)
+
+    if errors:
+        for err in errors:
+            print(err)
+        sys.stdout.flush()
+        return 1
+
+    print(f"OK ({len(raw_rules)} rules valid)")
+    sys.stdout.flush()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="rules_engine",
+        description="Deterministic rules engine for dynos prevention-rules.json.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_check = sub.add_parser("check", help="Evaluate rules against the tree.")
+    grp = p_check.add_mutually_exclusive_group()
+    grp.add_argument("--staged", dest="staged", action="store_true")
+    grp.add_argument("--all", dest="all", action="store_true")
+    p_check.add_argument("--rule", dest="rule", default=None)
+    p_check.add_argument("--root", dest="root", default=None)
+
+    p_desc = sub.add_parser("describe", help="List all rules.")
+    p_desc.add_argument("--root", dest="root", default=None)
+
+    p_install = sub.add_parser("install-hook", help="Install pre-commit hook.")
+    p_install.add_argument("--force", dest="force", action="store_true")
+
+    p_validate = sub.add_parser("validate-rules", help="Validate schemas of all rules.")
+    p_validate.add_argument("--root", dest="root", default=None)
+    p_validate.add_argument("--rules-path", dest="rules_path", default=None)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "check":
+            # Default is --staged when neither explicit flag given.
+            if not args.staged and not args.all:
+                args.staged = True
+            return _cmd_check(args)
+        if args.cmd == "describe":
+            return _cmd_describe(args)
+        if args.cmd == "install-hook":
+            return _cmd_install_hook(args)
+        if args.cmd == "validate-rules":
+            return _cmd_validate_rules(args)
+    except KeyboardInterrupt:
+        _warn("[rules_engine] interrupted")
+        return 2
+    except Exception as exc:
+        _warn(f"[rules_engine] internal error: {type(exc).__name__}: {exc}")
+        return 2
+
+    parser.error(f"unknown command: {args.cmd!r}")
+    return 2  # unreachable, but pleases type-checkers
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -57,6 +57,84 @@ VALID_EXECUTORS = {
     "all",
 }
 
+# Mirrors `hooks.rules_engine.TEMPLATE_SCHEMAS`. Kept inline here to keep
+# postmortem writes independent of the rules_engine module (which is
+# authored in seg-1 of this task, running in parallel). A seg-6 test
+# verifies that the two dicts stay structurally aligned; if you change
+# one you MUST change the other.
+TEMPLATE_SCHEMAS: dict = {
+    "every_name_in_X_satisfies_Y": {
+        "required": ["module", "container", "predicate"],
+        "enums": {"predicate": ["callable", "hasattr", "in_registry"]},
+        "types": {"module": str, "container": str, "predicate": str},
+    },
+    "pattern_must_not_appear": {
+        "required": ["regex", "scope"],
+        "types": {"regex": str, "scope": str},
+    },
+    "co_modification_required": {
+        "required": ["trigger_glob", "must_modify_glob"],
+        "types": {"trigger_glob": str, "must_modify_glob": str},
+    },
+    "signature_lock": {
+        "required": ["module", "function", "expected_params"],
+        "types": {"module": str, "function": str, "expected_params": list},
+    },
+    "caller_count_required": {
+        "required": ["symbol", "scope", "min_count"],
+        "types": {"symbol": str, "scope": str, "min_count": int},
+    },
+    "import_constant_only": {
+        "required": ["literal_pattern", "allowed_files"],
+        "types": {"literal_pattern": str, "allowed_files": list},
+    },
+    "advisory": {"required": []},
+}
+
+
+def _validate_rule_schema(rule: object) -> tuple[bool, str]:
+    """Validate one prevention rule against TEMPLATE_SCHEMAS.
+
+    Returns (ok, reason). When ok is False, *reason* names the exact
+    check that failed so the REJECT stderr line is actionable.
+    """
+    if not isinstance(rule, dict):
+        return False, "rule is not a dict"
+    template = rule.get("template")
+    if template is None:
+        return False, "missing template field"
+    if template not in TEMPLATE_SCHEMAS:
+        return False, f"unknown template: {template}"
+    schema = TEMPLATE_SCHEMAS[template]
+    params = rule.get("params")
+    if not isinstance(params, dict):
+        # advisory has no required keys, but still must have a (possibly
+        # empty) params dict — callers may extend advisory later.
+        if schema.get("required"):
+            return False, "params is not a dict"
+        params = {}
+    # (b) required keys present & non-None
+    for key in schema.get("required", []):
+        if params.get(key) is None:
+            return False, f"missing required param: {key}"
+    # (c) enum check
+    for key, allowed in schema.get("enums", {}).items():
+        if params.get(key) not in allowed:
+            return False, f"param {key}={params.get(key)!r} not in enum {allowed}"
+    # (d) type check
+    for key, typ in schema.get("types", {}).items():
+        value = params.get(key)
+        # bool is a subclass of int; reject bools where int is required
+        # unless the schema explicitly permits bool.
+        if typ is int and isinstance(value, bool):
+            return False, f"param {key} expected {typ.__name__}, got bool"
+        if not isinstance(value, typ):
+            return False, (
+                f"param {key} expected {typ.__name__}, "
+                f"got {type(value).__name__}"
+            )
+    return True, ""
+
 
 def _read_artifact(path: Path) -> dict | list | None:
     """Read a JSON artifact, returning None if missing or broken."""
@@ -139,7 +217,7 @@ def _normalize_rule(item: object) -> dict | None:
     enforcement = _clean_str(item.get("enforcement"), 32).lower()
     if enforcement not in VALID_ENFORCEMENT:
         enforcement = "prompt-constraint"
-    return {
+    normalized: dict = {
         "executor": _normalize_executor(item.get("executor")) or "all",
         "category": _normalize_category(item.get("category")),
         "rule": rule,
@@ -147,6 +225,14 @@ def _normalize_rule(item: object) -> dict | None:
         "rationale": _clean_str(item.get("rationale"), 300),
         "enforcement": enforcement,
     }
+    # Preserve structured template + params for AC 11 validation and AC 13
+    # template-aware routing. We deliberately keep the raw LLM values so
+    # the validator can reject ill-formed rules with a precise reason.
+    if "template" in item:
+        normalized["template"] = item.get("template")
+    if isinstance(item.get("params"), dict):
+        normalized["params"] = item.get("params")
+    return normalized
 
 
 def _normalize_analysis(analysis: object) -> dict:
@@ -414,6 +500,8 @@ The JSON must have this exact top-level shape:
   ],
   "prevention_rules": [
     {{
+      "template": "every_name_in_X_satisfies_Y|pattern_must_not_appear|co_modification_required|signature_lock|caller_count_required|import_constant_only|advisory",
+      "params": {{}},
       "executor": "backend-executor|ui-executor|db-executor|integration-executor|testing-executor|docs-executor|refactor-executor|ml-executor|all",
       "rule": "Specific preventive rule in imperative voice, max 100 chars",
       "category": "sec|cq|dc|perf|comp|ui|db|test|process|unknown",
@@ -441,6 +529,37 @@ The JSON must have this exact top-level shape:
   ],
   "hard_truth": "One sentence naming the biggest systemic weakness exposed by this task"
 }}
+
+## Prevention rule schema
+
+Each prevention_rules entry MUST use this structured format:
+{{
+  "template": "<one of: every_name_in_X_satisfies_Y | pattern_must_not_appear | co_modification_required | signature_lock | caller_count_required | import_constant_only | advisory>",
+  "params": {{...template-specific keys...}},
+  "rule": "<short human-readable rule text, max 100 chars>",
+  "executor": "<executor name or 'all'>",
+  "category": "sec|cq|dc|perf|comp|test|process|unknown",
+  "source_finding": "<finding ID or description>",
+  "rationale": "<why this rule prevents recurrence>",
+  "enforcement": "test|lint|static-check|runtime-guard|ci-gate|review-checklist|prompt-constraint"
+}}
+
+### Template params:
+- every_name_in_X_satisfies_Y: {{module: str, container: str, predicate: "callable"|"hasattr"|"in_registry"}}
+    Example: {{"template": "every_name_in_X_satisfies_Y", "params": {{"module": "hooks.lib_receipts", "container": "__all__", "predicate": "callable"}}, ...}}
+- pattern_must_not_appear: {{regex: str, scope: glob-str, context_required?: regex-str}}
+    Example: {{"template": "pattern_must_not_appear", "params": {{"regex": "time\\.time\\(\\)", "scope": "hooks/*.py"}}, ...}}
+- co_modification_required: {{trigger_glob: str, must_modify_glob: str}}
+    Example: {{"template": "co_modification_required", "params": {{"trigger_glob": "hooks/lib_*.py", "must_modify_glob": ".dynos/task-*/spec.md"}}, ...}}
+- signature_lock: {{module: str, function: str, expected_params: list[str]}}
+    Example: {{"template": "signature_lock", "params": {{"module": "hooks.lib_receipts", "function": "receipt_post_completion", "expected_params": ["task_dir", "handlers_run"]}}, ...}}
+- caller_count_required: {{symbol: str, scope: glob-str, min_count: int}}
+    Example: {{"template": "caller_count_required", "params": {{"symbol": "receipt_calibration_applied", "scope": "hooks/*.py", "min_count": 1}}, ...}}
+- import_constant_only: {{literal_pattern: regex-str, allowed_files: list[glob-str]}}
+    Example: {{"template": "import_constant_only", "params": {{"literal_pattern": "receipts/_injected-", "allowed_files": ["hooks/lib_receipts.py", "hooks/router.py"]}}, ...}}
+- advisory: {{}} (free-text rule; used when failure pattern is judgment-based)
+
+When the rule cannot be structurally expressed (e.g. "apply scrutiny for SEC-class issues"), you MUST emit `template: "advisory"` explicitly. NEVER omit the template field.
 
 Rules:
 - Every claim must be grounded in the provided task data.
@@ -502,6 +621,36 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
 
     # Extract and merge prevention rules
     new_rules = sanitized.get("prevention_rules", [])
+
+    # AC 11: schema-validate every LLM-authored rule against
+    # TEMPLATE_SCHEMAS. Rejected rules are NOT merged, are logged to
+    # stderr with the failing check, and tallied into the return dict
+    # so downstream callers (and tests) can assert on rejection counts.
+    #
+    # Why this lives BEFORE the lock: validation is pure / side-effect
+    # free aside from stderr; we want rejections visible regardless of
+    # whether the merge ultimately runs. The merge below operates only
+    # on the validated `new_rules` slice.
+    rejected_rules: list[dict] = []
+    accepted_rules: list[dict] = []
+    for rule in new_rules:
+        ok, reason = _validate_rule_schema(rule)
+        if ok:
+            accepted_rules.append(rule)
+        else:
+            template = rule.get("template") if isinstance(rule, dict) else None
+            print(
+                f"[postmortem_analysis] REJECT rule template={template} "
+                f"reason={reason}",
+                file=_sys.stderr,
+            )
+            rejected_rules.append({
+                "rule": rule,
+                "reason": reason,
+            })
+    new_rules = accepted_rules
+    rejected_count = len(rejected_rules)
+
     rules_path = persistent / "prevention-rules.json"
     if not new_rules:
         # Analysis was sanitized to zero usable rules — still emit the
@@ -515,7 +664,12 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
                 receipt_postmortem_analysis(task_dir, analysis_sha, 0, rules_sha_after)
         except (FileNotFoundError, OSError, ValueError) as exc:
             log_event(root, "postmortem_analysis_receipt_failed", task=task_id, error=str(exc))
-        return {"task_id": task_id, "rules_added": 0, "analysis_written": True}
+        return {
+            "task_id": task_id,
+            "rules_added": 0,
+            "analysis_written": True,
+            "rejected_count": rejected_count,
+        }
     # Lost-update protection: two processes (e.g., two worktrees, or one
     # task completing while another is mid-analysis) can both call
     # apply_analysis concurrently. write_json is atomic (tempfile + rename)
@@ -549,7 +703,7 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
                 text = rule.get("rule", "").strip()
                 if not text or text.lower() in existing_rule_texts:
                     continue
-                current_rules.append({
+                merged = {
                     "executor": rule.get("executor", "all"),
                     "category": rule.get("category", "unknown"),
                     "rule": text,
@@ -558,7 +712,14 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
                     "rationale": rule.get("rationale", ""),
                     "enforcement": rule.get("enforcement", "prompt-constraint"),
                     "added_at": now_iso(),
-                })
+                    # Persist the validated template + params so the
+                    # router (AC 13) can route enforced rules out of
+                    # the executor prompt and the rules engine (seg-1)
+                    # can compile them into runtime guards.
+                    "template": rule.get("template", "advisory"),
+                    "params": rule.get("params", {}) if isinstance(rule.get("params"), dict) else {},
+                }
+                current_rules.append(merged)
                 existing_rule_texts.add(text.lower())
                 added += 1
 
@@ -579,7 +740,12 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
     except (FileNotFoundError, OSError, ValueError) as exc:
         log_event(root, "postmortem_analysis_receipt_failed", task=task_id, error=str(exc))
 
-    return {"task_id": task_id, "rules_added": added, "analysis_written": True}
+    return {
+        "task_id": task_id,
+        "rules_added": added,
+        "analysis_written": True,
+        "rejected_count": rejected_count,
+    }
 
 
 def cmd_build_prompt(args: argparse.Namespace) -> int:

--- a/tests/test_gate_done.py
+++ b/tests/test_gate_done.py
@@ -15,6 +15,7 @@ from lib_receipts import (  # noqa: E402
     receipt_audit_done,
     receipt_postmortem_skipped,
     receipt_retrospective,
+    receipt_rules_check_passed,
     write_receipt,
 )
 
@@ -35,6 +36,9 @@ def _setup(tmp_path: Path) -> Path:
     (audit_dir / "report.json").write_text(json.dumps({"findings": []}))
     # The legacy DONE gate wants a `retrospective` receipt as well
     receipt_retrospective(td, 0.95, 0.9, 0.9, 1000)
+    # Task-005's new gate (CHECKPOINT_AUDIT->DONE) requires rules-check-passed
+    receipt_rules_check_passed(td, rules_evaluated=0, violations_count=0,
+                                error_violations=0, mode="all")
     return td
 
 

--- a/tests/test_inject_prompt_omits_enforced.py
+++ b/tests/test_inject_prompt_omits_enforced.py
@@ -1,0 +1,228 @@
+"""AC 25: build_executor_plan + inject-prompt CLI omit enforced rules
+unless --include-enforced is explicitly passed.
+
+Two tests:
+  (a) Build executor plan in-process with mixed advisory + enforced
+      rules. Assert the segment's `prevention_rules` text list contains
+      ONLY the advisory rules; assert prevention_rules_omitted equals
+      the enforced count.
+  (b) Drive `python3 hooks/router.py inject-prompt` as a subprocess
+      with the same mixed rules; without the flag the enforced rules
+      must be absent from stdout, with `--include-enforced` they must
+      reappear.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "hooks" / "router.py"
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from router import build_executor_plan  # noqa: E402
+
+
+def _persistent_dir(env_home: Path, project: Path) -> Path:
+    slug = str(project.resolve()).strip("/").replace("/", "-")
+    p = env_home / "projects" / slug
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _write_rules(persistent: Path, rules: list[dict]) -> Path:
+    rules_path = persistent / "prevention-rules.json"
+    rules_path.write_text(json.dumps({"rules": rules}))
+    return rules_path
+
+
+def _mixed_rules() -> list[dict]:
+    """Three advisory rules + two enforced (template != advisory).
+
+    The advisory rules cover both:
+      - explicit `template: "advisory"`
+      - missing template (legacy / pre-migration row) — backward-compat
+    """
+    return [
+        {
+            "executor": "backend-executor",
+            "rule": "ADVISORY one — be careful with concurrency",
+            "category": "process",
+            "enforcement": "review-checklist",
+            "template": "advisory",
+            "params": {},
+        },
+        {
+            "executor": "backend-executor",
+            "rule": "ADVISORY two — legacy rule with no template",
+            "category": "process",
+            "enforcement": "review-checklist",
+            # NOTE: no template key — backward-compat advisory.
+        },
+        {
+            "executor": "backend-executor",
+            "rule": "ADVISORY three — yet another advisory",
+            "category": "cq",
+            "enforcement": "prompt-constraint",
+            "template": "advisory",
+            "params": {},
+        },
+        {
+            "executor": "backend-executor",
+            "rule": "ENFORCED A — no time.time() in throttled paths",
+            "category": "cq",
+            "enforcement": "static-check",
+            "template": "pattern_must_not_appear",
+            "params": {"regex": r"\btime\.time\(\)", "scope": "hooks/*.py"},
+        },
+        {
+            "executor": "backend-executor",
+            "rule": "ENFORCED B — every name in __all__ must be callable",
+            "category": "cq",
+            "enforcement": "static-check",
+            "template": "every_name_in_X_satisfies_Y",
+            "params": {
+                "module": "hooks.lib_receipts",
+                "container": "__all__",
+                "predicate": "callable",
+            },
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (a) In-process build_executor_plan
+# ---------------------------------------------------------------------------
+
+
+def test_build_executor_plan_omits_enforced_by_default(tmp_path, monkeypatch):
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    project = tmp_path / "project"
+    (project / ".dynos").mkdir(parents=True)
+    monkeypatch.setenv("DYNOS_HOME", str(home))
+    persistent = _persistent_dir(home, project)
+    _write_rules(persistent, _mixed_rules())
+
+    plan = build_executor_plan(
+        project,
+        task_type="feature",
+        segments=[{"id": "s1", "executor": "backend-executor"}],
+    )
+    assert len(plan["segments"]) == 1
+    seg = plan["segments"][0]
+
+    # Default mode: advisory + missing-template kept; enforced omitted.
+    rules_text = seg["prevention_rules"]
+    advisory_count = sum(1 for r in rules_text if r.startswith("ADVISORY"))
+    enforced_count = sum(1 for r in rules_text if r.startswith("ENFORCED"))
+    assert advisory_count == 3, (
+        f"expected 3 advisory rules in injected prompt list, got "
+        f"{advisory_count}: {rules_text!r}"
+    )
+    assert enforced_count == 0, (
+        f"enforced rules MUST be omitted from prompt by default; got "
+        f"{enforced_count} in {rules_text!r}"
+    )
+    assert seg["prevention_rules_omitted"] == 2, (
+        f"prevention_rules_omitted must equal enforced-rule count (2); "
+        f"got {seg['prevention_rules_omitted']}"
+    )
+
+    # Sanity flip: with include_enforced=True, all 5 rules are present
+    # and prevention_rules_omitted is 0.
+    plan_all = build_executor_plan(
+        project,
+        task_type="feature",
+        segments=[{"id": "s1", "executor": "backend-executor"}],
+        include_enforced=True,
+    )
+    seg_all = plan_all["segments"][0]
+    assert len(seg_all["prevention_rules"]) == 5
+    assert seg_all["prevention_rules_omitted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# (b) CLI inject-prompt subprocess
+# ---------------------------------------------------------------------------
+
+
+def _run_inject_prompt(
+    *, project: Path, task_id: str, env_home: Path,
+    include_enforced: bool, base_prompt: str = "BASE EXECUTOR PROMPT",
+):
+    graph_path = project / ".dynos" / task_id / "execution-graph.json"
+    args = [
+        sys.executable, str(ROUTER), "inject-prompt",
+        "--root", str(project),
+        "--task-type", "feature",
+        "--graph", str(graph_path),
+        "--segment-id", "seg-A",
+    ]
+    if include_enforced:
+        args.append("--include-enforced")
+    env = {
+        **os.environ,
+        "DYNOS_HOME": str(env_home),
+        "PYTHONPATH": str(ROOT / "hooks"),
+    }
+    return subprocess.run(
+        args, input=base_prompt, text=True,
+        capture_output=True, check=False, env=env, cwd=str(ROOT),
+    )
+
+
+def test_inject_prompt_cli_default_omits_and_flag_includes(tmp_path):
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    project = tmp_path / "project"
+    task_id = "task-20260418-INJ"
+    task_dir = project / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    graph = {
+        "segments": [
+            {"id": "seg-A", "executor": "backend-executor"},
+        ]
+    }
+    (task_dir / "execution-graph.json").write_text(json.dumps(graph))
+
+    persistent = _persistent_dir(home, project)
+    _write_rules(persistent, _mixed_rules())
+
+    # Default: enforced rules MUST NOT appear in stdout.
+    r1 = _run_inject_prompt(
+        project=project, task_id=task_id, env_home=home,
+        include_enforced=False,
+    )
+    assert r1.returncode == 0, f"stderr={r1.stderr!r} stdout={r1.stdout!r}"
+    out1 = r1.stdout
+    # Advisory rules present; enforced absent.
+    assert "ADVISORY one" in out1
+    assert "ADVISORY two" in out1
+    assert "ADVISORY three" in out1
+    assert "ENFORCED A" not in out1, (
+        f"enforced rule leaked into default prompt: {out1!r}"
+    )
+    assert "ENFORCED B" not in out1
+
+    # With --include-enforced: every rule present.
+    r2 = _run_inject_prompt(
+        project=project, task_id=task_id, env_home=home,
+        include_enforced=True,
+    )
+    assert r2.returncode == 0, f"stderr={r2.stderr!r} stdout={r2.stdout!r}"
+    out2 = r2.stdout
+    assert "ADVISORY one" in out2
+    assert "ADVISORY two" in out2
+    assert "ADVISORY three" in out2
+    assert "ENFORCED A" in out2, (
+        f"--include-enforced must reintroduce enforced rules; got {out2!r}"
+    )
+    assert "ENFORCED B" in out2

--- a/tests/test_postmortem_schema_validation.py
+++ b/tests/test_postmortem_schema_validation.py
@@ -1,0 +1,200 @@
+"""AC 24: postmortem prevention-rule schema validation tests.
+
+Each test calls `apply_analysis(task_dir, analysis)` with a fixture
+analysis dict carrying a single prevention rule. We assert that:
+  - rules with malformed templates / params are REJECTED, not merged
+  - the returned dict's `rejected_count` correctly reflects rejections
+  - `template == "advisory"` is accepted regardless of params shape
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+sys.path.insert(0, str(ROOT / "memory"))
+
+import postmortem_analysis  # noqa: E402
+from postmortem_analysis import apply_analysis  # noqa: E402
+
+
+def _make_task_dir(tmp_path: Path, dynos_home: Path, *, task_id: str = "task-test") -> Path:
+    """Build the minimal directory shape apply_analysis expects.
+
+    `apply_analysis` derives the project root from `task_dir.parent.parent`,
+    then writes prevention-rules.json under
+    `_persistent_project_dir(root)`. We point DYNOS_HOME at *dynos_home*
+    so the persistent dir lands inside the test workspace.
+    """
+    project = tmp_path / "project"
+    task_dir = project / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "task-retrospective.json").write_text(
+        json.dumps({"task_id": task_id, "task_outcome": "done"})
+    )
+    return task_dir
+
+
+def _read_persisted_rules(dynos_home: Path, project: Path) -> list[dict]:
+    slug = str(project.resolve()).strip("/").replace("/", "-")
+    rules_path = dynos_home / "projects" / slug / "prevention-rules.json"
+    if not rules_path.exists():
+        return []
+    return json.loads(rules_path.read_text()).get("rules", [])
+
+
+def _analysis_with(rule: dict) -> dict:
+    return {
+        "summary": "fixture postmortem",
+        "root_causes": [
+            {
+                "finding_category": "cq",
+                "root_cause": "fixture root cause",
+                "immediate_cause": "fixture immediate cause",
+                "detection_failure": "fixture detection failure",
+                "affected_executor": "all",
+                "severity": "medium",
+                "evidence": ["fixture evidence"],
+            }
+        ],
+        "prevention_rules": [rule],
+        "repair_failures": [],
+        "model_suggestions": [],
+        "hard_truth": "fixture hard truth",
+    }
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(home))
+    return home
+
+
+# (a) Rule with template=every_name_in_X_satisfies_Y but missing predicate
+#     → rejected, NOT merged, rejected_count == 1.
+def test_missing_required_predicate_is_rejected(tmp_path, env, capsys):
+    task_dir = _make_task_dir(tmp_path, env)
+    project = task_dir.parent.parent
+    bad_rule = {
+        "rule": "every name in __all__ must be callable",
+        "executor": "backend-executor",
+        "category": "cq",
+        "source_finding": "F1",
+        "rationale": "prevent dead exports",
+        "enforcement": "static-check",
+        "template": "every_name_in_X_satisfies_Y",
+        "params": {
+            "module": "hooks.lib_receipts",
+            "container": "__all__",
+            # predicate omitted on purpose
+        },
+    }
+    result = apply_analysis(task_dir, _analysis_with(bad_rule))
+    assert result["rejected_count"] == 1, result
+    assert result["rules_added"] == 0, result
+    persisted = _read_persisted_rules(env, project)
+    assert persisted == [], f"rejected rule must NOT be merged; got {persisted!r}"
+    err = capsys.readouterr().err
+    assert "REJECT" in err
+    assert "every_name_in_X_satisfies_Y" in err
+
+
+# (b) Rule with template=no_such_template → rejected.
+def test_unknown_template_is_rejected(tmp_path, env, capsys):
+    task_dir = _make_task_dir(tmp_path, env)
+    project = task_dir.parent.parent
+    bad_rule = {
+        "rule": "this rule has a fictional template",
+        "executor": "backend-executor",
+        "category": "cq",
+        "source_finding": "F2",
+        "rationale": "should never be merged",
+        "enforcement": "prompt-constraint",
+        "template": "no_such_template",
+        "params": {},
+    }
+    result = apply_analysis(task_dir, _analysis_with(bad_rule))
+    assert result["rejected_count"] == 1
+    assert result["rules_added"] == 0
+    assert _read_persisted_rules(env, project) == []
+    err = capsys.readouterr().err
+    assert "REJECT" in err
+    assert "no_such_template" in err
+
+
+# (c) Valid rule → accepted and merged.
+def test_valid_rule_is_accepted_and_merged(tmp_path, env):
+    task_dir = _make_task_dir(tmp_path, env)
+    project = task_dir.parent.parent
+    good_rule = {
+        "rule": "do not call time.time() in throttled paths",
+        "executor": "backend-executor",
+        "category": "cq",
+        "source_finding": "F3",
+        "rationale": "monotonic clock required",
+        "enforcement": "static-check",
+        "template": "pattern_must_not_appear",
+        "params": {"regex": r"\btime\.time\(\)", "scope": "hooks/*.py"},
+    }
+    result = apply_analysis(task_dir, _analysis_with(good_rule))
+    assert result["rejected_count"] == 0
+    assert result["rules_added"] == 1
+    persisted = _read_persisted_rules(env, project)
+    assert len(persisted) == 1
+    p = persisted[0]
+    assert p["template"] == "pattern_must_not_appear"
+    assert p["params"]["regex"] == r"\btime\.time\(\)"
+    assert p["params"]["scope"] == "hooks/*.py"
+    assert p["rule"] == good_rule["rule"]
+
+
+# (d) Rule with template=advisory always accepted regardless of params shape.
+def test_advisory_rule_accepted_with_any_params_shape(tmp_path, env):
+    task_dir = _make_task_dir(tmp_path, env)
+    project = task_dir.parent.parent
+    # Empty params dict — accepted.
+    rule_a = {
+        "rule": "be more careful around CPU-bound work",
+        "executor": "all",
+        "category": "process",
+        "source_finding": "F4a",
+        "rationale": "process-level reminder",
+        "enforcement": "review-checklist",
+        "template": "advisory",
+        "params": {},
+    }
+    r1 = apply_analysis(task_dir, _analysis_with(rule_a))
+    assert r1["rejected_count"] == 0
+    assert r1["rules_added"] == 1
+    persisted = _read_persisted_rules(env, project)
+    assert len(persisted) == 1
+    assert persisted[0]["template"] == "advisory"
+
+    # Now add a SECOND advisory rule with wholly arbitrary keys in params.
+    # Advisory has no required keys; arbitrary params must not cause
+    # rejection.
+    rule_b = {
+        "rule": "review db migrations against rollback plan",
+        "executor": "db-executor",
+        "category": "db",
+        "source_finding": "F4b",
+        "rationale": "process-level db reminder",
+        "enforcement": "review-checklist",
+        "template": "advisory",
+        "params": {"freeform_note": "ad hoc bag", "complexity": 9000},
+    }
+    r2 = apply_analysis(task_dir, _analysis_with(rule_b))
+    assert r2["rejected_count"] == 0
+    assert r2["rules_added"] == 1
+    persisted = _read_persisted_rules(env, project)
+    assert len(persisted) == 2
+    assert {p["template"] for p in persisted} == {"advisory"}

--- a/tests/test_pre_commit_install.py
+++ b/tests/test_pre_commit_install.py
@@ -1,0 +1,232 @@
+"""AC 26: rules_engine install-hook CLI behaviour and bash-runnability.
+
+Five tests:
+  (a) Fresh git repo + no hook → install-hook writes
+      .git/hooks/pre-commit with mode 0o755 and the dynos marker.
+  (b) Re-running install-hook in the same repo is idempotent (exit 0).
+  (c) Pre-existing non-dynos hook + no --force → exit 1 refusal,
+      original hook bytes preserved.
+  (d) --force overwrites a pre-existing non-dynos hook.
+  (e) Running the installed hook (bash) against a staged-violation
+      tmp repo exits non-zero (the engine reports >= 1 error).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / "hooks" / "rules_engine.py"
+DYNOS_HOOKS_DIR = ROOT / "hooks"
+
+HOOK_MARKER = "# dynos-rules-engine v1"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    # Make commits possible without a globally-set user.
+    _git(repo, "config", "user.email", "tester@example.invalid")
+    _git(repo, "config", "user.name", "Tester")
+    return repo
+
+
+def _run_install(repo: Path, *, force: bool = False) -> subprocess.CompletedProcess:
+    args = [sys.executable, str(ENGINE), "install-hook"]
+    if force:
+        args.append("--force")
+    env = {**os.environ, "PYTHONPATH": str(DYNOS_HOOKS_DIR)}
+    # The CLI uses Path.cwd() to discover the repo, so cwd MUST be inside
+    # the tmp repo.
+    return subprocess.run(
+        args, cwd=str(repo), capture_output=True, text=True,
+        check=False, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Fresh install
+# ---------------------------------------------------------------------------
+
+
+def test_install_hook_writes_executable_marker_file(tmp_path):
+    repo = _init_repo(tmp_path)
+    r = _run_install(repo)
+    assert r.returncode == 0, f"stderr={r.stderr!r}"
+    hook_path = repo / ".git" / "hooks" / "pre-commit"
+    assert hook_path.exists(), "pre-commit hook must be written"
+    content = hook_path.read_text()
+    assert HOOK_MARKER in content, (
+        f"hook content must include marker {HOOK_MARKER!r}; got: {content!r}"
+    )
+    mode = hook_path.stat().st_mode & 0o777
+    assert mode == 0o755, f"hook mode must be 0o755, got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# (b) Idempotent re-run
+# ---------------------------------------------------------------------------
+
+
+def test_install_hook_is_idempotent(tmp_path):
+    repo = _init_repo(tmp_path)
+    r1 = _run_install(repo)
+    assert r1.returncode == 0
+    hook_path = repo / ".git" / "hooks" / "pre-commit"
+    bytes1 = hook_path.read_bytes()
+
+    r2 = _run_install(repo)
+    assert r2.returncode == 0, f"second install must exit 0; stderr={r2.stderr!r}"
+    bytes2 = hook_path.read_bytes()
+    assert bytes2 == bytes1, "idempotent re-run must NOT alter hook bytes"
+
+
+# ---------------------------------------------------------------------------
+# (c) Refuse to overwrite non-dynos hook without --force
+# ---------------------------------------------------------------------------
+
+
+def test_install_hook_refuses_existing_non_dynos_hook(tmp_path):
+    repo = _init_repo(tmp_path)
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / "pre-commit"
+    foreign_body = "#!/usr/bin/env bash\necho 'foreign hook'\nexit 0\n"
+    hook_path.write_text(foreign_body)
+    hook_path.chmod(0o755)
+
+    r = _run_install(repo)
+    assert r.returncode == 1, (
+        f"refusal must exit 1, got {r.returncode}; stderr={r.stderr!r}"
+    )
+    # Original bytes preserved.
+    assert hook_path.read_text() == foreign_body, (
+        "refusal path must NOT clobber the existing foreign hook"
+    )
+    assert "refusal" in r.stderr.lower() or "force" in r.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# (d) --force overwrites
+# ---------------------------------------------------------------------------
+
+
+def test_install_hook_force_overwrites_non_dynos_hook(tmp_path):
+    repo = _init_repo(tmp_path)
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / "pre-commit"
+    foreign = "#!/usr/bin/env bash\necho 'foreign hook'\nexit 0\n"
+    hook_path.write_text(foreign)
+    hook_path.chmod(0o755)
+
+    r = _run_install(repo, force=True)
+    assert r.returncode == 0, f"--force must succeed; stderr={r.stderr!r}"
+    new_content = hook_path.read_text()
+    assert HOOK_MARKER in new_content, (
+        "--force must replace foreign hook with dynos hook (marker present)"
+    )
+    assert "foreign hook" not in new_content, (
+        "foreign hook content must be gone after --force"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) Running the installed hook against a staged-violation repo
+# ---------------------------------------------------------------------------
+
+
+def test_installed_hook_fails_on_staged_violation(tmp_path):
+    """The installed hook script invokes the rules engine via
+    `git rev-parse --show-toplevel`. We make that resolve into a
+    workspace whose `hooks/rules_engine.py` is the real engine and
+    whose persistent rules dir contains a single `pattern_must_not_appear`
+    rule — then we stage a Python file containing the forbidden literal
+    and confirm the hook exits non-zero."""
+    workspace = tmp_path / "violation_repo"
+    workspace.mkdir()
+    # Symlink the real hooks/ directory into the workspace so the
+    # installed hook (`exec python3 .../hooks/rules_engine.py ...`)
+    # finds the engine.
+    (workspace / "hooks").symlink_to(DYNOS_HOOKS_DIR)
+
+    _git(workspace, "init", "--quiet")
+    _git(workspace, "config", "user.email", "tester@example.invalid")
+    _git(workspace, "config", "user.name", "Tester")
+
+    # Set up persistent rules dir under a tmp DYNOS_HOME. The persistent
+    # dir slug is derived from the repo's main worktree path; the
+    # engine derives that via `git rev-parse --git-common-dir`.
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    slug = str(workspace.resolve()).strip("/").replace("/", "-")
+    persistent = home / "projects" / slug
+    persistent.mkdir(parents=True, exist_ok=True)
+    rules = {
+        "rules": [
+            {
+                "rule_id": "r-no-bad-literal",
+                "template": "pattern_must_not_appear",
+                "params": {
+                    "regex": r"FORBIDDEN_LITERAL_TOKEN_XYZ",
+                    "scope": "*.py",
+                },
+                "severity": "error",
+            }
+        ]
+    }
+    (persistent / "prevention-rules.json").write_text(json.dumps(rules))
+
+    # Install the hook (cwd inside the workspace).
+    r_install = subprocess.run(
+        [sys.executable, str(ENGINE), "install-hook"],
+        cwd=str(workspace), capture_output=True, text=True,
+        env={**os.environ, "PYTHONPATH": str(DYNOS_HOOKS_DIR), "DYNOS_HOME": str(home)},
+        check=False,
+    )
+    assert r_install.returncode == 0, (
+        f"install-hook setup failed; stderr={r_install.stderr!r}"
+    )
+    hook_path = workspace / ".git" / "hooks" / "pre-commit"
+    assert hook_path.exists()
+
+    # Stage a violating file.
+    bad_file = workspace / "naughty.py"
+    bad_file.write_text("X = 'FORBIDDEN_LITERAL_TOKEN_XYZ'\n")
+    _git(workspace, "add", "naughty.py")
+
+    # Run the hook directly with bash. The hook execs python3 with the
+    # repo-discovered engine path; we pass DYNOS_HOME so the engine
+    # finds the persistent rules.
+    r_hook = subprocess.run(
+        ["bash", str(hook_path)],
+        cwd=str(workspace), capture_output=True, text=True,
+        env={**os.environ, "DYNOS_HOME": str(home), "PYTHONPATH": str(DYNOS_HOOKS_DIR)},
+        check=False,
+    )
+    assert r_hook.returncode != 0, (
+        f"hook must fail when staged violation exists; "
+        f"got returncode={r_hook.returncode}, stdout={r_hook.stdout!r}, "
+        f"stderr={r_hook.stderr!r}"
+    )
+    # Sanity: confirm the violation was reported by the engine.
+    assert "r-no-bad-literal" in (r_hook.stdout + r_hook.stderr), (
+        f"engine output must mention the violating rule_id; "
+        f"stdout={r_hook.stdout!r} stderr={r_hook.stderr!r}"
+    )

--- a/tests/test_rmw_concurrency.py
+++ b/tests/test_rmw_concurrency.py
@@ -45,6 +45,8 @@ def _worker_apply_analysis(task_dir_str: str, rule_text: str, delay: float = 0.0
             "source_finding": f"finding-for-{rule_text}",
             "rationale": "test",
             "enforcement": "prompt-constraint",
+            "template": "advisory",
+            "params": {},
         }],
     })
 
@@ -67,11 +69,13 @@ class TestPreventionRulesLock:
         from postmortem_analysis import apply_analysis
         apply_analysis(task_dir, {"summary": "t", "prevention_rules": [
             {"executor": "all", "category": "sec", "rule": "rule-A",
-             "source_finding": "f-A", "rationale": "r", "enforcement": "prompt-constraint"}
+             "source_finding": "f-A", "rationale": "r", "enforcement": "prompt-constraint",
+             "template": "advisory", "params": {}}
         ]})
         apply_analysis(task_dir, {"summary": "t", "prevention_rules": [
             {"executor": "all", "category": "sec", "rule": "rule-B",
-             "source_finding": "f-B", "rationale": "r", "enforcement": "prompt-constraint"}
+             "source_finding": "f-B", "rationale": "r", "enforcement": "prompt-constraint",
+             "template": "advisory", "params": {}}
         ]})
         # Find the rules file
         from lib_core import _persistent_project_dir

--- a/tests/test_rules_engine_dispatch.py
+++ b/tests/test_rules_engine_dispatch.py
@@ -1,0 +1,174 @@
+"""AC 22: rules-engine dispatcher integration test.
+
+Builds a synthetic prevention-rules.json with one rule per template
+(seven entries — six enforced + one advisory) and asserts that
+`run_checks` dispatches each rule exactly once and produces violations
+of the expected shape and count.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import rules_engine  # noqa: E402
+from rules_engine import run_checks  # noqa: E402
+
+
+def _project_modules(workspace: Path) -> None:
+    """Create importable Python packages used by enforced rules."""
+    pkg = workspace / "fix_dispatch_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    # every_name_in_X_satisfies_Y target — has a non-callable in __all__.
+    (pkg / "names.py").write_text(
+        "def alpha():\n    pass\n"
+        "BETA = 'not-a-callable'\n"
+        "__all__ = ['alpha', 'BETA']\n"
+    )
+    # signature_lock target — wrong signature for r-sig.
+    (pkg / "sig.py").write_text(
+        "def my_fn(only_one):\n    return None\n"
+    )
+
+
+def _project_files(workspace: Path) -> None:
+    """Create files that template handlers will scan during run_checks."""
+    # pattern_must_not_appear target — file with bad pattern.
+    (workspace / "uses_time.py").write_text(
+        "import time\n"
+        "def now():\n"
+        "    return time.time()\n"
+    )
+    # caller_count_required: target symbol called only once but rule
+    # demands min_count >= 5.
+    (workspace / "callers.py").write_text(
+        "def x():\n    foo()\n"
+    )
+    # import_constant_only target — literal in disallowed file.
+    (workspace / "leaks_literal.py").write_text(
+        "x = 'receipts/_injected-prompt'\n"
+    )
+    # co_modification_required target — staged trigger without companion.
+    (workspace / "lib_alpha.py").write_text("# trigger\n")
+
+
+def test_run_checks_dispatches_all_templates_once(tmp_path, monkeypatch, capsys):
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _project_modules(workspace)
+    _project_files(workspace)
+
+    monkeypatch.syspath_prepend(str(workspace))
+
+    rules_dir = tmp_path / "persistent"
+    rules_dir.mkdir()
+    rules = {
+        "rules": [
+            {
+                "rule_id": "r-every",
+                "template": "every_name_in_X_satisfies_Y",
+                "params": {
+                    "module": "fix_dispatch_pkg.names",
+                    "container": "__all__",
+                    "predicate": "callable",
+                },
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-pat",
+                "template": "pattern_must_not_appear",
+                "params": {"regex": r"\btime\.time\(\)", "scope": "*.py"},
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-co",
+                "template": "co_modification_required",
+                "params": {
+                    "trigger_glob": "lib_*.py",
+                    "must_modify_glob": "*.md",
+                },
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-sig",
+                "template": "signature_lock",
+                "params": {
+                    "module": "fix_dispatch_pkg.sig",
+                    "function": "my_fn",
+                    "expected_params": ["a", "b"],
+                },
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-call",
+                "template": "caller_count_required",
+                "params": {"symbol": "foo", "scope": "*.py", "min_count": 5},
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-ico",
+                "template": "import_constant_only",
+                "params": {
+                    "literal_pattern": r"receipts/_injected-prompt",
+                    "allowed_files": ["lib_constants.py"],
+                },
+                "severity": "error",
+            },
+            {
+                "rule_id": "r-adv",
+                "template": "advisory",
+                "params": {},
+                "severity": "warn",
+            },
+        ]
+    }
+    (rules_dir / "prevention-rules.json").write_text(json.dumps(rules))
+
+    # Point _persistent_project_dir at our rules dir for any root. The
+    # engine imported the symbol into its OWN module namespace, so we
+    # must patch the engine's reference, not lib_core's.
+    monkeypatch.setattr(
+        rules_engine, "_persistent_project_dir", lambda root: rules_dir
+    )
+
+    violations = run_checks(workspace, "all")
+
+    # Advisory contributes 0; co_modification_required is no-op in --all
+    # mode and contributes 0. The other five contribute exactly 1 each
+    # (each rule is constructed to produce exactly one violation against
+    # the fixtures).
+    assert len(violations) == 5, (
+        f"expected 5 violations from 5 enforced rules in --all mode, got "
+        f"{len(violations)}: {[(v.rule_id, v.message) for v in violations]}"
+    )
+
+    # Every violation has the rule_id of one of the enforced templates.
+    seen = {v.rule_id for v in violations}
+    assert seen == {"r-every", "r-pat", "r-sig", "r-call", "r-ico"}, (
+        f"unexpected rule_id set in violations: {sorted(seen)!r}"
+    )
+
+    # Sorted determinism guarantee (file, line, rule_id).
+    keys = [(v.file, v.line, v.rule_id) for v in violations]
+    assert keys == sorted(keys), (
+        f"violations not sorted by (file, line, rule_id): {keys!r}"
+    )
+
+    # Each violation has the contract shape from to_dict.
+    for v in violations:
+        d = v.to_dict()
+        for key in ("rule_id", "template", "file", "line", "message", "severity"):
+            assert key in d, f"violation dict missing {key!r}: {d!r}"
+        assert isinstance(d["line"], int)
+        assert d["severity"] in ("error", "warn")
+
+    # The advisory rule is silently a no-op (no stderr WARN/INFO about
+    # template name, no violation emitted under r-adv).
+    err = capsys.readouterr().err
+    assert "unknown template" not in err

--- a/tests/test_rules_engine_self_proof.py
+++ b/tests/test_rules_engine_self_proof.py
@@ -1,0 +1,70 @@
+"""AC 23: rules-engine self-proof integration test.
+
+Runs `run_checks(repo_root, "all")` against the actual dynos-work
+checkout and asserts:
+  - error_violations == 0  (the live tree complies with its own rules)
+  - elapsed < 2.0 seconds  (engine stays inside the perf budget)
+
+Marked `@pytest.mark.integration`. Auto-skipped unless either:
+  - the env var RUN_INTEGRATION=1 is set, or
+  - pytest is invoked with `-m integration`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from rules_engine import run_checks  # noqa: E402
+
+
+def _integration_requested(config) -> bool:
+    """Detect whether the user actually asked for integration tests.
+
+    Two channels:
+      1. RUN_INTEGRATION=1 environment variable.
+      2. The pytest invocation includes `-m integration` (or any marker
+         expression that selects the `integration` mark).
+    """
+    if os.environ.get("RUN_INTEGRATION") == "1":
+        return True
+    markexpr = ""
+    try:
+        markexpr = config.getoption("-m") or ""
+    except Exception:
+        markexpr = ""
+    return "integration" in markexpr
+
+
+@pytest.fixture(autouse=True)
+def _skip_unless_integration_requested(request):
+    if not _integration_requested(request.config):
+        pytest.skip(
+            "integration: set RUN_INTEGRATION=1 or pass `-m integration` to run"
+        )
+
+
+@pytest.mark.integration
+def test_self_proof_repo_passes_rules_within_budget():
+    repo_root = ROOT
+    start = time.perf_counter()
+    violations = run_checks(repo_root, "all")
+    elapsed = time.perf_counter() - start
+
+    error_violations = [v for v in violations if v.severity == "error"]
+    assert error_violations == [], (
+        f"self-proof: expected zero error-severity violations against the "
+        f"live tree, got {len(error_violations)}: "
+        f"{[(v.rule_id, v.file, v.line, v.message) for v in error_violations]}"
+    )
+    assert elapsed < 2.0, (
+        f"self-proof: run_checks took {elapsed:.3f}s, exceeds 2.0s budget"
+    )

--- a/tests/test_rules_engine_templates.py
+++ b/tests/test_rules_engine_templates.py
@@ -1,0 +1,511 @@
+"""AC 21: tests for each of the six rules-engine template handlers.
+
+Coverage requirement: every template needs happy + violation + at least
+one edge case. We construct minimal Python module fixtures + rules.json
+under tmp_path and invoke the template handler functions directly.
+
+We exercise:
+- every_name_in_X_satisfies_Y: happy + violation + import-failure-warn-and-skip
+- pattern_must_not_appear: happy + violation + context_required filtering
+                           + syntax-error-warn-and-skip
+- co_modification_required: happy + violation + mode="all" returns []
+- signature_lock: happy + violation + import-failure warn-and-skip
+- caller_count_required: happy + violation + sum-across-files
+- import_constant_only: happy + violation + allowed_files glob exclusion
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from rules_engine import (  # noqa: E402
+    Rule,
+    ScanScope,
+    check_caller_count_required,
+    check_co_modification_required,
+    check_every_name_in_X_satisfies_Y,
+    check_import_constant_only,
+    check_pattern_must_not_appear,
+    check_signature_lock,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scope(root: Path, files: list[Path], mode: str = "all") -> ScanScope:
+    return ScanScope(root=root.resolve(), files=tuple(sorted(files)), mode=mode)
+
+
+def _isolate_module_path(monkeypatch, mod_dir: Path) -> None:
+    """Insert *mod_dir* at sys.path[0] for the duration of the test."""
+    monkeypatch.syspath_prepend(str(mod_dir))
+
+
+# ---------------------------------------------------------------------------
+# every_name_in_X_satisfies_Y (3 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_every_name_in_X_satisfies_Y_happy_callable(tmp_path, monkeypatch):
+    pkg = tmp_path / "fix_pkg_a"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "good_mod.py").write_text(
+        "def alpha():\n    pass\n"
+        "def beta():\n    pass\n"
+        "__all__ = ['alpha', 'beta']\n"
+    )
+    _isolate_module_path(monkeypatch, tmp_path)
+    rule = Rule(
+        rule_id="r-good",
+        template="every_name_in_X_satisfies_Y",
+        params={
+            "module": "fix_pkg_a.good_mod",
+            "container": "__all__",
+            "predicate": "callable",
+        },
+    )
+    scope = _make_scope(tmp_path, [])
+    out = check_every_name_in_X_satisfies_Y(rule, scope)
+    assert out == [], (
+        "happy path: every name in __all__ resolves to a callable; "
+        "expected zero violations"
+    )
+
+
+def test_every_name_in_X_satisfies_Y_violation_non_callable(tmp_path, monkeypatch):
+    pkg = tmp_path / "fix_pkg_b"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "bad_mod.py").write_text(
+        "def alpha():\n    pass\n"
+        "BETA = 'not-a-callable'\n"
+        "__all__ = ['alpha', 'BETA']\n"
+    )
+    _isolate_module_path(monkeypatch, tmp_path)
+    rule = Rule(
+        rule_id="r-bad",
+        template="every_name_in_X_satisfies_Y",
+        params={
+            "module": "fix_pkg_b.bad_mod",
+            "container": "__all__",
+            "predicate": "callable",
+        },
+    )
+    out = check_every_name_in_X_satisfies_Y(rule, _make_scope(tmp_path, []))
+    assert len(out) == 1, f"expected 1 violation for non-callable BETA, got {out!r}"
+    v = out[0]
+    assert v.rule_id == "r-bad"
+    assert v.template == "every_name_in_X_satisfies_Y"
+    assert "'BETA'" in v.message
+    assert "fix_pkg_b.bad_mod.__all__" in v.message
+    assert v.severity == "error"
+
+
+def test_every_name_in_X_satisfies_Y_import_failure_warns_and_skips(
+    tmp_path, monkeypatch, capsys
+):
+    # Module that does not exist on sys.path. Importer must warn-and-skip,
+    # not raise, and return [].
+    rule = Rule(
+        rule_id="r-missing",
+        template="every_name_in_X_satisfies_Y",
+        params={
+            "module": "nonexistent_pkg_xyz_12345.deeply_buried",
+            "container": "__all__",
+            "predicate": "callable",
+        },
+    )
+    out = check_every_name_in_X_satisfies_Y(rule, _make_scope(tmp_path, []))
+    assert out == [], "import failure must produce no violations"
+    err = capsys.readouterr().err
+    assert "WARN" in err
+    assert "r-missing" in err
+    assert "nonexistent_pkg_xyz_12345.deeply_buried" in err
+
+
+# ---------------------------------------------------------------------------
+# pattern_must_not_appear (4 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_must_not_appear_happy_no_match(tmp_path):
+    f = tmp_path / "clean.py"
+    f.write_text("def foo():\n    return 1\n")
+    rule = Rule(
+        rule_id="r-pat-clean",
+        template="pattern_must_not_appear",
+        params={"regex": r"\btime\.time\(\)", "scope": "*.py"},
+    )
+    out = check_pattern_must_not_appear(rule, _make_scope(tmp_path, [f]))
+    assert out == [], "happy path: regex does not match → zero violations"
+
+
+def test_pattern_must_not_appear_violation(tmp_path):
+    f = tmp_path / "dirty.py"
+    f.write_text("import time\n\ndef now():\n    return time.time()\n")
+    rule = Rule(
+        rule_id="r-pat-dirty",
+        template="pattern_must_not_appear",
+        params={"regex": r"\btime\.time\(\)", "scope": "*.py"},
+    )
+    out = check_pattern_must_not_appear(rule, _make_scope(tmp_path, [f]))
+    assert len(out) == 1, f"expected exactly 1 violation, got {out!r}"
+    v = out[0]
+    assert v.rule_id == "r-pat-dirty"
+    assert v.line == 4
+    assert "time.time()" in v.message
+    assert v.file == "dirty.py"
+
+
+def test_pattern_must_not_appear_context_required_filters(tmp_path):
+    """When `context_required` is set, only matches whose smallest
+    enclosing AST node (by line containment) unparses to source that
+    matches the context regex are reported. The smallest-enclosing
+    node here is a function-def or expression that spans the match
+    line — we put the context on the same line as the match so the
+    enclosing single-line node carries the context."""
+    f = tmp_path / "mixed.py"
+    # Two single-line statements at module scope. The second one's
+    # smallest enclosing node spans both `lock_acquire()` and
+    # `time.time()`, so unparsing it yields the context.
+    f.write_text(
+        "x = time.time()\n"
+        "y = (lock_acquire(), time.time())\n"
+    )
+    rule = Rule(
+        rule_id="r-pat-ctx",
+        template="pattern_must_not_appear",
+        params={
+            "regex": r"\btime\.time\(\)",
+            "scope": "*.py",
+            "context_required": r"lock_acquire",
+        },
+    )
+    out = check_pattern_must_not_appear(rule, _make_scope(tmp_path, [f]))
+    assert len(out) == 1, (
+        f"context filter should keep only the lock-context match, got {out!r}"
+    )
+    v = out[0]
+    assert v.line == 2, f"expected line 2 (lock_acquire context), got {v.line}"
+
+
+def test_pattern_must_not_appear_syntax_error_warns_and_skips(tmp_path, capsys):
+    """When `context_required` is set and the file has a SyntaxError,
+    the handler must emit a stderr WARN and produce no violation
+    rather than raising."""
+    f = tmp_path / "broken.py"
+    f.write_text("def broken(:\n    return time.time()\n")
+    rule = Rule(
+        rule_id="r-pat-broken",
+        template="pattern_must_not_appear",
+        params={
+            "regex": r"\btime\.time\(\)",
+            "scope": "*.py",
+            "context_required": r"broken",
+        },
+    )
+    out = check_pattern_must_not_appear(rule, _make_scope(tmp_path, [f]))
+    assert out == [], "syntax error must produce no violations"
+    err = capsys.readouterr().err
+    assert "WARN" in err
+    assert "r-pat-broken" in err
+
+
+# ---------------------------------------------------------------------------
+# co_modification_required (3 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_co_modification_required_happy_when_both_modified(tmp_path):
+    trig = tmp_path / "lib_thing.py"
+    trig.write_text("# trigger\n")
+    accomp = tmp_path / "spec.md"
+    accomp.write_text("# spec\n")
+    rule = Rule(
+        rule_id="r-co-ok",
+        template="co_modification_required",
+        params={
+            "trigger_glob": "lib_*.py",
+            "must_modify_glob": "*.md",
+        },
+    )
+    out = check_co_modification_required(
+        rule, _make_scope(tmp_path, [trig, accomp], mode="staged")
+    )
+    assert out == [], "trigger AND accompanying file present → no violation"
+
+
+def test_co_modification_required_violation_when_only_trigger_modified(tmp_path):
+    trig = tmp_path / "lib_alpha.py"
+    trig.write_text("# trigger\n")
+    irrelevant = tmp_path / "README.txt"
+    irrelevant.write_text("hi\n")
+    rule = Rule(
+        rule_id="r-co-violate",
+        template="co_modification_required",
+        params={
+            "trigger_glob": "lib_*.py",
+            "must_modify_glob": "*.md",
+        },
+    )
+    out = check_co_modification_required(
+        rule, _make_scope(tmp_path, [trig, irrelevant], mode="staged")
+    )
+    assert len(out) == 1, f"trigger present but no *.md → expected 1 violation, got {out!r}"
+    v = out[0]
+    assert v.rule_id == "r-co-violate"
+    assert v.line == 0
+    assert "lib_alpha.py" in v.file
+    assert "*.md" in v.message
+
+
+def test_co_modification_required_returns_empty_in_all_mode(tmp_path, capsys):
+    trig = tmp_path / "lib_beta.py"
+    trig.write_text("# trigger\n")
+    rule = Rule(
+        rule_id="r-co-all",
+        template="co_modification_required",
+        params={
+            "trigger_glob": "lib_*.py",
+            "must_modify_glob": "*.md",
+        },
+    )
+    # mode="all": handler must short-circuit and return [] regardless of
+    # what files exist.
+    out = check_co_modification_required(
+        rule, _make_scope(tmp_path, [trig], mode="all")
+    )
+    assert out == [], (
+        "co_modification_required must be a no-op in --all mode "
+        "(staged-only template)"
+    )
+    err = capsys.readouterr().err
+    assert "INFO" in err and "r-co-all" in err
+
+
+# ---------------------------------------------------------------------------
+# signature_lock (3 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_signature_lock_happy(tmp_path, monkeypatch):
+    pkg = tmp_path / "fix_pkg_sig"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "mod.py").write_text(
+        "def my_fn(alpha, beta, gamma):\n    return None\n"
+    )
+    _isolate_module_path(monkeypatch, tmp_path)
+    rule = Rule(
+        rule_id="r-sig-ok",
+        template="signature_lock",
+        params={
+            "module": "fix_pkg_sig.mod",
+            "function": "my_fn",
+            "expected_params": ["alpha", "beta", "gamma"],
+        },
+    )
+    out = check_signature_lock(rule, _make_scope(tmp_path, []))
+    assert out == [], f"signature matches expected; got violations {out!r}"
+
+
+def test_signature_lock_violation_wrong_params(tmp_path, monkeypatch):
+    pkg = tmp_path / "fix_pkg_sig2"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "mod.py").write_text(
+        "def my_fn(alpha, beta):\n    return None\n"
+    )
+    _isolate_module_path(monkeypatch, tmp_path)
+    rule = Rule(
+        rule_id="r-sig-bad",
+        template="signature_lock",
+        params={
+            "module": "fix_pkg_sig2.mod",
+            "function": "my_fn",
+            "expected_params": ["alpha", "beta", "gamma"],
+        },
+    )
+    out = check_signature_lock(rule, _make_scope(tmp_path, []))
+    assert len(out) == 1, f"expected 1 violation, got {out!r}"
+    v = out[0]
+    assert v.rule_id == "r-sig-bad"
+    assert "['alpha', 'beta']" in v.message
+    assert "['alpha', 'beta', 'gamma']" in v.message
+
+
+def test_signature_lock_import_failure_warns_and_skips(tmp_path, capsys):
+    rule = Rule(
+        rule_id="r-sig-noimp",
+        template="signature_lock",
+        params={
+            "module": "missing_pkg_zzz_98765.totally_absent",
+            "function": "fn",
+            "expected_params": ["a"],
+        },
+    )
+    out = check_signature_lock(rule, _make_scope(tmp_path, []))
+    assert out == [], "import failure must produce no violations"
+    err = capsys.readouterr().err
+    assert "WARN" in err
+    assert "r-sig-noimp" in err
+    assert "missing_pkg_zzz_98765" in err
+
+
+# ---------------------------------------------------------------------------
+# caller_count_required (3 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_caller_count_required_happy_meets_min(tmp_path):
+    f = tmp_path / "uses.py"
+    f.write_text(
+        "def x():\n"
+        "    foo()\n"
+        "    foo()\n"
+    )
+    rule = Rule(
+        rule_id="r-call-ok",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 2},
+    )
+    out = check_caller_count_required(rule, _make_scope(tmp_path, [f]))
+    assert out == [], "2 calls meets min_count=2 → no violation"
+
+
+def test_caller_count_required_violation_below_min(tmp_path):
+    f = tmp_path / "uses.py"
+    f.write_text("def x():\n    foo()\n")
+    rule = Rule(
+        rule_id="r-call-low",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 3},
+    )
+    out = check_caller_count_required(rule, _make_scope(tmp_path, [f]))
+    assert len(out) == 1, f"1 call < min_count=3 → expected 1 violation, got {out!r}"
+    v = out[0]
+    assert v.file == "(repo-wide)"
+    assert v.line == 0
+    assert "1 time" in v.message or "1 time(s)" in v.message
+    assert ">= 3" in v.message
+
+
+def test_caller_count_required_sums_across_files(tmp_path):
+    a = tmp_path / "a.py"
+    a.write_text("def _():\n    foo()\n    obj.foo()\n")
+    b = tmp_path / "b.py"
+    b.write_text("def _():\n    foo()\n")
+    rule = Rule(
+        rule_id="r-call-sum",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 3},
+    )
+    out = check_caller_count_required(rule, _make_scope(tmp_path, [a, b]))
+    # 3 total calls (2 in a.py via Name + Attribute, 1 in b.py).
+    assert out == [], (
+        f"3 calls summed across both files meets min_count=3; got {out!r}"
+    )
+
+    # Now bump the threshold so the SAME files now violate — proves the
+    # sum is what's being compared, not just "is symbol present in some
+    # single file".
+    rule_high = Rule(
+        rule_id="r-call-sum-fail",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 4},
+    )
+    out2 = check_caller_count_required(rule_high, _make_scope(tmp_path, [a, b]))
+    assert len(out2) == 1
+    assert "3 time" in out2[0].message
+
+
+# ---------------------------------------------------------------------------
+# import_constant_only (3 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_import_constant_only_happy_only_in_allowed_file(tmp_path):
+    allowed = tmp_path / "lib_constants.py"
+    allowed.write_text(
+        "RECEIPT_NAME = 'receipts/_injected-prompt'\n"
+    )
+    other = tmp_path / "consumer.py"
+    other.write_text(
+        "from lib_constants import RECEIPT_NAME\n"
+        "def use():\n    return RECEIPT_NAME\n"
+    )
+    rule = Rule(
+        rule_id="r-ico-ok",
+        template="import_constant_only",
+        params={
+            "literal_pattern": r"receipts/_injected-prompt",
+            "allowed_files": ["lib_constants.py"],
+        },
+    )
+    out = check_import_constant_only(
+        rule, _make_scope(tmp_path, [allowed, other])
+    )
+    assert out == [], (
+        "literal only appears in the allowed file → no violation "
+        f"(got {out!r})"
+    )
+
+
+def test_import_constant_only_violation_in_disallowed_file(tmp_path):
+    allowed = tmp_path / "lib_constants.py"
+    allowed.write_text("RECEIPT_NAME = 'receipts/_injected-prompt'\n")
+    bad = tmp_path / "naughty.py"
+    bad.write_text(
+        "def f():\n"
+        "    return 'receipts/_injected-prompt'  # inline literal!\n"
+    )
+    rule = Rule(
+        rule_id="r-ico-bad",
+        template="import_constant_only",
+        params={
+            "literal_pattern": r"receipts/_injected-prompt",
+            "allowed_files": ["lib_constants.py"],
+        },
+    )
+    out = check_import_constant_only(
+        rule, _make_scope(tmp_path, [allowed, bad])
+    )
+    assert len(out) == 1, f"expected 1 violation, got {out!r}"
+    v = out[0]
+    assert v.rule_id == "r-ico-bad"
+    assert v.file == "naughty.py"
+    assert "receipts/_injected-prompt" in v.message
+    assert "lib_constants.py" in v.message
+
+
+def test_import_constant_only_allowed_files_glob_excludes_match(tmp_path):
+    """Even when a literal exists in two files, if BOTH match an
+    allowed_files glob then no violation is emitted. Demonstrates the
+    glob (not just exact-name) exclusion semantics."""
+    a = tmp_path / "lib_constants.py"
+    a.write_text("X = 'receipts/_injected-prompt'\n")
+    b = tmp_path / "lib_more.py"
+    b.write_text("Y = 'receipts/_injected-prompt'\n")
+    rule = Rule(
+        rule_id="r-ico-glob",
+        template="import_constant_only",
+        params={
+            "literal_pattern": r"receipts/_injected-prompt",
+            "allowed_files": ["lib_*.py"],
+        },
+    )
+    out = check_import_constant_only(rule, _make_scope(tmp_path, [a, b]))
+    assert out == [], (
+        f"both files match lib_*.py allowed glob → no violation; got {out!r}"
+    )

--- a/tools/migrate_prevention_rules.py
+++ b/tools/migrate_prevention_rules.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Migrate legacy free-text prevention rules to template-based engine schema.
+
+This script converts the historical prevention-rules.json (free-text `rule`
+strings, optional `enforcement` hint) into the structured template/params
+format consumed by `hooks.rules_engine`.
+
+Auto-classifier:
+    Deterministic regex match on `rule.text + enforcement` selects exactly one
+    template. Multiple-template-match → ambiguous. Zero-match → ambiguous.
+
+Modes:
+    --dry-run         : print before/after diff to stdout, do NOT write file.
+    --non-interactive : ambiguous rules become {template: "advisory"};
+                        ambiguous count summarised to stderr.
+    interactive (default):
+        ambiguous rules prompt operator with numbered candidate list,
+        plus 'a' (advisory), 's' (skip — keep raw rule untouched),
+        'q' (abort migration). EOF on stdin → 's'. KeyboardInterrupt → exit 1.
+
+Migration log:
+    tools/migration-logs/migration-{YYYY-MM-DD-HHMMSS}.json
+    Always written, even on --dry-run, so re-runs can be reasoned about.
+    (On abort the partial log is still flushed.)
+
+Exit codes:
+    0  success (migration completed or --dry-run finished)
+    1  operator aborted ('q' selection, KeyboardInterrupt)
+    2  file I/O failure (cannot read rules / cannot write rules / cannot
+       write log)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# hooks/ lives next to tools/. Add it to sys.path so we can import lib_core
+# and rules_engine without forcing a package install.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HOOKS_DIR = _REPO_ROOT / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from lib_core import _persistent_project_dir  # noqa: E402
+from rules_engine import TEMPLATE_SCHEMAS  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Auto-classifier
+# ---------------------------------------------------------------------------
+
+
+def _normalise_text(rule: dict) -> str:
+    """Return the lowercase concatenation of rule.text + enforcement."""
+    parts = [
+        str(rule.get("rule") or ""),
+        str(rule.get("text") or ""),
+        str(rule.get("enforcement") or ""),
+        str(rule.get("rationale") or ""),
+        str(rule.get("category") or ""),
+    ]
+    return " ".join(p for p in parts if p).lower()
+
+
+def _signature_all_satisfies_callable(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions __all__ AND (callable OR defined) →
+    every_name_in_X_satisfies_Y w/ container=__all__, predicate=callable.
+    """
+    has_all = "__all__" in text
+    has_callable_or_defined = (
+        re.search(r"\bcallable\b", text) is not None
+        or re.search(r"\bdefin(ed|ition|itions)\b", text) is not None
+    )
+    if not (has_all and has_callable_or_defined):
+        return None
+    return {
+        "template": "every_name_in_X_satisfies_Y",
+        "params": {
+            "module": "TODO_MODULE",
+            "container": "__all__",
+            "predicate": "callable",
+        },
+        "_classifier": "all+callable/defined",
+    }
+
+
+def _signature_handler_set(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions handler-set + register →
+    every_name_in_X_satisfies_Y w/ container=_LEARNING_HANDLERS.
+    """
+    handler_words = ("handler", "handlers", "_handlers")
+    has_handler = any(w in text for w in handler_words)
+    has_register = re.search(r"\bregister(ed)?\b", text) is not None
+    if not (has_handler and has_register):
+        return None
+    return {
+        "template": "every_name_in_X_satisfies_Y",
+        "params": {
+            "module": "TODO_MODULE",
+            "container": "_LEARNING_HANDLERS",
+            "predicate": "callable",
+        },
+        "_classifier": "handler+register",
+    }
+
+
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+
+
+def _signature_backtick_pattern(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions explicit regex-looking pattern in backticks →
+    pattern_must_not_appear.
+    """
+    raw_text = str(rule.get("rule") or rule.get("text") or "")
+    matches = _BACKTICK_RE.findall(raw_text)
+    if not matches:
+        return None
+    # Heuristic: at least one backtick token contains a regex
+    # metachar OR ends in `()` (a function-call signature).
+    candidates = [
+        m for m in matches
+        if re.search(r"[\\.\*\+\?\(\)\[\]\^\$]", m) or m.endswith("()")
+    ]
+    if not candidates:
+        return None
+    pattern = candidates[0]
+    # Convert literal `time.time()` style into a regex.
+    if not any(c in pattern for c in r"\^$*+?[]"):
+        regex_src = re.escape(pattern)
+    else:
+        regex_src = pattern
+    return {
+        "template": "pattern_must_not_appear",
+        "params": {
+            "regex": regex_src,
+            "scope": "**/*.py",
+        },
+        "_classifier": "backtick-pattern",
+    }
+
+
+def _signature_time_time(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions `time.time()` AND throttles → pattern_must_not_appear
+    regex `\\btime\\.time\\(\\)`.
+    """
+    has_time_time = "time.time()" in text or "time.time" in text
+    has_throttle_word = any(
+        w in text
+        for w in ("throttle", "throttles", "ttl", "rate limit", "rate-limit", "monotonic")
+    )
+    if not (has_time_time and has_throttle_word):
+        return None
+    return {
+        "template": "pattern_must_not_appear",
+        "params": {
+            "regex": r"\btime\.time\(\)",
+            "scope": "**/*.py",
+        },
+        "_classifier": "time.time()+throttle",
+    }
+
+
+def _signature_o_nofollow_lock(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions `O_NOFOLLOW` AND lock → pattern_must_not_appear (forbids
+    plain `open(lock_path` patterns in lock-related code).
+    """
+    has_nofollow = "o_nofollow" in text or "nofollow" in text
+    has_lock = "lock" in text
+    if not (has_nofollow and has_lock):
+        return None
+    return {
+        "template": "pattern_must_not_appear",
+        "params": {
+            # Catches the anti-pattern: plain open() of a *lock* file.
+            "regex": r"open\([^)]*lock[^)]*\)",
+            "scope": "**/*.py",
+        },
+        "_classifier": "O_NOFOLLOW+lock",
+    }
+
+
+def _signature_signature_lock(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions signature/params/inspect → signature_lock."""
+    keywords = ("signature", "inspect.signature", "ordered param", "parameter list")
+    has_sig = any(k in text for k in keywords)
+    if not has_sig:
+        return None
+    # Need both a function reference and a parameter mention to be
+    # confident; otherwise the term "signature" might mean something else.
+    if not (re.search(r"\bparam(s|eter|eters)?\b", text) or "inspect" in text):
+        return None
+    return {
+        "template": "signature_lock",
+        "params": {
+            "module": "TODO_MODULE",
+            "function": "TODO_FUNCTION",
+            "expected_params": [],
+        },
+        "_classifier": "signature+params/inspect",
+    }
+
+
+def _signature_caller_count(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions caller count or `>=N` uses → caller_count_required."""
+    if re.search(r"\bcaller(s|-count| count)?\b", text):
+        return {
+            "template": "caller_count_required",
+            "params": {
+                "symbol": "TODO_SYMBOL",
+                "scope": "**/*.py",
+                "min_count": 1,
+            },
+            "_classifier": "caller-count",
+        }
+    if re.search(r">=\s*\d+\s*(use|uses|call|calls|caller|callers)", text):
+        return {
+            "template": "caller_count_required",
+            "params": {
+                "symbol": "TODO_SYMBOL",
+                "scope": "**/*.py",
+                "min_count": 1,
+            },
+            "_classifier": "caller-count-N",
+        }
+    return None
+
+
+def _signature_import_constant_only(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions string literal/constant only in X → import_constant_only."""
+    has_literal_or_constant = any(
+        w in text for w in ("string literal", "literal", "constant", "constants")
+    )
+    has_only_in = bool(
+        re.search(r"only (in|allowed in|defined in|imported)", text)
+        or "single source of truth" in text
+    )
+    if not (has_literal_or_constant and has_only_in):
+        return None
+    return {
+        "template": "import_constant_only",
+        "params": {
+            "literal_pattern": "TODO_PATTERN",
+            "allowed_files": ["TODO_FILE.py"],
+        },
+        "_classifier": "literal+only-in",
+    }
+
+
+def _signature_co_modification(text: str, rule: dict) -> Optional[dict]:
+    """Rule mentions co-modify/spec amendment → co_modification_required."""
+    keywords = (
+        "co-modif", "co modif", "co-amend", "spec amendment", "spec amendments",
+        "same commit", "co-modification", "co-edit", "co edit",
+    )
+    if not any(k in text for k in keywords):
+        return None
+    return {
+        "template": "co_modification_required",
+        "params": {
+            "trigger_glob": "TODO_TRIGGER_GLOB",
+            "must_modify_glob": "TODO_MUST_MODIFY_GLOB",
+        },
+        "_classifier": "co-modify/spec-amendment",
+    }
+
+
+# Order matters only for stable diagnostics; logic still runs them all.
+_SIGNATURES = [
+    ("all+callable", _signature_all_satisfies_callable),
+    ("handler+register", _signature_handler_set),
+    ("backtick-pattern", _signature_backtick_pattern),
+    ("time.time()+throttle", _signature_time_time),
+    ("O_NOFOLLOW+lock", _signature_o_nofollow_lock),
+    ("signature+params", _signature_signature_lock),
+    ("caller-count", _signature_caller_count),
+    ("import-constant-only", _signature_import_constant_only),
+    ("co-modify", _signature_co_modification),
+]
+
+
+def classify(rule: dict) -> tuple[str, list[dict]]:
+    """Return (status, candidates) for a single raw rule.
+
+    status:
+        "single"    — exactly one template matched; candidates has 1 entry.
+        "ambiguous" — zero or many candidates; operator must choose.
+    """
+    text = _normalise_text(rule)
+    candidates: list[dict] = []
+    for _name, fn in _SIGNATURES:
+        try:
+            cand = fn(text, rule)
+        except Exception:
+            cand = None
+        if cand is not None:
+            candidates.append(cand)
+    if len(candidates) == 1:
+        return ("single", candidates)
+    return ("ambiguous", candidates)
+
+
+# ---------------------------------------------------------------------------
+# Migration core
+# ---------------------------------------------------------------------------
+
+
+def _strip_classifier_meta(template_dict: dict) -> dict:
+    """Remove auto-classifier debug fields from a template dict."""
+    out = dict(template_dict)
+    out.pop("_classifier", None)
+    return out
+
+
+_RULE_ID_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _derive_rule_id(rule: dict, idx: int) -> str:
+    """Derive a stable rule_id for a legacy rule that lacks one."""
+    existing = rule.get("rule_id") or rule.get("id")
+    if existing:
+        return str(existing)
+    src = rule.get("source_finding") or rule.get("source_task") or ""
+    cat = rule.get("category") or "rule"
+    base = f"{cat}-{src}-{idx}".lower()
+    base = _RULE_ID_RE.sub("-", base).strip("-")
+    return base or f"rule-{idx}"
+
+
+def _build_migrated(
+    rule: dict,
+    template_dict: dict,
+    idx: int,
+) -> dict:
+    """Construct the migrated rule dict, preserving legacy metadata."""
+    template_dict = _strip_classifier_meta(template_dict)
+    migrated = {
+        "rule_id": _derive_rule_id(rule, idx),
+        "template": template_dict["template"],
+        "params": template_dict.get("params", {}),
+        "severity": str(rule.get("severity", "error")),
+        "source_finding": str(rule.get("source_finding", "")),
+        "rationale": str(rule.get("rationale", "")),
+    }
+    # Preserve legacy fields that are non-engine but useful for audit trail.
+    for k in ("category", "executor", "added_at", "source_task"):
+        if k in rule:
+            migrated[k] = rule[k]
+    # Keep the original free-text rule under a separate field for traceability.
+    if rule.get("rule"):
+        migrated["legacy_text"] = rule["rule"]
+    return migrated
+
+
+def _diff_lines(before: list[dict], after: list[dict]) -> list[str]:
+    """Return human-readable per-rule before/after diff lines."""
+    lines = []
+    for i, (b, a) in enumerate(zip(before, after)):
+        b_summary = (b.get("rule") or b.get("text") or "")[:80]
+        a_template = a.get("template", "?")
+        a_params = json.dumps(a.get("params", {}), sort_keys=True)
+        lines.append(f"--- rule {i} ---")
+        lines.append(f"  before: {b_summary!r}")
+        lines.append(f"  after : template={a_template} params={a_params}")
+    return lines
+
+
+def _prompt_for_choice(
+    idx: int,
+    rule: dict,
+    candidates: list[dict],
+) -> str:
+    """Prompt the operator and return one of:
+    "advisory", "skip", "abort", or a template name (when chosen by number).
+    EOF → "skip". KeyboardInterrupt is *not* caught here; caller handles.
+    """
+    raw = (rule.get("rule") or rule.get("text") or "").strip()
+    summary = raw if len(raw) <= 200 else raw[:200] + "..."
+    sys.stderr.write(
+        f"\n--- rule {idx} (ambiguous) ---\n"
+        f"  text: {summary}\n"
+        f"  enforcement: {rule.get('enforcement', '<none>')}\n"
+    )
+    if candidates:
+        sys.stderr.write("  candidate templates:\n")
+        for i, c in enumerate(candidates, start=1):
+            sys.stderr.write(
+                f"    [{i}] {c['template']}  "
+                f"(matched by {c.get('_classifier', '?')})\n"
+            )
+    else:
+        sys.stderr.write("  candidate templates: <none>\n")
+    n = len(candidates)
+    prompt = f"Choose [1-{n}], 'a' for advisory, 's' to skip, 'q' to abort: "
+    # Iterative re-prompt loop (SEC-002 fix: was recursive, now bounded).
+    # Hard cap on attempts prevents infinite-input DoS via piped junk.
+    MAX_ATTEMPTS = 100
+    for _ in range(MAX_ATTEMPTS):
+        sys.stderr.write(prompt)
+        sys.stderr.flush()
+        try:
+            line = input()
+        except EOFError:
+            return "skip"
+        choice = (line or "").strip().lower()
+        if choice == "a":
+            return "advisory"
+        if choice == "s" or choice == "":
+            return "skip"
+        if choice == "q":
+            return "abort"
+        if choice.isdigit():
+            i = int(choice)
+            if 1 <= i <= n:
+                return f"__index_{i - 1}"
+        sys.stderr.write("  (unrecognised input)\n")
+    # Bounded retry exhausted — treat as skip rather than crashing.
+    sys.stderr.write(
+        f"  (max {MAX_ATTEMPTS} attempts reached; defaulting to skip)\n"
+    )
+    return "skip"
+
+
+def _write_log(log_dir: Path, log: dict) -> Optional[Path]:
+    """Write the migration log JSON. Returns the path written or None on error.
+    Errors are reported to stderr and converted to exit code 2 by the caller.
+    """
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        sys.stderr.write(f"ERROR: cannot create log dir {log_dir}: {exc}\n")
+        return None
+    ts = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    log_path = log_dir / f"migration-{ts}.json"
+    try:
+        with log_path.open("w", encoding="utf-8") as f:
+            json.dump(log, f, indent=2, sort_keys=True)
+            f.write("\n")
+    except OSError as exc:
+        sys.stderr.write(f"ERROR: cannot write log {log_path}: {exc}\n")
+        return None
+    return log_path
+
+
+def _atomic_write_rules(rules_path: Path, payload: dict) -> bool:
+    """Atomically write the migrated rules file. Returns False on I/O error."""
+    try:
+        rules_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        sys.stderr.write(
+            f"ERROR: cannot create rules-file parent {rules_path.parent}: {exc}\n"
+        )
+        return False
+    tmp_path = rules_path.with_suffix(rules_path.suffix + ".tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=False)
+            f.write("\n")
+        os.replace(tmp_path, rules_path)
+    except OSError as exc:
+        sys.stderr.write(f"ERROR: cannot write rules file {rules_path}: {exc}\n")
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="migrate_prevention_rules",
+        description=(
+            "Migrate legacy free-text prevention rules to the template-based "
+            "rules-engine schema."
+        ),
+    )
+    parser.add_argument(
+        "--rules-path",
+        dest="rules_path",
+        default=None,
+        help=(
+            "Path to prevention-rules.json. Defaults to "
+            "_persistent_project_dir(repo_root)/prevention-rules.json."
+        ),
+    )
+    parser.add_argument(
+        "--non-interactive",
+        dest="non_interactive",
+        action="store_true",
+        help="Default ambiguous rules to template='advisory' instead of prompting.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="Print before/after diff to stdout but do NOT write the rules file.",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    repo_root = _REPO_ROOT
+    rules_path = (
+        Path(args.rules_path) if args.rules_path
+        else _persistent_project_dir(repo_root) / "prevention-rules.json"
+    )
+
+    log_dir = repo_root / "tools" / "migration-logs"
+
+    # ---- Load existing rules ------------------------------------------------
+    if not rules_path.exists():
+        sys.stderr.write(f"ERROR: rules file not found at {rules_path}\n")
+        return 2
+    try:
+        with rules_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"ERROR: cannot read {rules_path}: {exc}\n")
+        return 2
+
+    if not isinstance(data, dict):
+        sys.stderr.write(
+            f"ERROR: top-level JSON in {rules_path} must be an object\n"
+        )
+        return 2
+
+    raw_rules = data.get("rules")
+    if not isinstance(raw_rules, list):
+        sys.stderr.write(
+            f"ERROR: 'rules' field in {rules_path} must be a list\n"
+        )
+        return 2
+
+    # ---- Classify and (optionally) prompt ----------------------------------
+    migrated: list[dict] = []
+    log_entries: list[dict] = []
+    auto_count = 0
+    advisory_default_count = 0
+    operator_chosen_count = 0
+    skipped_count = 0
+    aborted = False
+
+    for idx, rule in enumerate(raw_rules):
+        if not isinstance(rule, dict):
+            log_entries.append({
+                "index": idx,
+                "status": "skipped",
+                "reason": "not a dict",
+            })
+            skipped_count += 1
+            # Keep the malformed entry verbatim so we don't lose data.
+            migrated.append(rule)
+            continue
+
+        status, candidates = classify(rule)
+
+        if status == "single":
+            chosen = candidates[0]
+            migrated.append(_build_migrated(rule, chosen, idx))
+            log_entries.append({
+                "index": idx,
+                "status": "auto",
+                "template": chosen["template"],
+                "classifier": chosen.get("_classifier"),
+            })
+            auto_count += 1
+            continue
+
+        # status == "ambiguous"
+        if args.non_interactive:
+            chosen = {
+                "template": "advisory",
+                "params": {},
+                "_classifier": "ambiguous-default",
+            }
+            migrated.append(_build_migrated(rule, chosen, idx))
+            log_entries.append({
+                "index": idx,
+                "status": "advisory-default",
+                "candidate_count": len(candidates),
+            })
+            advisory_default_count += 1
+            continue
+
+        # Interactive mode: prompt the operator.
+        try:
+            decision = _prompt_for_choice(idx, rule, candidates)
+        except KeyboardInterrupt:
+            sys.stderr.write(
+                "\nABORT: KeyboardInterrupt during prompt; "
+                "saving partial log and exiting\n"
+            )
+            log_entries.append({
+                "index": idx,
+                "status": "aborted",
+                "reason": "KeyboardInterrupt",
+            })
+            aborted = True
+            # Persist partial log before exit (errors here are non-fatal).
+            _write_log(log_dir, {
+                "rules_path": str(rules_path),
+                "dry_run": bool(args.dry_run),
+                "non_interactive": bool(args.non_interactive),
+                "aborted": True,
+                "summary": {
+                    "total_input": len(raw_rules),
+                    "auto": auto_count,
+                    "advisory_default": advisory_default_count,
+                    "operator_chosen": operator_chosen_count,
+                    "skipped": skipped_count,
+                },
+                "entries": log_entries,
+            })
+            return 1
+
+        if decision == "abort":
+            sys.stderr.write("\nABORT: operator chose 'q'; exiting\n")
+            log_entries.append({
+                "index": idx,
+                "status": "aborted",
+                "reason": "operator chose 'q'",
+            })
+            aborted = True
+            _write_log(log_dir, {
+                "rules_path": str(rules_path),
+                "dry_run": bool(args.dry_run),
+                "non_interactive": bool(args.non_interactive),
+                "aborted": True,
+                "summary": {
+                    "total_input": len(raw_rules),
+                    "auto": auto_count,
+                    "advisory_default": advisory_default_count,
+                    "operator_chosen": operator_chosen_count,
+                    "skipped": skipped_count,
+                },
+                "entries": log_entries,
+            })
+            return 1
+
+        if decision == "skip":
+            log_entries.append({
+                "index": idx,
+                "status": "skipped",
+                "reason": "operator skipped (or EOF)",
+            })
+            skipped_count += 1
+            # Preserve the original rule untouched.
+            migrated.append(rule)
+            continue
+
+        if decision == "advisory":
+            chosen = {"template": "advisory", "params": {}}
+            migrated.append(_build_migrated(rule, chosen, idx))
+            log_entries.append({
+                "index": idx,
+                "status": "operator-advisory",
+            })
+            operator_chosen_count += 1
+            continue
+
+        if decision.startswith("__index_"):
+            i = int(decision[len("__index_"):])
+            if 0 <= i < len(candidates):
+                chosen = candidates[i]
+                migrated.append(_build_migrated(rule, chosen, idx))
+                log_entries.append({
+                    "index": idx,
+                    "status": "operator-chosen",
+                    "template": chosen["template"],
+                })
+                operator_chosen_count += 1
+                continue
+        # Defensive fallback: treat unknown decision as advisory.
+        chosen = {"template": "advisory", "params": {}}
+        migrated.append(_build_migrated(rule, chosen, idx))
+        log_entries.append({
+            "index": idx,
+            "status": "operator-fallback-advisory",
+        })
+        advisory_default_count += 1
+
+    # ---- Build payload ------------------------------------------------------
+    new_payload = {
+        "rules": migrated,
+        "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "migration_version": 1,
+    }
+    # Preserve unknown top-level keys (forward-compat).
+    for k, v in data.items():
+        if k not in {"rules", "updated_at"}:
+            new_payload.setdefault(k, v)
+
+    # ---- Diff (always for --dry-run, else summary line only) ---------------
+    if args.dry_run:
+        for line in _diff_lines(raw_rules, migrated):
+            print(line)
+        sys.stdout.flush()
+
+    # ---- Write log ---------------------------------------------------------
+    log = {
+        "rules_path": str(rules_path),
+        "dry_run": bool(args.dry_run),
+        "non_interactive": bool(args.non_interactive),
+        "aborted": aborted,
+        "summary": {
+            "total_input": len(raw_rules),
+            "auto": auto_count,
+            "advisory_default": advisory_default_count,
+            "operator_chosen": operator_chosen_count,
+            "skipped": skipped_count,
+        },
+        "entries": log_entries,
+    }
+    log_path = _write_log(log_dir, log)
+    if log_path is None:
+        # Log write failure is fatal — operators rely on the log for audit.
+        return 2
+
+    # ---- Write rules file (unless dry-run) ---------------------------------
+    if not args.dry_run:
+        ok = _atomic_write_rules(rules_path, new_payload)
+        if not ok:
+            return 2
+
+    # ---- Final stderr summary ----------------------------------------------
+    total = len(raw_rules)
+    sys.stderr.write(
+        f"{auto_count} auto, "
+        f"{advisory_default_count} advisory-default, "
+        f"{operator_chosen_count} operator-chosen, "
+        f"{skipped_count} skipped, "
+        f"{total} total\n"
+    )
+    sys.stderr.write(f"log: {log_path}\n")
+    if args.dry_run:
+        sys.stderr.write("dry-run: rules file NOT modified\n")
+    sys.stderr.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        rc = main()
+    except KeyboardInterrupt:
+        sys.stderr.write("\nABORT: KeyboardInterrupt at top level\n")
+        rc = 1
+    sys.exit(rc)

--- a/tools/migration-logs/migration-2026-04-18-232150.json
+++ b/tools/migration-logs/migration-2026-04-18-232150.json
@@ -1,0 +1,182 @@
+{
+  "aborted": false,
+  "dry_run": true,
+  "entries": [
+    {
+      "candidate_count": 0,
+      "index": 0,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 1,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 2,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 3,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 4,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 5,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 6,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 7,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 8,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 9,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 10,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "time.time()+throttle",
+      "index": 11,
+      "status": "auto",
+      "template": "pattern_must_not_appear"
+    },
+    {
+      "candidate_count": 0,
+      "index": 12,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 13,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 14,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 15,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 16,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 17,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "O_NOFOLLOW+lock",
+      "index": 18,
+      "status": "auto",
+      "template": "pattern_must_not_appear"
+    },
+    {
+      "candidate_count": 0,
+      "index": 19,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 20,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "all+callable/defined",
+      "index": 21,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "candidate_count": 0,
+      "index": 22,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "handler+register",
+      "index": 23,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "classifier": "handler+register",
+      "index": 24,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "candidate_count": 0,
+      "index": 25,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 26,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "co-modify/spec-amendment",
+      "index": 27,
+      "status": "auto",
+      "template": "co_modification_required"
+    },
+    {
+      "candidate_count": 0,
+      "index": 28,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "literal+only-in",
+      "index": 29,
+      "status": "auto",
+      "template": "import_constant_only"
+    },
+    {
+      "candidate_count": 0,
+      "index": 30,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 31,
+      "status": "advisory-default"
+    }
+  ],
+  "non_interactive": true,
+  "rules_path": "/Users/hassam/.dynos/projects/Users-hassam-Documents-dynos-work/prevention-rules.json",
+  "summary": {
+    "advisory_default": 25,
+    "auto": 7,
+    "operator_chosen": 0,
+    "skipped": 0,
+    "total_input": 32
+  }
+}

--- a/tools/migration-logs/migration-2026-04-18-232203.json
+++ b/tools/migration-logs/migration-2026-04-18-232203.json
@@ -1,0 +1,182 @@
+{
+  "aborted": false,
+  "dry_run": false,
+  "entries": [
+    {
+      "candidate_count": 0,
+      "index": 0,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 1,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 2,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 3,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 4,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 5,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 6,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 7,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 8,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 9,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 10,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "time.time()+throttle",
+      "index": 11,
+      "status": "auto",
+      "template": "pattern_must_not_appear"
+    },
+    {
+      "candidate_count": 0,
+      "index": 12,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 13,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 14,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 15,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 16,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 17,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "O_NOFOLLOW+lock",
+      "index": 18,
+      "status": "auto",
+      "template": "pattern_must_not_appear"
+    },
+    {
+      "candidate_count": 0,
+      "index": 19,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 20,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "all+callable/defined",
+      "index": 21,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "candidate_count": 0,
+      "index": 22,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "handler+register",
+      "index": 23,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "classifier": "handler+register",
+      "index": 24,
+      "status": "auto",
+      "template": "every_name_in_X_satisfies_Y"
+    },
+    {
+      "candidate_count": 0,
+      "index": 25,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 26,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "co-modify/spec-amendment",
+      "index": 27,
+      "status": "auto",
+      "template": "co_modification_required"
+    },
+    {
+      "candidate_count": 0,
+      "index": 28,
+      "status": "advisory-default"
+    },
+    {
+      "classifier": "literal+only-in",
+      "index": 29,
+      "status": "auto",
+      "template": "import_constant_only"
+    },
+    {
+      "candidate_count": 0,
+      "index": 30,
+      "status": "advisory-default"
+    },
+    {
+      "candidate_count": 0,
+      "index": 31,
+      "status": "advisory-default"
+    }
+  ],
+  "non_interactive": true,
+  "rules_path": "/Users/hassam/.dynos/projects/Users-hassam-Documents-dynos-work/prevention-rules.json",
+  "summary": {
+    "advisory_default": 25,
+    "auto": 7,
+    "operator_chosen": 0,
+    "skipped": 0,
+    "total_input": 32
+  }
+}


### PR DESCRIPTION
## Summary
Converts `prevention-rules.json` from "advice injected into LLM prompts" into "Python-evaluated gates at commit time and stage-transition time". Eliminates the trust-me-bro pattern for code-quality rules in the same way PR #123 did for stage transitions. Rules are now declarative data; the engine is fixed Python; new postmortem-generated rules add JSON entries the engine knows how to evaluate (no per-rule Python).

Natural follow-on to task-004 / PR #123. Together they take the foundry from "trust the LLM" to "trust verified by code at every gate".

## What landed

1. **`hooks/rules_engine.py`** (NEW, ~1300 LOC): six template handlers + `advisory` no-op. `run_checks` dispatcher with sorted-deterministic violations. Four CLI subcommands.
2. **ReDoS defense** (`_safe_compile_regex`): static nested-quantifier shape detector + SIGALRM-based runtime canary on Unix.
3. **`receipt_rules_check_passed`**: writer that REFUSES to write when `error_violations != 0`.
4. **Two new transition_task gates**: `EXECUTION → TEST_EXECUTION` and `CHECKPOINT_AUDIT → DONE` require the receipt; `force=True` only escape.
5. **TEMPLATE_SCHEMAS validation** in `apply_analysis`: rejects malformed rules; postmortem prompt rewritten to instruct LLM to emit `{template, params}`.
6. **inject-prompt filter**: omits non-advisory rules from prompts (engine handles them); `--include-enforced` flag for debugging.
7. **`tools/migrate_prevention_rules.py`** (NEW): one-time migration of existing 32 rules. Interactive / non-interactive / dry-run modes. Bounded retry loop (no recursion).
8. **README**: "Install commit-time rules check" section for new clones.
9. **6 new test files** (~2200 LOC): per-template happy+violation+edge, dispatch, self-proof (`@pytest.mark.integration`), schema validation, filter, pre-commit installer subprocess.

## Bootstrap proof
task-005's own `DONE → CALIBRATED` transition succeeded under the new code. Engine self-check (`--all` mode) passes with 0 error-severity violations in **0.036s** against the post-migration tree.

## Repair cycle
3 cycle-0 blockers, all fixed in cycle-1:

| ID | Issue | Fix |
|---|---|---|
| sc-001 | `TODO_PATTERN` sentinel in migrated rules would fire against the migration script itself once committed | Demoted both rules to advisory |
| SEC-001 | ReDoS via uncontrolled `re.compile` on user regex | `_safe_compile_regex` with static + SIGALRM canary |
| SEC-002 | Recursive `_prompt_for_choice` (unbounded stack) | Bounded `for _ in range(100)` loop, exhaustion=skip |

## Migration outcome
- 32 rules → 7 templated + 25 advisory (after demoting 5 TODO/over-broad rules to advisory)
- `validate-rules` exits 0
- Postmortem-generated 6 new rules using the new `{template, params}` schema (proves the postmortem schema validation works end-to-end)

## Test plan
- [x] `pytest tests/ -q` → **1153 passed, 1 skipped** (task-004 self-proof auto-skipped since that task's CALIBRATED state predates this commit)
- [x] `pytest tests/test_rules_engine_self_proof.py -m integration` → 1 passed (engine <2s + 0 errors against real tree)
- [x] `python3 hooks/rules_engine.py check --all` → exit 0
- [x] `python3 hooks/rules_engine.py validate-rules` → OK (32 rules valid)
- [x] ReDoS canary: `(a+)+$` rejected, `time\.time\(\)` accepted
- [ ] After merge: monitor for any rule that produces false positives in real commits → re-classify to advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)