### PR TITLE
close 6 framework enforcement gaps from investigator report

### DIFF
--- a/cli/assets/templates/base/start.md
+++ b/cli/assets/templates/base/start.md
@@ -55,7 +55,17 @@ receipt_planner_spawn(
 )
 
 # After spec-completion auditor (plan audit):
-receipt_plan_audit(task_dir, tokens_used=TOTAL_TOKENS, finding_count=N)
+# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
+# the PLAN_AUDIT exit gate re-hashes these artifacts at transition time and
+# refuses to advance when any has drifted since the audit was recorded.
+receipt_plan_audit(
+    task_dir,
+    tokens_used=TOTAL_TOKENS,
+    finding_count=N,
+    spec_sha256=SPEC_SHA256,
+    plan_sha256=PLAN_SHA256,
+    graph_sha256=GRAPH_SHA256,
+)
 
 ```
 

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -455,6 +455,403 @@ def require_receipts_for_done(task_dir: Path) -> list[str]:
     return gaps
 
 
+def _compute_bypassed_gates_for_force(
+    *,
+    task_dir: Path,
+    manifest: dict,
+    current_stage: str | None,
+    next_stage: str,
+) -> list[str]:
+    """Return the list of gate error strings that WOULD have been raised
+    if ``transition_task(..., force=False)`` had been called for this
+    edge. Used for the force_override observability receipt and event.
+
+    This MUST mirror the semantics of the ``if not force:`` gate block in
+    ``transition_task``. We duplicate the checks rather than share a
+    common helper because the gate block today calls ``_refuse()``
+    (raises immediately) for several checks; threading a dry-run flag
+    through every call site risks silently changing refusal semantics.
+
+    Returns a possibly-empty list[str]. Never raises — all internal
+    failures (missing files, unreadable receipts, etc.) are swallowed so
+    the forced transition still proceeds.
+    """
+    try:
+        from lib_receipts import (
+            read_receipt,
+            hash_file,
+            _receipts_dir,
+            plan_validated_receipt_matches,
+            plan_audit_matches,
+        )
+    except Exception:
+        return []
+
+    errs: list[str] = []
+
+    # Mirror of _check_human_approval — returns an error string on failure
+    # rather than raising.
+    def _human_approval_err(stage_label: str, artifact_path: Path) -> str | None:
+        try:
+            receipt_step = f"human-approval-{stage_label}"
+            receipt_path = _receipts_dir(task_dir) / f"{receipt_step}.json"
+            receipt = read_receipt(task_dir, receipt_step)
+            if receipt is None:
+                return (
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing receipt {receipt_step} at {receipt_path} "
+                    f"(artifact: {artifact_path})"
+                )
+            if not artifact_path.exists():
+                return (
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"receipt {receipt_step} present at {receipt_path} but "
+                    f"artifact missing at {artifact_path}"
+                )
+            expected = receipt.get("artifact_sha256") or ""
+            actual = hash_file(artifact_path)
+            if not isinstance(expected, str) or expected != actual:
+                return (
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"hash mismatch for receipt {receipt_step} "
+                    f"(receipt: {receipt_path}, artifact: {artifact_path}) "
+                    f"expected={(expected or '')[:12]} actual={actual[:12]}"
+                )
+        except Exception:
+            return None
+        return None
+
+    def _rules_check_err() -> str | None:
+        try:
+            receipt = read_receipt(task_dir, "rules-check-passed")
+            receipt_path = task_dir / "receipts" / "rules-check-passed.json"
+            if receipt is None:
+                return (
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing or failed rules-check-passed receipt at "
+                    f"{receipt_path} (error_violations=missing)"
+                )
+            if receipt.get("error_violations", 1) != 0:
+                n = receipt.get("error_violations", "missing")
+                return (
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing or failed rules-check-passed receipt at "
+                    f"{receipt_path} (error_violations={n})"
+                )
+        except Exception:
+            return None
+        return None
+
+    # ---- AC 3: SPEC_REVIEW -> PLANNING
+    if current_stage == "SPEC_REVIEW" and next_stage == "PLANNING":
+        err = _human_approval_err("SPEC_REVIEW", task_dir / "spec.md")
+        if err:
+            errs.append(err)
+
+    # ---- AC 4: PLAN_REVIEW -> PLAN_AUDIT
+    if current_stage == "PLAN_REVIEW" and next_stage == "PLAN_AUDIT":
+        err = _human_approval_err("PLAN_REVIEW", task_dir / "plan.md")
+        if err:
+            errs.append(err)
+
+    # ---- F6: planner-spec at SPEC_NORMALIZATION -> SPEC_REVIEW.
+    classification = manifest.get("classification") or {}
+    fast_track_flag = bool(
+        manifest.get("fast_track", False)
+        or (
+            isinstance(classification, dict)
+            and classification.get("fast_track", False)
+        )
+    )
+    if (
+        current_stage == "SPEC_NORMALIZATION"
+        and next_stage == "SPEC_REVIEW"
+        and not fast_track_flag
+    ):
+        if read_receipt(task_dir, "planner-spec") is None:
+            errs.append(
+                "receipt: planner-spec (planner spec spawn was never recorded)"
+            )
+
+    # ---- F6: planner-plan at PLANNING -> PLAN_REVIEW.
+    if current_stage == "PLANNING" and next_stage == "PLAN_REVIEW":
+        if read_receipt(task_dir, "planner-plan") is None:
+            errs.append(
+                "receipt: planner-plan (planner plan spawn was never recorded)"
+            )
+
+    # ---- AC 6: TDD_REVIEW -> PRE_EXECUTION_SNAPSHOT
+    if current_stage == "TDD_REVIEW" and next_stage == "PRE_EXECUTION_SNAPSHOT":
+        err = _human_approval_err(
+            "TDD_REVIEW", task_dir / "evidence" / "tdd-tests.md"
+        )
+        if err:
+            errs.append(err)
+
+    # ---- PLAN_AUDIT exit gates (F4 + tdd_required)
+    if current_stage == "PLAN_AUDIT" and next_stage in {"TDD_REVIEW", "PRE_EXECUTION_SNAPSHOT"}:
+        risk_level = classification.get("risk_level") if isinstance(classification, dict) else None
+        if risk_level in {"high", "critical"}:
+            pa_path = _receipts_dir(task_dir) / "plan-audit-check.json"
+            audit_result = plan_audit_matches(task_dir)
+            if audit_result is True:
+                pass
+            elif isinstance(audit_result, str):
+                errs.append(f"plan-audit-check: {audit_result}")
+            else:
+                errs.append(
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"missing receipt plan-audit-check at {pa_path} "
+                    f"(risk_level={risk_level} requires plan-audit-check)"
+                )
+        if next_stage == "PRE_EXECUTION_SNAPSHOT" and get_tdd_required(manifest):
+            errs.append(
+                f"Cannot transition {current_stage} -> {next_stage}: "
+                f"manifest.classification.tdd_required=true requires "
+                f"routing through TDD_REVIEW (manifest: {task_dir / 'manifest.json'})"
+            )
+
+    # ---- F1: EXECUTION requires fresh plan-validated receipt.
+    if next_stage == "EXECUTION":
+        match_result = plan_validated_receipt_matches(task_dir)
+        if match_result is True:
+            pass
+        elif isinstance(match_result, str):
+            errs.append(f"plan-validated: {match_result}")
+        else:
+            errs.append("receipt: plan-validated (plan was never validated)")
+
+    # ---- CHECKPOINT_AUDIT gate — mirror the graph+routing segment check.
+    if next_stage == "CHECKPOINT_AUDIT":
+        routing_payload = read_receipt(task_dir, "executor-routing")
+        if routing_payload is None:
+            errs.append("receipt: executor-routing (executor routing was never recorded)")
+        elif current_stage in {"TEST_EXECUTION", "REPAIR_EXECUTION"}:
+            required_seg_ids: list[str] = []
+            seen: set[str] = set()
+
+            def _add(seg_id: object) -> None:
+                if isinstance(seg_id, str) and seg_id and seg_id not in seen:
+                    required_seg_ids.append(seg_id)
+                    seen.add(seg_id)
+
+            graph_path = task_dir / "execution-graph.json"
+            if graph_path.exists():
+                try:
+                    graph = load_json(graph_path)
+                except (OSError, ValueError):
+                    graph = None
+                if isinstance(graph, dict):
+                    graph_segments = graph.get("segments")
+                    if isinstance(graph_segments, list):
+                        for entry in graph_segments:
+                            if isinstance(entry, dict):
+                                _add(entry.get("id"))
+            routing_segments = routing_payload.get("segments")
+            if isinstance(routing_segments, list):
+                for entry in routing_segments:
+                    if isinstance(entry, dict):
+                        _add(entry.get("segment_id"))
+            for seg_id in required_seg_ids:
+                if read_receipt(task_dir, f"executor-{seg_id}") is None:
+                    errs.append(
+                        f"receipt: executor-{seg_id} (segment {seg_id} never completed)"
+                    )
+
+    # ---- REPAIR cap exhaustion.
+    if next_stage == "REPAIR_PLANNING" and current_stage == "REPAIR_EXECUTION":
+        repair_log_path = task_dir / "repair-log.json"
+        if repair_log_path.exists():
+            try:
+                repair_log = load_json(repair_log_path)
+            except (OSError, ValueError):
+                repair_log = None
+            if isinstance(repair_log, dict):
+                exhausted: list[str] = []
+                for batch in repair_log.get("batches", []):
+                    if not isinstance(batch, dict):
+                        continue
+                    for task_entry in batch.get("tasks", []):
+                        if not isinstance(task_entry, dict):
+                            continue
+                        fid = task_entry.get("finding_id", "unknown")
+                        retries = task_entry.get("retry_count", 0)
+                        try:
+                            retries_int = int(retries)
+                        except (TypeError, ValueError):
+                            retries_int = 0
+                        if retries_int >= 3:
+                            exhausted.append(f"{fid} (retry_count={retries_int})")
+                if exhausted:
+                    errs.append(
+                        f"repair cap exceeded (max 3 retries) for finding(s): "
+                        f"{', '.join(exhausted)}. Transition to FAILED instead — "
+                        f"human review needed."
+                    )
+
+    # ---- DONE gates.
+    if next_stage == "DONE":
+        if not (task_dir / "task-retrospective.json").exists():
+            errs.append("task-retrospective.json (run /dynos-work:audit to generate)")
+        if not list(task_dir.glob("audit-reports/*.json")):
+            errs.append("audit-reports/ (no audit reports found — audit was never run)")
+        if read_receipt(task_dir, "retrospective") is None:
+            errs.append("receipt: retrospective (reward was never computed via receipts)")
+        if current_stage in {"CHECKPOINT_AUDIT", "FINAL_AUDIT"}:
+            try:
+                done_gaps = require_receipts_for_done(task_dir)
+            except Exception:
+                done_gaps = []
+            if done_gaps:
+                rd = _receipts_dir(task_dir)
+                errs.append(
+                    f"Cannot transition {current_stage} -> {next_stage}: "
+                    f"receipt gaps in {rd}: " + "; ".join(done_gaps)
+                )
+
+    # ---- DONE -> CALIBRATED requires calibration-applied.
+    if current_stage == "DONE" and next_stage == "CALIBRATED":
+        ca_path = _receipts_dir(task_dir) / "calibration-applied.json"
+        if read_receipt(task_dir, "calibration-applied") is None:
+            errs.append(
+                f"Cannot transition {current_stage} -> {next_stage}: "
+                f"missing receipt calibration-applied at {ca_path}"
+            )
+
+    # ---- rules-check-passed at TEST_EXECUTION entry and CHECKPOINT_AUDIT -> DONE.
+    if next_stage == "TEST_EXECUTION":
+        err = _rules_check_err()
+        if err:
+            errs.append(err)
+    if current_stage == "CHECKPOINT_AUDIT" and next_stage == "DONE":
+        err = _rules_check_err()
+        if err:
+            errs.append(err)
+
+    # ---- Illegal transition itself is a bypassed "gate" under force=True.
+    if next_stage not in ALLOWED_STAGE_TRANSITIONS.get(current_stage or "", set()):
+        errs.append(f"Illegal stage transition: {current_stage} -> {next_stage}")
+
+    return errs
+
+
+def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
+    """Copy task-retrospective.json into the persistent project dir so
+    the nightly calibration pipeline can find it after worktree removal.
+
+    Invariant: this function NEVER raises. Emits
+    ``retrospective_flushed`` on success, ``retrospective_flush_failed``
+    on OSError. A missing source file is a silent skip (the DONE gate
+    already requires its presence; callers rely on the gate's error
+    path, not on this function's side effects).
+    """
+    src = task_dir / "task-retrospective.json"
+    if not src.exists():
+        return
+    root = task_dir.parent.parent
+    task_id = manifest.get("task_id") or task_dir.name
+    # SEC-001 hardening: validate task_id as a safe slug BEFORE path join.
+    # A crafted manifest with "task_id": "../../evil" would otherwise escape
+    # the persistent retrospectives dir. Accepts current dynos format
+    # (task-YYYYMMDD-NNN) plus test-style ids (task-T, task-A).
+    import re as _re_slug
+    if not isinstance(task_id, str) or not _re_slug.match(
+        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
+    ):
+        try:
+            from lib_log import log_event as _log_flush
+            _log_flush(
+                root,
+                "retrospective_flush_failed",
+                task=str(task_id),
+                task_id=str(task_id),
+                source=str(src),
+                destination="",
+                error=f"invalid task_id slug: {task_id!r}",
+            )
+        except Exception:
+            pass
+        return
+    try:
+        dst_dir = _persistent_project_dir(root) / "retrospectives"
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst = dst_dir / f"{task_id}.json"
+        # Defense-in-depth: assert resolved dst is under dst_dir.
+        try:
+            dst.resolve().relative_to(dst_dir.resolve())
+        except ValueError:
+            raise OSError(f"resolved dst escapes retrospectives dir: {dst}")
+    except OSError as exc:
+        # Can't even compute or create the destination dir — log and bail.
+        try:
+            from lib_log import log_event as _log_flush
+            _log_flush(
+                root,
+                "retrospective_flush_failed",
+                task=task_id,
+                task_id=task_id,
+                source=str(src),
+                destination="",
+                error=str(exc),
+            )
+        except Exception:
+            pass
+        return
+    try:
+        from lib_receipts import _atomic_write_text
+        _atomic_write_text(dst, src.read_text("utf-8"))
+    except OSError as exc:
+        try:
+            from lib_log import log_event as _log_flush
+            _log_flush(
+                root,
+                "retrospective_flush_failed",
+                task=task_id,
+                task_id=task_id,
+                source=str(src),
+                destination=str(dst),
+                error=str(exc),
+            )
+        except Exception:
+            pass
+        return
+    except Exception as exc:
+        # Non-OSError (unexpected) — still must not block DONE.
+        try:
+            from lib_log import log_event as _log_flush
+            _log_flush(
+                root,
+                "retrospective_flush_failed",
+                task=task_id,
+                task_id=task_id,
+                source=str(src),
+                destination=str(dst),
+                error=f"unexpected: {exc}",
+            )
+        except Exception:
+            pass
+        return
+    # Success path — hash the newly-written destination for the event.
+    try:
+        from lib_receipts import hash_file
+        dst_hash = hash_file(dst)
+    except Exception:
+        dst_hash = ""
+    try:
+        from lib_log import log_event as _log_flush
+        _log_flush(
+            root,
+            "retrospective_flushed",
+            task=task_id,
+            task_id=task_id,
+            source=str(src),
+            destination=str(dst),
+            sha256=dst_hash,
+        )
+    except Exception:
+        pass
+
+
 def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> tuple[str, dict]:
     """Transition a task to a new stage, enforcing allowed transitions."""
     manifest_path = task_dir / "manifest.json"
@@ -466,7 +863,12 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
         raise ValueError(f"Illegal stage transition: {current_stage} -> {next_stage}")
     # ---- Receipt-based transition gates (unmissable) ----
     if not force:
-        from lib_receipts import read_receipt, hash_file
+        from lib_receipts import (
+            read_receipt,
+            hash_file,
+            plan_validated_receipt_matches,
+            plan_audit_matches,
+        )
         from lib_log import log_event as _log_event
         gate_errors: list[str] = []
         _root = task_dir.parent.parent
@@ -558,6 +960,40 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
         if current_stage == "PLAN_REVIEW" and next_stage == "PLAN_AUDIT":
             _check_human_approval("PLAN_REVIEW", task_dir / "plan.md")
 
+        # ---- F6: planner-spec receipt required at SPEC_NORMALIZATION ->
+        # SPEC_REVIEW (skipped when manifest.fast_track is True — fast-track
+        # writes only a planner-plan receipt for the combined Spec+Plan
+        # spawn). Fast-track detection mirrors hooks/planner.py:
+        # manifest.get("fast_track", False), with a fallback through
+        # classification["fast_track"] for any older manifests that stored
+        # the flag under the classification subtree.
+        _classification = manifest.get("classification") or {}
+        _fast_track_flag = bool(
+            manifest.get("fast_track", False)
+            or (
+                isinstance(_classification, dict)
+                and _classification.get("fast_track", False)
+            )
+        )
+        if (
+            current_stage == "SPEC_NORMALIZATION"
+            and next_stage == "SPEC_REVIEW"
+            and not _fast_track_flag
+        ):
+            if read_receipt(task_dir, "planner-spec") is None:
+                gate_errors.append(
+                    "receipt: planner-spec (planner spec spawn was never recorded)"
+                )
+
+        # ---- F6: planner-plan receipt required at PLANNING -> PLAN_REVIEW.
+        # Applies to both normal and fast-track paths (fast-track writes a
+        # planner-plan receipt for the combined Spec+Plan spawn).
+        if current_stage == "PLANNING" and next_stage == "PLAN_REVIEW":
+            if read_receipt(task_dir, "planner-plan") is None:
+                gate_errors.append(
+                    "receipt: planner-plan (planner plan spawn was never recorded)"
+                )
+
         # ---- AC 6: TDD_REVIEW -> PRE_EXECUTION_SNAPSHOT requires
         # human-approval-TDD_REVIEW whose artifact_sha256 matches
         # sha256(evidence/tdd-tests.md).
@@ -576,7 +1012,20 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
             if risk_level in {"high", "critical"}:
                 from lib_receipts import _receipts_dir  # type: ignore
                 pa_path = _receipts_dir(task_dir) / "plan-audit-check.json"
-                if read_receipt(task_dir, "plan-audit-check") is None:
+                # Hash-bound freshness: the presence of a plan-audit-check
+                # receipt is necessary but no longer sufficient. The audit
+                # must have been computed over the current spec.md /
+                # plan.md / execution-graph.json. plan_audit_matches
+                # returns True (fresh), str (drift reason), or False
+                # (missing/legacy).
+                audit_result = plan_audit_matches(task_dir)
+                if audit_result is True:
+                    pass  # fresh audit; gate passes.
+                elif isinstance(audit_result, str):
+                    gate_errors.append(f"plan-audit-check: {audit_result}")
+                else:
+                    # Preserve the existing missing-receipt refuse path
+                    # (raises immediately via _refuse).
                     _refuse(
                         f"Cannot transition {current_stage} -> {next_stage}: "
                         f"missing receipt plan-audit-check at {pa_path} "
@@ -589,10 +1038,25 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                     f"routing through TDD_REVIEW (manifest: {task_dir / 'manifest.json'})"
                 )
 
-        # EXECUTION requires plan-validated receipt
+        # EXECUTION requires plan-validated receipt AND the captured artifact
+        # hashes MUST match current disk. Presence alone is insufficient —
+        # a stale receipt whose plan.md/spec.md/execution-graph.json have
+        # drifted since validation cannot authorize the transition.
+        # plan_validated_receipt_matches returns:
+        #   True         -> all artifacts unchanged; gate passes.
+        #   str (reason) -> a tracked artifact drifted (e.g. "plan.md hash
+        #                   drift"); append prefixed error.
+        #   False        -> receipt missing or malformed; legacy message.
         if next_stage == "EXECUTION":
-            if read_receipt(task_dir, "plan-validated") is None:
-                gate_errors.append("receipt: plan-validated (plan was never validated)")
+            match_result = plan_validated_receipt_matches(task_dir)
+            if match_result is True:
+                pass  # fresh receipt; gate passes.
+            elif isinstance(match_result, str):
+                gate_errors.append(f"plan-validated: {match_result}")
+            else:
+                gate_errors.append(
+                    "receipt: plan-validated (plan was never validated)"
+                )
 
         # CHECKPOINT_AUDIT requires executor-routing receipt + per-segment
         # executor-{seg_id} receipts proving every planned segment actually
@@ -720,6 +1184,82 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                 f"Cannot transition to {next_stage} — missing required artifacts:\n"
                 + "\n".join(f"  - {e}" for e in gate_errors)
             )
+
+    # ---- F7: force_override observability ----
+    # When force=True, compute what gate errors WOULD have fired had
+    # force been False, emit a dedicated `force_override` event, and
+    # write a `force-override-{from}-{to}.json` receipt via the
+    # receipt_force_override writer. The transition proceeds regardless
+    # of receipt-write failure (force is a break-glass door and
+    # observability must never block recovery).
+    if force:
+        bypassed_gates: list[str] = _compute_bypassed_gates_for_force(
+            task_dir=task_dir,
+            manifest=manifest,
+            current_stage=current_stage,
+            next_stage=next_stage,
+        )
+        _root_force = task_dir.parent.parent
+        _task_id_force = manifest.get("task_id") or task_dir.name
+        try:
+            from lib_log import log_event as _log_force
+            _log_force(
+                _root_force,
+                "force_override",
+                task=_task_id_force,
+                task_id=_task_id_force,
+                from_stage=current_stage,
+                to_stage=next_stage,
+                bypassed_gates=list(bypassed_gates),
+            )
+        except Exception:
+            pass  # Logging must never block the forced transition.
+        try:
+            from lib_receipts import receipt_force_override
+            receipt_force_override(
+                task_dir,
+                from_stage=current_stage or "UNKNOWN",
+                to_stage=next_stage,
+                bypassed_gates=list(bypassed_gates),
+            )
+        except OSError as _force_rcpt_exc:
+            try:
+                from lib_log import log_event as _log_force_fail
+                _log_force_fail(
+                    _root_force,
+                    "force_override_receipt_write_failed",
+                    task=_task_id_force,
+                    task_id=_task_id_force,
+                    error=str(_force_rcpt_exc),
+                )
+            except Exception:
+                pass
+        except Exception:
+            # Non-OSError receipt-write failures are ALSO non-blocking
+            # (e.g. validation bugs should not lock out recovery) — we
+            # log best-effort and proceed.
+            try:
+                from lib_log import log_event as _log_force_fail
+                _log_force_fail(
+                    _root_force,
+                    "force_override_receipt_write_failed",
+                    task=_task_id_force,
+                    task_id=_task_id_force,
+                    error="unexpected receipt writer failure",
+                )
+            except Exception:
+                pass
+
+    # ---- F10: Retrospective flush on DONE ----
+    # For any transition into DONE (force=True or force=False), copy the
+    # task's retrospective into the persistent project dir so it survives
+    # worktree removal and feeds collect_retrospectives().
+    # Failure (disk full, permission) does NOT block the DONE transition —
+    # force-style invariant: observability layer cannot wedge the state
+    # machine. Emits retrospective_flushed on success,
+    # retrospective_flush_failed on error.
+    if next_stage == "DONE":
+        _flush_retrospective_on_done(task_dir=task_dir, manifest=manifest)
 
     manifest["stage"] = next_stage
     if next_stage == "DONE":
@@ -908,16 +1448,85 @@ def find_active_tasks(root: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 def collect_retrospectives(root: Path) -> list[dict]:
-    """Collect all task retrospective JSON files from .dynos/."""
-    retrospectives: list[dict] = []
-    for path in sorted((root / ".dynos").glob("task-*/task-retrospective.json")):
+    """Collect all task retrospective JSON files from both the worktree
+    and the project-persistent directory.
+
+    Reads from:
+      - ``root/.dynos/task-*/task-retrospective.json`` (in-tree, written
+        by the audit skill).
+      - ``_persistent_project_dir(root)/retrospectives/*.json`` (written
+        by ``transition_task`` on the DONE edge — survives worktree
+        removal).
+
+    Dedupe policy: entries are keyed by ``retro["task_id"]`` (string).
+    When the same task appears in both sources, the PERSISTENT copy wins
+    because it is the hash-verified final state at DONE time; the
+    worktree copy may have been edited post-DONE (not supposed to
+    happen, but possible).
+
+    Missing persistent dir (new project, no DONE tasks yet) is treated
+    as empty. Malformed JSON is skipped silently on either side. Entries
+    without a string ``task_id`` are kept under synthetic keys so a
+    malformed registry cannot drop a legitimate worktree entry.
+    """
+    by_task_id: dict[str, dict] = {}
+    synth_counter = 0
+
+    def _ingest(path: Path, persistent: bool) -> None:
+        nonlocal synth_counter
         try:
             data = load_json(path)
         except (json.JSONDecodeError, FileNotFoundError, OSError):
-            continue
+            return
+        if not isinstance(data, dict):
+            return
         data["_path"] = str(path)
-        retrospectives.append(data)
-    return retrospectives
+        data["_source"] = "persistent" if persistent else "worktree"
+
+        tid = data.get("task_id")
+        if isinstance(tid, str) and tid:
+            key = tid
+        else:
+            # No task_id — give a synthetic, path-stable key so we never
+            # accidentally collapse legitimate-but-malformed entries.
+            synth_counter += 1
+            key = f"__no_task_id__::{data['_path']}::{synth_counter}"
+
+        existing = by_task_id.get(key)
+        if existing is None:
+            by_task_id[key] = data
+            return
+        existing_is_persistent = existing.get("_source") == "persistent"
+        if persistent and not existing_is_persistent:
+            # Persistent beats worktree.
+            by_task_id[key] = data
+        elif not persistent and existing_is_persistent:
+            # Worktree loses to persistent — keep existing.
+            return
+        else:
+            # Same source twice — last-write wins (deterministic given
+            # sorted iteration).
+            by_task_id[key] = data
+
+    # 1) Worktree retros.
+    try:
+        dynos_dir = root / ".dynos"
+        if dynos_dir.exists():
+            for path in sorted(dynos_dir.glob("task-*/task-retrospective.json")):
+                _ingest(path, persistent=False)
+    except OSError:
+        pass
+
+    # 2) Persistent retros — may not exist for new projects (cold start).
+    try:
+        persistent_dir = _persistent_project_dir(root) / "retrospectives"
+        if persistent_dir.exists():
+            for path in sorted(persistent_dir.glob("*.json")):
+                _ingest(path, persistent=True)
+    except OSError:
+        pass
+
+    return list(by_task_id.values())
 
 
 def retrospective_task_ids(root: Path) -> list[str]:

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -80,6 +80,7 @@ __all__ = [
     "validate_chain",
     "hash_file",
     "plan_validated_receipt_matches",
+    "plan_audit_matches",
     "receipt_plan_routing",
     "receipt_spec_validated",
     "receipt_plan_validated",
@@ -98,6 +99,7 @@ __all__ = [
     "receipt_postmortem_skipped",
     "receipt_calibration_applied",
     "receipt_rules_check_passed",
+    "receipt_force_override",
     "RECEIPT_CONTRACT_VERSION",
     "CALIBRATION_POLICY_FILES",
     "INJECTED_PROMPTS_DIR",
@@ -127,6 +129,11 @@ _LOG_MESSAGES: dict[str, str] = {
     "postmortem-skipped": "[DONE] postmortem skipped — reason={reason}",
     "calibration-applied": "[DONE] calibration applied — retros={retros_consumed} scores={scores_updated}",
     "rules-check-passed": "[DONE] rules check — {rules_evaluated} rules evaluated, {violations_count} violations",
+    # Prefix pattern: force-override-{from_stage}-{to_stage} — handled in
+    # write_receipt() via the prefix branch below. The entry here documents
+    # the format string for reviewers; the {N} placeholder is filled in by
+    # the writer using len(bypassed_gates) at write time.
+    "force-override-*": "[FORCE] {from_stage} → {to_stage} — bypassed {N} gate(s)",
 }
 
 
@@ -234,6 +241,17 @@ def write_receipt(task_dir: Path, step_name: str, **payload: Any) -> Path:
         append_execution_log(task_dir, f"[DONE] {step_name} — executor={payload.get('executor_type','')} agent={'learned:' + agent if injected else 'generic'} tokens={payload.get('tokens_used','?')}")
     elif step_name.startswith("audit-") and step_name != "audit-routing":
         append_execution_log(task_dir, f"[DONE] {step_name} — findings={payload.get('finding_count',0)} blocking={payload.get('blocking_count',0)}")
+    elif step_name.startswith("force-override-"):
+        # Dedicated log line for forced transitions. Format pinned by
+        # _LOG_MESSAGES["force-override-*"].
+        bypassed = payload.get("bypassed_gates", [])
+        n_bypassed = len(bypassed) if isinstance(bypassed, list) else 0
+        from_stage = payload.get("from_stage", "?")
+        to_stage = payload.get("to_stage", "?")
+        append_execution_log(
+            task_dir,
+            f"[FORCE] {from_stage} → {to_stage} — bypassed {n_bypassed} gate(s)",
+        )
 
     return receipt_path
 
@@ -436,11 +454,17 @@ def receipt_plan_validated(
     )
 
 
-def plan_validated_receipt_matches(task_dir: Path) -> bool:
+def plan_validated_receipt_matches(task_dir: Path) -> "bool | str":
     """Return True if a plan-validated receipt exists AND its captured
     artifact hashes match the current spec.md, plan.md, and
-    execution-graph.json content. Callers (e.g. execute preflight) can
-    use this to skip a full re-validation when nothing has drifted.
+    execution-graph.json content.
+
+    Returns ``False`` when the receipt is missing or malformed (e.g. an
+    older receipt without an ``artifact_hashes`` payload). Returns a
+    descriptive string naming the drifted artifact (e.g.
+    ``"plan.md hash drift"``) when the receipt is present but one of the
+    tracked artifacts has changed on disk. Callers distinguish these
+    three outcomes to surface drift-vs-missing distinctly.
     """
     receipt = read_receipt(task_dir, "plan-validated")
     if receipt is None or not receipt.get("validation_passed", False):
@@ -453,7 +477,53 @@ def plan_validated_receipt_matches(task_dir: Path) -> bool:
     for name in ("spec.md", "plan.md", "execution-graph.json"):
         current = _hash_artifact(task_dir / name)
         if current != captured.get(name):
-            return False
+            return f"{name} hash drift"
+    return True
+
+
+def plan_audit_matches(task_dir: Path) -> "bool | str":
+    """Return ``True`` if a ``plan-audit-check`` receipt exists AND its
+    captured artifact hashes match the current spec.md, plan.md, and
+    execution-graph.json content.
+
+    Returns ``False`` when the receipt is missing entirely. Returns a
+    descriptive string naming the drifted artifact (e.g.
+    ``"plan.md hash drift"``) when the receipt is present but one of the
+    tracked artifacts has changed on disk since the audit ran. Callers
+    distinguish the three outcomes to surface drift-vs-missing distinctly
+    at the PLAN_AUDIT exit gate.
+
+    Receipts written before the hash-binding landed (pre-F2) do not carry
+    ``spec_sha256``/``plan_sha256``/``graph_sha256`` fields. Such receipts
+    are treated as ``False`` (missing) so the gate forces a fresh audit
+    rather than silently trusting a legacy payload.
+    """
+    receipt = read_receipt(task_dir, "plan-audit-check")
+    if receipt is None:
+        return False
+    # Legacy receipts (pre-F2) lacked the three hash fields. Without
+    # hashes we cannot verify freshness — behave like missing.
+    expected_spec = receipt.get("spec_sha256")
+    expected_plan = receipt.get("plan_sha256")
+    expected_graph = receipt.get("graph_sha256")
+    if not (
+        isinstance(expected_spec, str) and expected_spec
+        and isinstance(expected_plan, str) and expected_plan
+        and isinstance(expected_graph, str) and expected_graph
+    ):
+        return False
+    # Hash each artifact on disk. Missing files count as drift with a
+    # descriptive string (the audit was computed over a file that is now
+    # absent — clearly not fresh).
+    current_spec = _hash_artifact(task_dir / "spec.md")
+    if current_spec != expected_spec:
+        return "spec.md hash drift"
+    current_plan = _hash_artifact(task_dir / "plan.md")
+    if current_plan != expected_plan:
+        return "plan.md hash drift"
+    current_graph = _hash_artifact(task_dir / "execution-graph.json")
+    if current_graph != expected_graph:
+        return "execution-graph.json hash drift"
     return True
 
 
@@ -716,32 +786,27 @@ def receipt_planner_spawn(  # called dynamically from skills/start/SKILL.md
     tokens_used: int | None,
     model_used: str | None = None,
     agent_name: str | None = None,
-    injected_prompt_sha256: str | None = _INJECTED_PROMPT_SHA256_MISSING,  # type: ignore[assignment]
+    injected_prompt_sha256: str = _INJECTED_PROMPT_SHA256_MISSING,  # type: ignore[assignment]
 ) -> Path:
     """Write receipt proving a planner subagent completed. Also records tokens.
 
-    SEC-004 hardening: ``injected_prompt_sha256`` is required at the call
-    site — callers MUST pass it explicitly (either a non-empty digest or
-    literal ``None`` for the legacy/no-sidecar path). Omitting the kwarg
-    is a caller bug and raises ``TypeError`` so a forgotten sidecar
-    assertion cannot silently ship.
+    SEC-004 hardening: ``injected_prompt_sha256`` is REQUIRED at the call
+    site. Omitting the kwarg entirely raises ``TypeError`` (the sentinel
+    default is a deliberate forced-kwarg pattern so a forgotten sidecar
+    assertion cannot silently ship). Passing ``injected_prompt_sha256=None``
+    explicitly is ALSO rejected — ``None`` is no longer a legal value and
+    raises ``ValueError`` with a message containing the substring
+    ``legacy None path removed``. The only valid value is a non-empty
+    sha256 hex digest captured from
+    ``hooks/router.py planner-inject-prompt --task-id <id> --phase <phase>``.
 
-    When ``injected_prompt_sha256`` is a non-empty string, asserts that
-    the per-phase planner injected-prompt sidecar at ``task_dir /
-    "receipts" / INJECTED_PLANNER_PROMPTS_DIR / f"{phase}.sha256"`` exists
-    AND its contents (after stripping trailing whitespace) match the
-    supplied digest. On missing file or mismatch this function raises
-    ``ValueError`` naming the phase. The mismatch message contains the
-    literal substring ``hash mismatch`` so downstream tests can pin it.
-
-    When ``injected_prompt_sha256`` is ``None`` (the legacy path —
-    explicitly requested by the caller), no assertion is performed and no
-    sidecar file is required. This legacy call mode is accepted but will
-    be removed once all call sites are migrated to invoke
-    ``hooks/router.py planner-inject-prompt`` before the receipt write.
-    Put plainly: legacy call (``injected_prompt_sha256=None`` must be
-    explicit) is accepted but will be removed once all call sites are
-    migrated.
+    The writer asserts that the per-phase planner injected-prompt sidecar
+    at ``task_dir / "receipts" / INJECTED_PLANNER_PROMPTS_DIR /
+    f"{phase}.sha256"`` exists AND its contents (after stripping trailing
+    whitespace) match the supplied digest. On missing file or mismatch
+    this function raises ``ValueError`` naming the phase. The mismatch
+    message contains the literal substring ``hash mismatch`` so
+    downstream tests can pin it.
 
     The sidecar path is
     ``task_dir/receipts/_injected-planner-prompts/{phase}.sha256`` — both
@@ -753,43 +818,46 @@ def receipt_planner_spawn(  # called dynamically from skills/start/SKILL.md
     if injected_prompt_sha256 is _INJECTED_PROMPT_SHA256_MISSING:
         raise TypeError(
             "receipt_planner_spawn: injected_prompt_sha256 is required. "
-            "Pass a non-empty sha256 hex digest (after running "
+            "Pass a non-empty sha256 hex digest obtained from "
             "`hooks/router.py planner-inject-prompt --task-id <id> "
-            "--phase <phase>`) OR pass `injected_prompt_sha256=None` "
-            "explicitly for the legacy no-sidecar path."
+            "--phase <phase>`. The None (no-sidecar) path has been removed."
+        )
+    if injected_prompt_sha256 is None:
+        raise ValueError(
+            "injected_prompt_sha256 must be a non-empty sha256 hex string; "
+            "legacy None path removed"
         )
     step_name = f"planner-{phase}"
 
-    # Sidecar assertion — only active when the caller opted in by passing
-    # a non-None digest. Legacy callers (None) skip this entirely.
-    if injected_prompt_sha256 is not None:
-        if not isinstance(injected_prompt_sha256, str) or not injected_prompt_sha256:
-            raise ValueError(
-                "receipt_planner_spawn: injected_prompt_sha256 must be a "
-                "non-empty string when provided"
-            )
-        sidecar_file = (
-            task_dir / "receipts" / INJECTED_PLANNER_PROMPTS_DIR
-            / f"{phase}.sha256"
+    # Sidecar assertion — unconditional now. Every caller must first run
+    # `hooks/router.py planner-inject-prompt` and pass the captured digest.
+    if not isinstance(injected_prompt_sha256, str) or not injected_prompt_sha256:
+        raise ValueError(
+            "receipt_planner_spawn: injected_prompt_sha256 must be a "
+            "non-empty string"
         )
-        if not sidecar_file.exists():
-            raise ValueError(
-                f"receipt_planner_spawn: planner sidecar missing for phase "
-                f"{phase!r} at {sidecar_file}. Run `hooks/router.py "
-                f"planner-inject-prompt --task-id <id> --phase {phase}` first."
-            )
-        try:
-            on_disk = sidecar_file.read_text().strip()
-        except OSError as e:
-            raise ValueError(
-                f"receipt_planner_spawn: planner sidecar unreadable for "
-                f"phase {phase!r} at {sidecar_file}: {e}"
-            ) from e
-        if on_disk != injected_prompt_sha256:
-            raise ValueError(
-                f"receipt_planner_spawn: hash mismatch for phase {phase!r} "
-                f"— sidecar={on_disk!r}, payload={injected_prompt_sha256!r}."
-            )
+    sidecar_file = (
+        task_dir / "receipts" / INJECTED_PLANNER_PROMPTS_DIR
+        / f"{phase}.sha256"
+    )
+    if not sidecar_file.exists():
+        raise ValueError(
+            f"receipt_planner_spawn: planner sidecar missing for phase "
+            f"{phase!r} at {sidecar_file}. Run `hooks/router.py "
+            f"planner-inject-prompt --task-id <id> --phase {phase}` first."
+        )
+    try:
+        on_disk = sidecar_file.read_text().strip()
+    except OSError as e:
+        raise ValueError(
+            f"receipt_planner_spawn: planner sidecar unreadable for "
+            f"phase {phase!r} at {sidecar_file}: {e}"
+        ) from e
+    if on_disk != injected_prompt_sha256:
+        raise ValueError(
+            f"receipt_planner_spawn: hash mismatch for phase {phase!r} "
+            f"— sidecar={on_disk!r}, payload={injected_prompt_sha256!r}."
+        )
 
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, f"planner-{phase}", model_used or "default", tokens_used)
@@ -809,8 +877,31 @@ def receipt_plan_audit(
     tokens_used: int | None,
     finding_count: int = 0,
     model_used: str | None = None,
+    *,
+    spec_sha256: str,
+    plan_sha256: str,
+    graph_sha256: str,
 ) -> Path:
-    """Write receipt proving plan audit (spec-completion check) ran. Also records tokens."""
+    """Write receipt proving plan audit (spec-completion check) ran.
+
+    Hash-binding (F2): the three keyword-only arguments ``spec_sha256``,
+    ``plan_sha256``, and ``graph_sha256`` are REQUIRED. Each must be a
+    non-empty string (typically a sha256 hex digest of the corresponding
+    artifact at audit time). These hashes are embedded in the receipt
+    payload so the PLAN_AUDIT exit gate can detect artifact drift via
+    ``plan_audit_matches(task_dir)`` and refuse to advance when the audit
+    was computed over a stale version of the artifacts.
+
+    Also records token usage to ``token-usage.json`` when ``tokens_used``
+    is positive.
+    """
+    if not isinstance(spec_sha256, str) or not spec_sha256:
+        raise ValueError("spec_sha256 must be a non-empty string")
+    if not isinstance(plan_sha256, str) or not plan_sha256:
+        raise ValueError("plan_sha256 must be a non-empty string")
+    if not isinstance(graph_sha256, str) or not graph_sha256:
+        raise ValueError("graph_sha256 must be a non-empty string")
+
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, "plan-audit-check", model_used or "default", tokens_used)
     return write_receipt(
@@ -819,6 +910,9 @@ def receipt_plan_audit(
         tokens_used=tokens_used,
         finding_count=finding_count,
         model_used=model_used,
+        spec_sha256=spec_sha256,
+        plan_sha256=plan_sha256,
+        graph_sha256=graph_sha256,
     )
 
 
@@ -1061,6 +1155,68 @@ def receipt_rules_check_passed(
         rules_file_sha256=rules_file_sha256,
         checked_at=now_iso(),
         mode=mode,
+    )
+
+
+def receipt_force_override(
+    task_dir: Path,
+    from_stage: str,
+    to_stage: str,
+    bypassed_gates: list[str],
+) -> Path:
+    """Write receipt proving a forced stage transition occurred.
+
+    Emitted by ``transition_task`` when invoked with ``force=True``. The
+    payload enumerates the gate errors that would have been raised if
+    ``force`` were ``False`` (``bypassed_gates``) so the audit chain
+    records not just that force was used but which guardrails it
+    bypassed.
+
+    Writes ``receipts/force-override-{from_stage}-{to_stage}.json``. One
+    force per edge — subsequent forced transitions over the same edge
+    overwrite via the atomic write path.
+
+    Validation:
+      - ``from_stage`` and ``to_stage`` MUST be non-empty strings; empty
+        or non-string values raise ``ValueError`` naming the arg.
+      - ``bypassed_gates`` MUST be a list (possibly empty). Every entry
+        MUST be a string. Any other container type or non-string entry
+        raises ``ValueError``.
+    """
+    if not isinstance(from_stage, str) or not from_stage:
+        raise ValueError("from_stage must be a non-empty string")
+    if not isinstance(to_stage, str) or not to_stage:
+        raise ValueError("to_stage must be a non-empty string")
+    # SEC-002 hardening: stage names MUST be strict uppercase identifier
+    # slugs. Prevents path traversal via crafted manifest["stage"] values
+    # like "../../etc/x" reaching the receipt filename.
+    import re as _re_stage
+    _STAGE_RE = r"^[A-Z][A-Z0-9_]*$"
+    if not _re_stage.match(_STAGE_RE, from_stage):
+        raise ValueError(
+            f"from_stage must match {_STAGE_RE} (got {from_stage!r})"
+        )
+    if not _re_stage.match(_STAGE_RE, to_stage):
+        raise ValueError(
+            f"to_stage must match {_STAGE_RE} (got {to_stage!r})"
+        )
+    if not isinstance(bypassed_gates, list):
+        raise ValueError("bypassed_gates must be a list of strings")
+    for idx, entry in enumerate(bypassed_gates):
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"bypassed_gates[{idx}] must be a string (got {type(entry).__name__})"
+            )
+
+    step_name = f"force-override-{from_stage}-{to_stage}"
+    return write_receipt(
+        task_dir,
+        step_name,
+        from_stage=from_stage,
+        to_stage=to_stage,
+        bypassed_gates=list(bypassed_gates),
+        bypassed_count=len(bypassed_gates),
+        forced_at=now_iso(),
     )
 
 

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -576,15 +576,19 @@ def compute_reward(task_dir: Path) -> dict:
             pass
 
     # --- 3. Spec review iterations ---
+    # Count approval receipts (not log lines): matches the current filename
+    # `human-approval-SPEC_REVIEW.json` and any future rotation suffix
+    # (e.g. `human-approval-SPEC_REVIEW-002.json`). No fallback to
+    # `execution-log.md` scanning — the log-line scanner was deprecated
+    # because log lines are not a hash-bound audit record.
+    receipts_dir = task_dir / "receipts"
     spec_review_iterations = 0
+    if receipts_dir.is_dir():
+        spec_review_iterations = len(list(receipts_dir.glob("human-approval-SPEC_REVIEW*.json")))
+
+    # execution-log.md path is still needed below for DORA recovery-time
+    # tracking and subagent-spawn counting (sections 4b and 6).
     log_path = task_dir / "execution-log.md"
-    if log_path.exists():
-        try:
-            for line in log_path.read_text().splitlines():
-                if "[HUMAN] SPEC_REVIEW" in line:
-                    spec_review_iterations += 1
-        except OSError:
-            pass
 
     # --- 4. Classification from manifest ---
     manifest = load_json(task_dir / "manifest.json")

--- a/hooks/validate_task_artifacts.py
+++ b/hooks/validate_task_artifacts.py
@@ -40,9 +40,13 @@ def main() -> int:
 
     # Receipt short-circuit: if planning already validated these exact
     # artifacts and nothing has drifted, skip the redo entirely.
+    # plan_validated_receipt_matches returns True on a fresh match; a
+    # drift string or False means we must re-run validation. Use strict
+    # identity check because `str` is truthy and would otherwise
+    # short-circuit through a drifted receipt.
     if use_receipt:
         from lib_receipts import plan_validated_receipt_matches
-        if plan_validated_receipt_matches(task_dir):
+        if plan_validated_receipt_matches(task_dir) is True:
             print(f"Artifact validation skipped (plan-validated receipt fresh) for {task_dir}")
             return 0
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -72,7 +72,22 @@ receipt_plan_validated(
 )
 
 # After spec-completion auditor (plan audit; only invoked for high/critical risk):
-receipt_plan_audit(task_dir, tokens_used=TOTAL_TOKENS, finding_count=N)
+# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
+# compute them at audit time via:
+#   from lib_receipts import hash_file
+#   spec_sha256 = hash_file(task_dir / "spec.md")
+#   plan_sha256 = hash_file(task_dir / "plan.md")
+#   graph_sha256 = hash_file(task_dir / "execution-graph.json")
+# The PLAN_AUDIT exit gate re-hashes these artifacts and refuses to advance
+# when any has drifted since the audit was recorded.
+receipt_plan_audit(
+    task_dir,
+    tokens_used=TOTAL_TOKENS,
+    finding_count=N,
+    spec_sha256=SPEC_SHA256,
+    plan_sha256=PLAN_SHA256,
+    graph_sha256=GRAPH_SHA256,
+)
 
 ```
 

--- a/tests/test_collect_retrospectives_union.py
+++ b/tests/test_collect_retrospectives_union.py
@@ -1,0 +1,171 @@
+"""Tests for `collect_retrospectives` reading both worktree and
+persistent sources (F11, CRITERION 11).
+
+`collect_retrospectives(root)` now unions entries from:
+  - `root/.dynos/task-*/task-retrospective.json` (the worktree copy)
+  - `_persistent_project_dir(root)/retrospectives/*.json` (the
+    copy-on-DONE flush destination)
+
+Deduplication is keyed by `retro["task_id"]`. When the same task
+appears in both, the PERSISTENT copy wins (it is the hash-verified
+final state at DONE time; the worktree copy may have been edited
+post-DONE).
+
+Missing persistent dir is treated as empty (cold-start for new
+projects). Malformed JSON is skipped silently on either side.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import (  # noqa: E402
+    _persistent_project_dir,
+    collect_retrospectives,
+)
+
+
+def _setup_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a project tmp dir and point DYNOS_HOME at a sibling dir
+    so `_persistent_project_dir(root)` resolves inside the test tree."""
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(home))
+    project = tmp_path / "project"
+    (project / ".dynos").mkdir(parents=True)
+    return project
+
+
+def _write_worktree_retro(root: Path, task_id: str, *, extra: dict | None = None) -> None:
+    """Write a task-retrospective.json under `.dynos/{task_id}/`."""
+    td = root / ".dynos" / task_id
+    td.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"task_id": task_id, "quality_score": 0.5, "_origin": "worktree"}
+    if extra:
+        payload.update(extra)
+    (td / "task-retrospective.json").write_text(json.dumps(payload))
+
+
+def _write_persistent_retro(root: Path, task_id: str, *, extra: dict | None = None) -> None:
+    """Write a retrospective into the persistent dir (the copy-on-DONE
+    flush destination)."""
+    pdir = _persistent_project_dir(root) / "retrospectives"
+    pdir.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"task_id": task_id, "quality_score": 0.9, "_origin": "persistent"}
+    if extra:
+        payload.update(extra)
+    (pdir / f"{task_id}.json").write_text(json.dumps(payload))
+
+
+def _tids(retros: list[dict]) -> set[str]:
+    return {r.get("task_id") for r in retros if isinstance(r.get("task_id"), str)}
+
+
+# ---------------------------------------------------------------------------
+# Union behavior
+# ---------------------------------------------------------------------------
+
+
+def test_merges_both_sources(tmp_path: Path,
+                             monkeypatch: pytest.MonkeyPatch) -> None:
+    """A worktree-only task and a persistent-only task must both appear
+    in the result — the union of the two sources."""
+    root = _setup_project(tmp_path, monkeypatch)
+    _write_worktree_retro(root, "task-A")
+    _write_persistent_retro(root, "task-B")
+
+    retros = collect_retrospectives(root)
+    assert _tids(retros) == {"task-A", "task-B"}
+
+
+def test_persistent_wins_on_conflict(tmp_path: Path,
+                                      monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same task_id present in BOTH sources with different content.
+    The result must reflect the persistent-dir row, not the worktree
+    row. Keyed by `_origin` which we set to "worktree" / "persistent"."""
+    root = _setup_project(tmp_path, monkeypatch)
+    _write_worktree_retro(root, "task-X",
+                          extra={"quality_score": 0.01})
+    _write_persistent_retro(root, "task-X",
+                            extra={"quality_score": 0.99})
+
+    retros = collect_retrospectives(root)
+    rows = [r for r in retros if r.get("task_id") == "task-X"]
+    assert len(rows) == 1, f"expected exactly one row for task-X — got {rows!r}"
+    row = rows[0]
+    # Persistent wins — row shows persistent's _origin + its quality_score.
+    assert row.get("_origin") == "persistent", (
+        f"persistent must win on conflict — got _origin={row.get('_origin')!r}"
+    )
+    assert row.get("quality_score") == 0.99
+
+
+def test_works_when_persistent_dir_missing(tmp_path: Path,
+                                            monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh project with no persistent retrospectives dir returns
+    only worktree rows without raising. Cold-start scenario."""
+    root = _setup_project(tmp_path, monkeypatch)
+    _write_worktree_retro(root, "task-solo")
+    # _persistent_project_dir(root)/retrospectives is absent.
+    assert not (_persistent_project_dir(root) / "retrospectives").exists()
+
+    retros = collect_retrospectives(root)
+    assert _tids(retros) == {"task-solo"}
+
+
+def test_works_when_worktree_is_empty(tmp_path: Path,
+                                       monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only persistent retrospectives present; `.dynos/` has no
+    task-*/ directories. Result returns the persistent rows."""
+    root = _setup_project(tmp_path, monkeypatch)
+    _write_persistent_retro(root, "task-persistent-only")
+    # No worktree retros.
+    retros = collect_retrospectives(root)
+    assert _tids(retros) == {"task-persistent-only"}
+
+
+def test_skips_malformed_json(tmp_path: Path,
+                               monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed retro file (invalid JSON) in the persistent dir must
+    not crash `collect_retrospectives`. Valid rows around it are still
+    returned."""
+    root = _setup_project(tmp_path, monkeypatch)
+    pdir = _persistent_project_dir(root) / "retrospectives"
+    pdir.mkdir(parents=True, exist_ok=True)
+    # Good entry.
+    _write_persistent_retro(root, "task-good")
+    # Malformed entry.
+    (pdir / "task-bad.json").write_text("{not valid json")
+
+    retros = collect_retrospectives(root)
+    # No crash. The good entry is in the result; the malformed one
+    # is either skipped or kept under a synthetic key — either way it
+    # must not cause an exception and must not shadow task-good.
+    assert "task-good" in _tids(retros)
+
+
+def test_malformed_worktree_entry_does_not_drop_persistent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive regression: a malformed worktree retro in the same
+    task_id namespace must not shadow a valid persistent copy. The
+    impl keys synthetic-task-id entries under a `__no_task_id__::...`
+    slot so a malformed entry can never collapse a legitimate row
+    sharing its task_id."""
+    root = _setup_project(tmp_path, monkeypatch)
+    # Malformed worktree file.
+    td = root / ".dynos" / "task-gremlin"
+    td.mkdir(parents=True)
+    (td / "task-retrospective.json").write_text("{broken")
+    # Valid persistent row for the same task_id — MUST survive.
+    _write_persistent_retro(root, "task-gremlin", extra={"quality_score": 0.88})
+
+    retros = collect_retrospectives(root)
+    rows = [r for r in retros if r.get("task_id") == "task-gremlin"]
+    assert len(rows) == 1, f"lost persistent row for task-gremlin: {retros!r}"
+    assert rows[0]["quality_score"] == 0.88

--- a/tests/test_force_override_observability.py
+++ b/tests/test_force_override_observability.py
@@ -1,0 +1,270 @@
+"""Tests for the force_override observability layer (F7 + F8,
+CRITERIA 7 and 8).
+
+When `transition_task` is called with `force=True`:
+
+  (F7) Before mutating the manifest, compute what the gate block WOULD
+       have refused on — `bypassed_gates: list[str]` — then
+         (a) emit a `force_override` event via `log_event` with
+             `task_id`, `from_stage`, `to_stage`, `bypassed_gates`.
+         (b) write `receipts/force-override-{from}-{to}.json` via the
+             new `receipt_force_override` writer.
+
+  (F8) `receipt_force_override(task_dir, from_stage, to_stage,
+       bypassed_gates)` validates its inputs and writes a well-formed
+       receipt payload. Bad args → ValueError naming the arg.
+
+Neither (F7)'s observability write nor (F8)'s validation must ever
+block a forced transition — force is a break-glass door by design.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import transition_task  # noqa: E402
+from lib_receipts import receipt_force_override  # noqa: E402
+
+
+def _read_events(td: Path) -> list[dict]:
+    """Read all task-scoped events.jsonl entries as a list of dicts.
+
+    The F7 event is emitted via `log_event(root, "force_override",
+    task=task_id, ...)`. `log_event` routes to the task-scoped file
+    when the task dir exists, which it does in these tests.
+    """
+    events_path = td / "events.jsonl"
+    if not events_path.exists():
+        return []
+    events: list[dict] = []
+    for line in events_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        events.append(json.loads(line))
+    return events
+
+
+def _setup_pre_exec_task(tmp_path: Path, slug: str = "FO") -> Path:
+    """A task at PRE_EXECUTION_SNAPSHOT with NO plan-validated receipt.
+    PRE_EXECUTION_SNAPSHOT → EXECUTION refuses by default (plan was
+    never validated). force=True turns that into a bypassed gate."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / f"task-20260419-{slug}"
+    td.mkdir(parents=True)
+    (td / "spec.md").write_text("# s\n")
+    (td / "plan.md").write_text("# p\n")
+    (td / "execution-graph.json").write_text("{}\n")
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": "PRE_EXECUTION_SNAPSHOT",
+        "classification": {"risk_level": "medium"},
+    }))
+    return td
+
+
+def _setup_noop_task(tmp_path: Path, slug: str = "NOOP") -> Path:
+    """A task at FOUNDRY_INITIALIZED advancing to SPEC_NORMALIZATION.
+    That edge has no receipt gates (see ALLOWED_STAGE_TRANSITIONS and
+    the gate block in transition_task), so a force=True call emits a
+    `force_override` event/receipt with an EMPTY `bypassed_gates` list.
+    This pins the "every force produces a receipt" invariant (ADR /
+    Plan Open Question #2 — empty list still records)."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / f"task-20260419-{slug}"
+    td.mkdir(parents=True)
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": "FOUNDRY_INITIALIZED",
+        "classification": {"risk_level": "medium"},
+    }))
+    return td
+
+
+# ---------------------------------------------------------------------------
+# F7: force_override receipt + event
+# ---------------------------------------------------------------------------
+
+
+def test_forced_transition_writes_receipt(tmp_path: Path) -> None:
+    """force=True across a would-refuse edge → the
+    `force-override-{from}-{to}.json` receipt is created by
+    `transition_task`."""
+    td = _setup_pre_exec_task(tmp_path, slug="FO-RCPT")
+    # Sanity check: without force the gate refuses (proves there IS a
+    # gate to bypass on this edge).
+    with pytest.raises(ValueError):
+        transition_task(td, "EXECUTION")
+
+    transition_task(td, "EXECUTION", force=True)
+
+    receipt_path = td / "receipts" / "force-override-PRE_EXECUTION_SNAPSHOT-EXECUTION.json"
+    assert receipt_path.exists(), (
+        f"force_override receipt must exist at {receipt_path}"
+    )
+    payload = json.loads(receipt_path.read_text())
+    assert payload["from_stage"] == "PRE_EXECUTION_SNAPSHOT"
+    assert payload["to_stage"] == "EXECUTION"
+    assert isinstance(payload["bypassed_gates"], list)
+    # The plan-validated missing gate should have been captured.
+    joined = " ".join(payload["bypassed_gates"])
+    assert "plan-validated" in joined or "plan was never validated" in joined, (
+        f"bypassed_gates did not capture the plan-validated gate: {payload['bypassed_gates']!r}"
+    )
+
+
+def test_forced_transition_emits_force_override_event(tmp_path: Path) -> None:
+    """force=True → a `force_override` entry is appended to events.jsonl,
+    carrying the task_id and a non-empty `bypassed_gates` list."""
+    td = _setup_pre_exec_task(tmp_path, slug="FO-EVT")
+    transition_task(td, "EXECUTION", force=True)
+
+    events = _read_events(td)
+    force_events = [e for e in events if e.get("event") == "force_override"]
+    assert len(force_events) >= 1, (
+        f"no force_override event found in events.jsonl — got events: {[e.get('event') for e in events]}"
+    )
+    ev = force_events[0]
+    assert ev.get("task_id") == td.name, f"task_id mismatch: {ev!r}"
+    assert ev.get("from_stage") == "PRE_EXECUTION_SNAPSHOT"
+    assert ev.get("to_stage") == "EXECUTION"
+    assert isinstance(ev.get("bypassed_gates"), list)
+    assert len(ev["bypassed_gates"]) >= 1, (
+        f"bypassed_gates must be non-empty for a refused edge: {ev!r}"
+    )
+
+
+def test_forced_transition_with_no_bypassed_gates_still_records(tmp_path: Path) -> None:
+    """force=True on an edge that would NOT have refused still writes a
+    receipt + event, but with an empty `bypassed_gates` list. The
+    invariant is "every force leaves a trace", regardless of whether
+    force was strictly necessary."""
+    td = _setup_noop_task(tmp_path, slug="FO-NOOP")
+    transition_task(td, "SPEC_NORMALIZATION", force=True)
+
+    receipt_path = td / "receipts" / "force-override-FOUNDRY_INITIALIZED-SPEC_NORMALIZATION.json"
+    assert receipt_path.exists()
+    payload = json.loads(receipt_path.read_text())
+    assert payload["bypassed_gates"] == [], (
+        f"no-gate edge must record an empty bypassed_gates list: {payload!r}"
+    )
+
+    events = _read_events(td)
+    force_events = [e for e in events if e.get("event") == "force_override"]
+    assert len(force_events) == 1, (
+        f"exactly one force_override event expected — got {force_events!r}"
+    )
+    assert force_events[0].get("bypassed_gates") == []
+
+
+# ---------------------------------------------------------------------------
+# F8: receipt_force_override writer validation
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_writer_signature_valid_args(tmp_path: Path) -> None:
+    """Direct call with valid args → a receipt file exists, and the
+    payload carries the exact values we passed in."""
+    td = tmp_path / ".dynos" / "task-FO-DIRECT"
+    td.mkdir(parents=True)
+    out = receipt_force_override(
+        td,
+        from_stage="X",
+        to_stage="Y",
+        bypassed_gates=["gate1"],
+    )
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["from_stage"] == "X"
+    assert payload["to_stage"] == "Y"
+    assert payload["bypassed_gates"] == ["gate1"]
+
+
+def test_receipt_writer_rejects_path_traversal_stage(tmp_path: Path) -> None:
+    """SEC-002 regression: crafted stage values must not escape receipts/.
+    Stage names must match ^[A-Z][A-Z0-9_]*$ to prevent path injection."""
+    td = _setup_pre_exec_task(tmp_path, slug="SEC2")
+    with pytest.raises(ValueError, match="from_stage must match"):
+        receipt_force_override(td, "../../etc/x", "DONE", [])
+    with pytest.raises(ValueError, match="to_stage must match"):
+        receipt_force_override(td, "EXECUTION", "../evil", [])
+    with pytest.raises(ValueError, match="from_stage must match"):
+        receipt_force_override(td, "execution", "DONE", [])  # lowercase rejected
+    with pytest.raises(ValueError, match="to_stage must match"):
+        receipt_force_override(td, "EXECUTION", "done/x", [])
+
+
+def test_receipt_writer_rejects_bad_args(tmp_path: Path) -> None:
+    """Every bad-arg combination → ValueError naming the offending arg.
+    This is a guardrail against silent "" / None / non-list slipping
+    into the receipt chain."""
+    td = tmp_path / ".dynos" / "task-FO-BAD"
+    td.mkdir(parents=True)
+
+    # Empty from_stage
+    with pytest.raises(ValueError, match="from_stage"):
+        receipt_force_override(td, from_stage="", to_stage="Y", bypassed_gates=[])
+
+    # Empty to_stage
+    with pytest.raises(ValueError, match="to_stage"):
+        receipt_force_override(td, from_stage="X", to_stage="", bypassed_gates=[])
+
+    # Non-list bypassed_gates
+    with pytest.raises(ValueError, match="bypassed_gates"):
+        receipt_force_override(
+            td, from_stage="X", to_stage="Y",
+            bypassed_gates="not a list",  # type: ignore[arg-type]
+        )
+
+    # List with non-string entry
+    with pytest.raises(ValueError, match="bypassed_gates"):
+        receipt_force_override(
+            td, from_stage="X", to_stage="Y",
+            bypassed_gates=[1, 2, 3],  # type: ignore[list-item]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run isolation — force=True must NOT leak state into force=False.
+# ---------------------------------------------------------------------------
+
+
+def test_forced_transition_does_not_corrupt_normal_gate_state(tmp_path: Path) -> None:
+    """ADR Risk-Note: the dry-run gate pass used to compute
+    `bypassed_gates` runs on a LOCAL `errs` list that must NOT
+    contaminate a subsequent force=False call's gate block.
+
+    Scenario:
+      1. Task A: force=True across a would-refuse edge. A's dry-run
+         builds a non-empty bypassed_gates list.
+      2. Task B (separate task): force=False across the SAME edge
+         (with all gates satisfied). B MUST pass cleanly — no leaked
+         errs from Task A.
+    """
+    # --- Task A: force=True on a would-refuse edge --------------------
+    td_a = _setup_pre_exec_task(tmp_path, slug="ISO-A")
+    transition_task(td_a, "EXECUTION", force=True)
+    manifest_a = json.loads((td_a / "manifest.json").read_text())
+    assert manifest_a["stage"] == "EXECUTION"
+
+    # --- Task B: a fresh task on the SAME edge, force=False ----------
+    # Write a valid plan-validated receipt so the gate passes legitimately.
+    td_b = _setup_pre_exec_task(tmp_path, slug="ISO-B")
+    from lib_receipts import receipt_plan_validated
+    receipt_plan_validated(td_b, segment_count=0, criteria_coverage=[])
+    # No force this time — the gate must evaluate clean with no leak
+    # from the prior force=True call in the same process.
+    transition_task(td_b, "EXECUTION")
+    manifest_b = json.loads((td_b / "manifest.json").read_text())
+    assert manifest_b["stage"] == "EXECUTION"
+    # Task B must NOT have produced a force_override receipt (it was
+    # not forced).
+    force_rcpt = td_b / "receipts" / "force-override-PRE_EXECUTION_SNAPSHOT-EXECUTION.json"
+    assert not force_rcpt.exists(), (
+        f"Task B (force=False) must not emit a force_override receipt: {force_rcpt}"
+    )

--- a/tests/test_gate_execution_freshness.py
+++ b/tests/test_gate_execution_freshness.py
@@ -1,0 +1,135 @@
+"""Tests for the EXECUTION gate's hash-bound plan-validated freshness (F1, CRITERION 1).
+
+The EXECUTION gate at `hooks/lib_core.py` used to accept any
+`plan-validated` receipt (presence check). F1 extends the gate so a
+*stale* receipt — one written when the artifacts had different content
+than on disk today — cannot authorize the transition. Drift and missing
+emit distinct error strings so the operator can tell them apart.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import transition_task  # noqa: E402
+from lib_receipts import receipt_plan_validated  # noqa: E402
+
+
+def _setup_task(tmp_path: Path) -> Path:
+    """Build a task at PRE_EXECUTION_SNAPSHOT with the three planning artifacts
+    present (spec.md / plan.md / execution-graph.json). PRE_EXECUTION_SNAPSHOT
+    is the only stage that can advance to EXECUTION per
+    ALLOWED_STAGE_TRANSITIONS."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / "task-20260419-EX"
+    td.mkdir(parents=True)
+    (td / "spec.md").write_text("# spec v1\n")
+    (td / "plan.md").write_text("# plan v1\n")
+    (td / "execution-graph.json").write_text('{"task_id": "task-20260419-EX", "segments": []}\n')
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260419-EX",
+        "stage": "PRE_EXECUTION_SNAPSHOT",
+        "classification": {"risk_level": "medium"},
+    }))
+    return td
+
+
+def test_gate_refuses_when_plan_drifts(tmp_path: Path) -> None:
+    """Write a valid plan-validated receipt, then mutate plan.md. The
+    EXECUTION gate must refuse because the captured artifact hashes no
+    longer match disk. The error must name the drifted artifact via the
+    literal substring `plan.md hash` so operators can tell drift from
+    a missing-receipt failure."""
+    td = _setup_task(tmp_path)
+    receipt_plan_validated(td, segment_count=0, criteria_coverage=[])
+    # Mutate plan.md AFTER the receipt was written. The receipt's
+    # captured hash is now stale.
+    (td / "plan.md").write_text("# plan v2 DRIFTED\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "EXECUTION")
+    msg = str(excinfo.value)
+    assert "plan.md hash" in msg, (
+        f"drift message must contain 'plan.md hash' substring — got: {msg!r}"
+    )
+    # Manifest must NOT have advanced.
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "PRE_EXECUTION_SNAPSHOT"
+
+
+def test_gate_accepts_when_plan_unchanged(tmp_path: Path) -> None:
+    """With a fresh receipt and unchanged artifacts, the EXECUTION
+    transition must succeed and the manifest must reflect the new stage."""
+    td = _setup_task(tmp_path)
+    receipt_plan_validated(td, segment_count=0, criteria_coverage=[])
+
+    transition_task(td, "EXECUTION")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "EXECUTION"
+
+
+def test_gate_still_refuses_when_receipt_missing(tmp_path: Path) -> None:
+    """No receipt at all. The pre-existing `plan was never validated`
+    message must still fire — F1 only *extends* the gate, never weakens
+    the missing-receipt branch."""
+    td = _setup_task(tmp_path)
+    # Intentionally do NOT write a plan-validated receipt.
+
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "EXECUTION")
+    msg = str(excinfo.value)
+    assert "plan was never validated" in msg, (
+        f"missing-receipt message must contain 'plan was never validated' — "
+        f"got: {msg!r}"
+    )
+
+
+def test_drift_and_missing_produce_distinct_messages(tmp_path: Path) -> None:
+    """F12: the two failure modes must emit semantically distinct strings.
+    An operator diagnosing a refusal must be able to tell hash drift
+    apart from never-validated at a glance — without that, F1's whole
+    point (surface drift) is invisible.
+
+    Concretely we assert:
+      - the drift message DOES NOT contain the never-validated phrase.
+      - the missing-receipt message DOES NOT contain the drift phrase.
+    """
+    # --- drift path -------------------------------------------------
+    td_drift = _setup_task(tmp_path)
+    receipt_plan_validated(td_drift, segment_count=0, criteria_coverage=[])
+    (td_drift / "plan.md").write_text("# drifted\n")
+    with pytest.raises(ValueError) as drift_excinfo:
+        transition_task(td_drift, "EXECUTION")
+    drift_msg = str(drift_excinfo.value)
+
+    # --- missing path -----------------------------------------------
+    # Use a second task dir so we don't pollute the drift state.
+    project2 = tmp_path / "project2"
+    td_missing = project2 / ".dynos" / "task-20260419-EX2"
+    td_missing.mkdir(parents=True)
+    (td_missing / "spec.md").write_text("# s\n")
+    (td_missing / "plan.md").write_text("# p\n")
+    (td_missing / "execution-graph.json").write_text("{}\n")
+    (td_missing / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260419-EX2",
+        "stage": "PRE_EXECUTION_SNAPSHOT",
+        "classification": {"risk_level": "medium"},
+    }))
+    with pytest.raises(ValueError) as miss_excinfo:
+        transition_task(td_missing, "EXECUTION")
+    miss_msg = str(miss_excinfo.value)
+
+    # Distinctness — each branch must NOT wear the other branch's vocabulary.
+    assert "was never validated" not in drift_msg, (
+        f"drift message leaked never-validated vocabulary: {drift_msg!r}"
+    )
+    assert "hash drift" not in miss_msg, (
+        f"missing message leaked hash-drift vocabulary: {miss_msg!r}"
+    )
+    # Sanity check — the two messages are different strings.
+    assert drift_msg != miss_msg

--- a/tests/test_gate_plan_audit.py
+++ b/tests/test_gate_plan_audit.py
@@ -10,13 +10,19 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
 
 from lib_core import transition_task  # noqa: E402
-from lib_receipts import receipt_plan_audit  # noqa: E402
+from lib_receipts import receipt_plan_audit, hash_file  # noqa: E402
 
 
 def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Path:
     project = tmp_path / "project"
     td = project / ".dynos" / "task-20260418-PA"
     td.mkdir(parents=True)
+    # Create the three artifacts the PLAN_AUDIT exit gate's hash-binding
+    # check re-hashes. Without these files the hash match would fail and
+    # high/critical-risk transitions would refuse even with a receipt.
+    (td / "spec.md").write_text("# spec")
+    (td / "plan.md").write_text("# plan")
+    (td / "execution-graph.json").write_text('{"segments": []}')
     classification: dict = {"risk_level": risk}
     if tdd_required is not None:
         classification["tdd_required"] = tdd_required
@@ -26,6 +32,18 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
         "classification": classification,
     }))
     return td
+
+
+def _write_plan_audit(td: Path) -> None:
+    """Write a plan-audit-check receipt bound to the current artifact hashes."""
+    receipt_plan_audit(
+        td,
+        tokens_used=100,
+        finding_count=0,
+        spec_sha256=hash_file(td / "spec.md"),
+        plan_sha256=hash_file(td / "plan.md"),
+        graph_sha256=hash_file(td / "execution-graph.json"),
+    )
 
 
 def test_critical_without_receipt_refuses(tmp_path: Path):
@@ -42,7 +60,7 @@ def test_high_without_receipt_refuses(tmp_path: Path):
 
 def test_critical_with_receipt_passes(tmp_path: Path):
     td = _setup(tmp_path, risk="critical")
-    receipt_plan_audit(td, tokens_used=100, finding_count=0)
+    _write_plan_audit(td)
     transition_task(td, "PRE_EXECUTION_SNAPSHOT")
     assert json.loads((td / "manifest.json").read_text())["stage"] == "PRE_EXECUTION_SNAPSHOT"
 

--- a/tests/test_gate_plan_audit_freshness.py
+++ b/tests/test_gate_plan_audit_freshness.py
@@ -1,0 +1,108 @@
+"""Tests for the PLAN_AUDIT exit gate hash-bound freshness check (F4, CRITERION 4).
+
+PLAN_AUDIT → {TDD_REVIEW, PRE_EXECUTION_SNAPSHOT} on high/critical-risk
+tasks now requires `plan_audit_matches(task_dir) is True`. Drift
+(descriptive string) and missing (False) emit distinct error messages.
+Low/medium-risk tasks still skip the receipt requirement entirely so
+this test file's low-risk case preserves the pre-F4 behavior.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import transition_task  # noqa: E402
+from lib_receipts import hash_file, receipt_plan_audit  # noqa: E402
+
+
+def _setup(tmp_path: Path, *, risk: str) -> Path:
+    project = tmp_path / "project"
+    td = project / ".dynos" / f"task-20260419-PAF-{risk}"
+    td.mkdir(parents=True)
+    (td / "spec.md").write_text("# spec\n")
+    (td / "plan.md").write_text("# plan\n")
+    (td / "execution-graph.json").write_text('{"segments": []}\n')
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": "PLAN_AUDIT",
+        "classification": {"risk_level": risk},
+    }))
+    return td
+
+
+def _write_fresh_audit(td: Path) -> None:
+    receipt_plan_audit(
+        td,
+        tokens_used=100,
+        finding_count=0,
+        spec_sha256=hash_file(td / "spec.md"),
+        plan_sha256=hash_file(td / "plan.md"),
+        graph_sha256=hash_file(td / "execution-graph.json"),
+    )
+
+
+def test_refuses_when_plan_edited_after_audit(tmp_path: Path) -> None:
+    """Write the audit receipt with fresh hashes, then mutate plan.md.
+    The high-risk PLAN_AUDIT → PRE_EXECUTION_SNAPSHOT transition must
+    refuse with a message naming `plan.md` (the drifted artifact)."""
+    td = _setup(tmp_path, risk="high")
+    _write_fresh_audit(td)
+    # Drift the plan AFTER audit wrote its hashes.
+    (td / "plan.md").write_text("# plan EDITED AFTER AUDIT\n")
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "PRE_EXECUTION_SNAPSHOT")
+    msg = str(excinfo.value)
+    assert "plan.md" in msg, (
+        f"PLAN_AUDIT drift message must name the drifted artifact — got: {msg!r}"
+    )
+    # And this is a drift failure, not a missing-receipt failure.
+    # The missing-receipt branch emits "missing receipt plan-audit-check";
+    # the drift branch emits "plan-audit-check: plan.md hash drift".
+    assert "missing receipt" not in msg, (
+        f"drift path leaked missing-receipt vocabulary: {msg!r}"
+    )
+    # Manifest did NOT advance.
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "PLAN_AUDIT"
+
+
+def test_accepts_when_all_artifacts_unchanged(tmp_path: Path) -> None:
+    """Fresh audit receipt, no subsequent mutation → transition succeeds."""
+    td = _setup(tmp_path, risk="high")
+    _write_fresh_audit(td)
+    transition_task(td, "PRE_EXECUTION_SNAPSHOT")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "PRE_EXECUTION_SNAPSHOT"
+
+
+def test_missing_receipt_emits_missing_message(tmp_path: Path) -> None:
+    """No receipt at all → pre-existing missing-receipt message path.
+    Drift and missing are distinct outcomes — this asserts the missing
+    branch still behaves as before F4."""
+    td = _setup(tmp_path, risk="critical")
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "PRE_EXECUTION_SNAPSHOT")
+    msg = str(excinfo.value)
+    # The pre-F4 message format is preserved by spec.
+    assert "plan-audit-check" in msg
+    # Must NOT look like a drift string — drift reads "plan.md hash drift";
+    # missing reads "missing receipt plan-audit-check at ...".
+    assert "hash drift" not in msg, (
+        f"missing-receipt message leaked drift vocabulary: {msg!r}"
+    )
+
+
+def test_low_risk_still_skips_llm_audit_check(tmp_path: Path) -> None:
+    """Low-risk tasks never consulted `plan-audit-check`. F4 preserves
+    that — a low-risk task with zero receipts (and all three artifacts
+    present so we don't fail elsewhere) advances cleanly."""
+    td = _setup(tmp_path, risk="low")
+    # No receipt; no mutation; low-risk; transition must succeed.
+    transition_task(td, "PRE_EXECUTION_SNAPSHOT")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "PRE_EXECUTION_SNAPSHOT"

--- a/tests/test_gate_planner_receipts.py
+++ b/tests/test_gate_planner_receipts.py
@@ -1,0 +1,174 @@
+"""Tests for the two new planner transition gates (F6, CRITERION 6).
+
+Two new gate clauses in `transition_task`:
+
+1. SPEC_NORMALIZATION → SPEC_REVIEW requires a `planner-spec` receipt
+   (skipped on fast-track tasks — fast-track writes only a combined
+   planner-plan receipt for the Spec+Plan spawn).
+2. PLANNING → PLAN_REVIEW requires a `planner-plan` receipt. This fires
+   on both normal and fast-track paths.
+
+Writing a planner receipt requires two things: the sidecar digest file
+at `receipts/_injected-planner-prompts/{phase}.sha256` AND a matching
+`injected_prompt_sha256` string. We exercise both the refusal path
+(no receipt) and the success path (receipt + sidecar both present).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import transition_task  # noqa: E402
+from lib_receipts import receipt_planner_spawn  # noqa: E402
+
+
+PLANNER_DIGEST = "a" * 64  # fixed test digest; real callers hash the prompt
+
+
+def _write_planner_receipt(td: Path, phase: str) -> None:
+    """Write the planner sidecar + receipt for the given phase.
+
+    `receipt_planner_spawn` asserts the sidecar file exists AND matches
+    the supplied digest; we materialize both in a single helper so tests
+    stay readable.
+    """
+    sidecar_dir = td / "receipts" / "_injected-planner-prompts"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    (sidecar_dir / f"{phase}.sha256").write_text(PLANNER_DIGEST)
+    receipt_planner_spawn(
+        td,
+        phase,
+        tokens_used=0,
+        injected_prompt_sha256=PLANNER_DIGEST,
+    )
+
+
+def _setup(tmp_path: Path, *, stage: str, fast_track: bool = False,
+           classification_fast_track: bool = False,
+           slug: str = "PR") -> Path:
+    """Build a task at the given stage. Fast-track flag can be set at the
+    top level of the manifest OR under `classification.fast_track` — the
+    gate tolerates either (see seg-1 evidence)."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / f"task-20260419-{slug}"
+    td.mkdir(parents=True)
+    manifest: dict = {
+        "task_id": td.name,
+        "stage": stage,
+        "classification": {"risk_level": "medium"},
+    }
+    if fast_track:
+        manifest["fast_track"] = True
+    if classification_fast_track:
+        manifest["classification"]["fast_track"] = True
+    (td / "manifest.json").write_text(json.dumps(manifest))
+    # Artifacts that SPEC_REVIEW / PLAN_REVIEW / downstream gates may touch.
+    (td / "spec.md").write_text("# spec\n")
+    (td / "plan.md").write_text("# plan\n")
+    return td
+
+
+# ---------------------------------------------------------------------------
+# Refusal paths — receipt missing.
+# ---------------------------------------------------------------------------
+
+
+def test_spec_review_requires_planner_spec(tmp_path: Path) -> None:
+    """Normal (non-fast-track) path: SPEC_NORMALIZATION → SPEC_REVIEW
+    with NO planner-spec receipt must refuse and the error must name the
+    missing receipt step (`planner-spec`)."""
+    td = _setup(tmp_path, stage="SPEC_NORMALIZATION", slug="PS-NOREC")
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "SPEC_REVIEW")
+    assert "planner-spec" in str(excinfo.value), (
+        f"gate error must name planner-spec — got: {excinfo.value!r}"
+    )
+
+
+def test_plan_review_requires_planner_plan(tmp_path: Path) -> None:
+    """PLANNING → PLAN_REVIEW without a planner-plan receipt must refuse
+    and the error must name the missing receipt step (`planner-plan`)."""
+    td = _setup(tmp_path, stage="PLANNING", slug="PP-NOREC")
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "PLAN_REVIEW")
+    assert "planner-plan" in str(excinfo.value), (
+        f"gate error must name planner-plan — got: {excinfo.value!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fast-track path — planner-spec requirement skipped.
+# ---------------------------------------------------------------------------
+
+
+def test_fast_track_skips_planner_spec_requirement(tmp_path: Path) -> None:
+    """Fast-track tasks (manifest.fast_track=True) combine Spec+Plan
+    into one planner spawn and only emit a planner-plan receipt. The
+    SPEC_NORMALIZATION → SPEC_REVIEW gate must therefore NOT require a
+    planner-spec receipt on the fast-track path. With no planner-spec
+    written, the transition must succeed."""
+    td = _setup(tmp_path, stage="SPEC_NORMALIZATION",
+                fast_track=True, slug="FT-TOP")
+    # No planner-spec receipt present. Fast-track = gate skipped.
+    transition_task(td, "SPEC_REVIEW")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "SPEC_REVIEW"
+
+
+def test_fast_track_flag_under_classification_also_skips(tmp_path: Path) -> None:
+    """Seg-1 accepts `manifest.classification.fast_track=True` as an
+    alternate source of the flag (older manifests stored it there).
+    This test pins that fallback so future refactors don't silently
+    drop it."""
+    td = _setup(tmp_path, stage="SPEC_NORMALIZATION",
+                classification_fast_track=True, slug="FT-CLS")
+    transition_task(td, "SPEC_REVIEW")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "SPEC_REVIEW"
+
+
+# ---------------------------------------------------------------------------
+# Success path — receipts written.
+# ---------------------------------------------------------------------------
+
+
+def test_both_gates_pass_when_receipts_present(tmp_path: Path) -> None:
+    """End-to-end: write a planner-spec receipt; SPEC_NORMALIZATION →
+    SPEC_REVIEW succeeds. Then write a planner-plan receipt; PLANNING
+    → PLAN_REVIEW succeeds."""
+    td = _setup(tmp_path, stage="SPEC_NORMALIZATION", slug="HAPPY")
+
+    # --- first edge: need planner-spec --------------------------------
+    _write_planner_receipt(td, "spec")
+    transition_task(td, "SPEC_REVIEW")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "SPEC_REVIEW"
+
+    # Move the task through SPEC_REVIEW → PLANNING manually by
+    # rewriting the manifest rather than going through transition_task
+    # (the human-approval gate between these two stages is out of
+    # scope for this file's focus).
+    manifest["stage"] = "PLANNING"
+    (td / "manifest.json").write_text(json.dumps(manifest))
+
+    # --- second edge: need planner-plan -------------------------------
+    _write_planner_receipt(td, "plan")
+    transition_task(td, "PLAN_REVIEW")
+    manifest_after = json.loads((td / "manifest.json").read_text())
+    assert manifest_after["stage"] == "PLAN_REVIEW"
+
+
+def test_planner_plan_gate_still_fires_under_fast_track(tmp_path: Path) -> None:
+    """Fast-track skips planner-spec but NOT planner-plan (fast-track
+    still writes planner-plan for the combined spawn). A fast-track task
+    with no planner-plan receipt must still be refused at
+    PLANNING → PLAN_REVIEW. Regression guard — easy to mistakenly
+    gate both fast-track checks together."""
+    td = _setup(tmp_path, stage="PLANNING", fast_track=True, slug="FT-PP")
+    with pytest.raises(ValueError, match="planner-plan"):
+        transition_task(td, "PLAN_REVIEW")

--- a/tests/test_plan_validated_receipt_freshness.py
+++ b/tests/test_plan_validated_receipt_freshness.py
@@ -45,22 +45,32 @@ class TestReceiptFreshness:
         from lib_receipts import receipt_plan_validated, plan_validated_receipt_matches
         receipt_plan_validated(task_dir, segment_count=0, criteria_coverage=[])
         (task_dir / "spec.md").write_text("# Spec\nv2 changed\n")
-        assert plan_validated_receipt_matches(task_dir) is False, \
-            "spec drift must invalidate the receipt"
+        # F1: drift now returns a descriptive string naming the artifact
+        # (used by the EXECUTION gate to surface drift-vs-missing
+        # distinctly). A bare `False` is reserved for "receipt missing".
+        result = plan_validated_receipt_matches(task_dir)
+        assert result is not True, "spec drift must invalidate the receipt"
+        assert result is not False, "drift must NOT return False (that's the missing-receipt signal)"
+        assert isinstance(result, str) and "spec.md" in result, \
+            f"expected drift string naming spec.md, got {result!r}"
 
     def test_plan_change_invalidates(self, tmp_path: Path):
         task_dir = _setup_task(tmp_path)
         from lib_receipts import receipt_plan_validated, plan_validated_receipt_matches
         receipt_plan_validated(task_dir, segment_count=0, criteria_coverage=[])
         (task_dir / "plan.md").write_text("# Plan\nv2\n")
-        assert plan_validated_receipt_matches(task_dir) is False
+        result = plan_validated_receipt_matches(task_dir)
+        assert isinstance(result, str) and "plan.md" in result, \
+            f"expected drift string naming plan.md, got {result!r}"
 
     def test_graph_change_invalidates(self, tmp_path: Path):
         task_dir = _setup_task(tmp_path)
         from lib_receipts import receipt_plan_validated, plan_validated_receipt_matches
         receipt_plan_validated(task_dir, segment_count=0, criteria_coverage=[])
         (task_dir / "execution-graph.json").write_text('{"task_id":"x","segments":[]}\n')
-        assert plan_validated_receipt_matches(task_dir) is False
+        result = plan_validated_receipt_matches(task_dir)
+        assert isinstance(result, str) and "execution-graph.json" in result, \
+            f"expected drift string naming execution-graph.json, got {result!r}"
 
     def test_legacy_receipt_without_hashes_treated_as_drift(self, tmp_path: Path):
         """Old receipts written before this commit don't have artifact_hashes.

--- a/tests/test_receipt_contract_version.py
+++ b/tests/test_receipt_contract_version.py
@@ -101,9 +101,32 @@ def _exercise_writer(name: str, td: Path):
     if name == "receipt_post_completion":
         return receipt_post_completion(td, [])
     if name == "receipt_planner_spawn":
-        return receipt_planner_spawn(td, "spec", 0, injected_prompt_sha256=None)
+        # Post-F5: the None legacy path is rejected. Write the sidecar
+        # so the writer's unconditional hash-match assertion passes.
+        planner_sd = td / "receipts" / "_injected-planner-prompts"
+        planner_sd.mkdir(parents=True, exist_ok=True)
+        digest = "d" * 64
+        (planner_sd / "spec.sha256").write_text(digest)
+        return receipt_planner_spawn(
+            td, "spec", 0, injected_prompt_sha256=digest
+        )
     if name == "receipt_plan_audit":
-        return receipt_plan_audit(td, tokens_used=0, finding_count=0)
+        return receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="a" * 64,
+            plan_sha256="b" * 64,
+            graph_sha256="c" * 64,
+        )
+    if name == "receipt_force_override":
+        from lib_receipts import receipt_force_override
+        return receipt_force_override(
+            td,
+            from_stage="PLANNING",
+            to_stage="PLAN_REVIEW",
+            bypassed_gates=[],
+        )
     return None
 
 

--- a/tests/test_receipt_plan_audit_hash.py
+++ b/tests/test_receipt_plan_audit_hash.py
@@ -1,0 +1,206 @@
+"""Tests for receipt_plan_audit hash payload (F2) and plan_audit_matches
+helper (F3). CRITERIA 2 and 3.
+
+F2: `receipt_plan_audit(...)` now requires three kw-only string kwargs:
+`spec_sha256`, `plan_sha256`, `graph_sha256`. Each must be non-empty.
+The written payload carries all three.
+
+F3: `plan_audit_matches(task_dir)` returns:
+  - True  when the receipt exists AND all three hashes match disk
+  - a descriptive string (e.g. "plan.md hash drift") when the receipt
+    is present but one of the artifacts drifted on disk
+  - False when the receipt is missing (or legacy — pre-F2 no-hash
+    payload; that path is covered indirectly here by the missing case)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import (  # noqa: E402
+    hash_file,
+    plan_audit_matches,
+    receipt_plan_audit,
+)
+
+
+def _setup_artifacts(tmp_path: Path) -> Path:
+    """Create a task dir with the three planning artifacts on disk."""
+    td = tmp_path / ".dynos" / "task-audit"
+    td.mkdir(parents=True)
+    (td / "spec.md").write_text("# spec content\n")
+    (td / "plan.md").write_text("# plan content\n")
+    (td / "execution-graph.json").write_text('{"segments": []}\n')
+    return td
+
+
+def _write_fresh_receipt(td: Path) -> None:
+    """Write a plan-audit-check receipt whose hashes match current disk."""
+    receipt_plan_audit(
+        td,
+        tokens_used=100,
+        finding_count=0,
+        spec_sha256=hash_file(td / "spec.md"),
+        plan_sha256=hash_file(td / "plan.md"),
+        graph_sha256=hash_file(td / "execution-graph.json"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# F2: receipt_plan_audit payload / signature
+# ---------------------------------------------------------------------------
+
+
+def test_payload_contains_three_hashes(tmp_path: Path) -> None:
+    """Write a receipt with known hex digests; read the JSON back; assert
+    the three keys are present and match exactly what we passed in."""
+    td = _setup_artifacts(tmp_path)
+    spec_h = "a" * 64
+    plan_h = "b" * 64
+    graph_h = "c" * 64
+    receipt_path = receipt_plan_audit(
+        td,
+        tokens_used=0,
+        finding_count=0,
+        spec_sha256=spec_h,
+        plan_sha256=plan_h,
+        graph_sha256=graph_h,
+    )
+    payload = json.loads(receipt_path.read_text())
+    assert payload["spec_sha256"] == spec_h
+    assert payload["plan_sha256"] == plan_h
+    assert payload["graph_sha256"] == graph_h
+
+
+def test_requires_spec_sha256(tmp_path: Path) -> None:
+    """Missing kwarg → TypeError (kw-only required argument).
+    Empty string → ValueError (explicit rejection of blank)."""
+    td = _setup_artifacts(tmp_path)
+    # Omission — kw-only required → TypeError.
+    with pytest.raises(TypeError):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            plan_sha256="b" * 64,
+            graph_sha256="c" * 64,
+        )
+    # Empty string — explicit ValueError naming the arg.
+    with pytest.raises(ValueError, match="spec_sha256"):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="",
+            plan_sha256="b" * 64,
+            graph_sha256="c" * 64,
+        )
+
+
+def test_requires_plan_sha256(tmp_path: Path) -> None:
+    td = _setup_artifacts(tmp_path)
+    with pytest.raises(TypeError):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="a" * 64,
+            graph_sha256="c" * 64,
+        )
+    with pytest.raises(ValueError, match="plan_sha256"):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="a" * 64,
+            plan_sha256="",
+            graph_sha256="c" * 64,
+        )
+
+
+def test_requires_graph_sha256(tmp_path: Path) -> None:
+    td = _setup_artifacts(tmp_path)
+    with pytest.raises(TypeError):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="a" * 64,
+            plan_sha256="b" * 64,
+        )
+    with pytest.raises(ValueError, match="graph_sha256"):
+        receipt_plan_audit(
+            td,
+            tokens_used=0,
+            finding_count=0,
+            spec_sha256="a" * 64,
+            plan_sha256="b" * 64,
+            graph_sha256="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# F3: plan_audit_matches helper
+# ---------------------------------------------------------------------------
+
+
+def test_matches_true_on_fresh(tmp_path: Path) -> None:
+    """Write a receipt over fresh artifacts; the helper must return True."""
+    td = _setup_artifacts(tmp_path)
+    _write_fresh_receipt(td)
+    assert plan_audit_matches(td) is True
+
+
+def test_matches_returns_drift_string_on_plan_edit(tmp_path: Path) -> None:
+    """Write a receipt, then mutate plan.md. The helper must return a
+    descriptive string naming plan.md — specifically `str` and `"plan.md"`
+    must appear, so callers (PLAN_AUDIT exit gate) can surface the
+    artifact identity in error messages."""
+    td = _setup_artifacts(tmp_path)
+    _write_fresh_receipt(td)
+    (td / "plan.md").write_text("# plan content DRIFTED\n")
+    result = plan_audit_matches(td)
+    assert isinstance(result, str), f"expected str on drift, got {type(result).__name__}"
+    assert "plan.md" in result, f"drift string must name plan.md — got {result!r}"
+    # And it must NOT be the boolean True literal — callers key off isinstance.
+    assert result is not True
+    assert result is not False
+
+
+def test_matches_returns_drift_string_on_spec_edit(tmp_path: Path) -> None:
+    """Parallel drift test for spec.md — ensures the helper reports the
+    correct artifact. Regression: a buggy impl could blindly say `plan.md`
+    on every drift; this test rules that out."""
+    td = _setup_artifacts(tmp_path)
+    _write_fresh_receipt(td)
+    (td / "spec.md").write_text("# spec content DRIFTED\n")
+    result = plan_audit_matches(td)
+    assert isinstance(result, str)
+    assert "spec.md" in result
+    assert "plan.md" not in result, (
+        f"drift helper mis-identified which artifact drifted: {result!r}"
+    )
+
+
+def test_matches_returns_drift_string_on_graph_edit(tmp_path: Path) -> None:
+    """Parallel drift test for execution-graph.json."""
+    td = _setup_artifacts(tmp_path)
+    _write_fresh_receipt(td)
+    (td / "execution-graph.json").write_text('{"segments": ["drifted"]}\n')
+    result = plan_audit_matches(td)
+    assert isinstance(result, str)
+    assert "execution-graph.json" in result
+
+
+def test_matches_returns_false_when_missing(tmp_path: Path) -> None:
+    """No receipt → False (NOT a drift string). Callers distinguish this
+    as the missing-receipt branch."""
+    td = _setup_artifacts(tmp_path)
+    # Intentionally do not write a plan-audit-check receipt.
+    result = plan_audit_matches(td)
+    assert result is False, f"missing receipt must return False, got {result!r}"

--- a/tests/test_receipt_planner_spawn_sidecar.py
+++ b/tests/test_receipt_planner_spawn_sidecar.py
@@ -2,9 +2,10 @@
 receipt).
 
 `receipt_planner_spawn(task_dir, phase, ..., injected_prompt_sha256=...)`
-now asserts that `receipts/_injected-planner-prompts/{phase}.sha256`
-exists and matches the supplied digest when non-None. When None, the
-receipt is written without assertion (legacy path).
+asserts that `receipts/_injected-planner-prompts/{phase}.sha256` exists
+and matches the supplied digest. As of F5 the legacy None path is
+rejected — callers MUST supply a non-empty sha256 hex digest obtained
+from `hooks/router.py planner-inject-prompt`.
 """
 from __future__ import annotations
 
@@ -80,21 +81,20 @@ def test_sidecar_hash_mismatch_raises(tmp_path: Path):
         )
 
 
-def test_injected_prompt_sha256_none_writes_receipt(tmp_path: Path):
-    """Legacy path: injected_prompt_sha256=None → no sidecar required."""
+def test_none_injected_prompt_sha256_rejected(tmp_path: Path):
+    """F5: explicit `injected_prompt_sha256=None` raises ValueError whose
+    message contains `legacy None path removed`. The legacy no-sidecar
+    code path is gone — there is no way to write a planner-spawn receipt
+    without a matching sidecar digest."""
     td = _task_dir(tmp_path)
-    out = receipt_planner_spawn(
-        td,
-        "plan",
-        tokens_used=50,
-        model_used="sonnet",
-        injected_prompt_sha256=None,
-    )
-    assert out.exists()
-    payload = json.loads(out.read_text())
-    assert payload["phase"] == "plan"
-    # Legacy receipts carry an explicit null for the injected digest.
-    assert payload.get("injected_prompt_sha256") is None
+    with pytest.raises(ValueError, match="legacy None path removed"):
+        receipt_planner_spawn(
+            td,
+            "plan",
+            tokens_used=50,
+            model_used="sonnet",
+            injected_prompt_sha256=None,
+        )
 
 
 def test_omitted_kwarg_raises_typeerror(tmp_path: Path):

--- a/tests/test_retrospective_flush.py
+++ b/tests/test_retrospective_flush.py
@@ -1,0 +1,242 @@
+"""Tests for the DONE-edge retrospective flush (F10, CRITERION 10).
+
+On any transition into `next_stage == "DONE"`, `transition_task` copies
+`task_dir/task-retrospective.json` to
+`_persistent_project_dir(root)/retrospectives/{task_id}.json` so the
+retro survives worktree removal and reaches the calibration
+pipeline's `collect_retrospectives(root)` sweep.
+
+Invariants:
+
+  - Success path emits a `retrospective_flushed` event and the
+    destination file exists with the same content as the source.
+  - Failure path (e.g. destination read-only) emits a
+    `retrospective_flush_failed` event but DOES NOT block the DONE
+    transition. Force-style break-glass — observability must never
+    lock the state machine.
+  - Subsequent DONE transitions on the same task_id (re-play) overwrite
+    the persistent copy with the latest source.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import (  # noqa: E402
+    _persistent_project_dir,
+    transition_task,
+)
+from lib_receipts import (  # noqa: E402
+    receipt_audit_routing,
+    receipt_postmortem_skipped,
+    receipt_retrospective,
+    receipt_rules_check_passed,
+)
+
+
+def _setup_done_ready(tmp_path: Path, slug: str = "RF",
+                      quality: float = 0.95) -> Path:
+    """Build a task at CHECKPOINT_AUDIT with every receipt/artifact the
+    DONE gate requires so `transition_task(..., "DONE")` succeeds
+    without needing `force=True`.
+
+    Returns the task directory."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / f"task-20260419-{slug}"
+    td.mkdir(parents=True)
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": "CHECKPOINT_AUDIT",
+        "classification": {"risk_level": "medium"},
+    }))
+    # Retrospective artifact (source of the flush).
+    (td / "task-retrospective.json").write_text(json.dumps({
+        "task_id": td.name,
+        "quality_score": quality,
+        "cost_score": 0.8,
+        "efficiency_score": 0.8,
+    }, indent=2))
+    audit_dir = td / "audit-reports"
+    audit_dir.mkdir()
+    (audit_dir / "report.json").write_text(json.dumps({"findings": []}))
+
+    receipt_retrospective(td, quality, 0.9, 0.9, 1000)
+    receipt_rules_check_passed(
+        td, rules_evaluated=0, violations_count=0,
+        error_violations=0, mode="all",
+    )
+    receipt_audit_routing(td, [])
+    receipt_postmortem_skipped(td, "no-findings", "a" * 64)
+    return td
+
+
+def _install_dynos_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point DYNOS_HOME at a tmp dir so _persistent_project_dir resolves
+    to a writable location under the test's tmp tree, not the user's
+    real ~/.dynos."""
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(home))
+    return home
+
+
+def _read_events(td: Path) -> list[dict]:
+    events_path = td / "events.jsonl"
+    if not events_path.exists():
+        return []
+    return [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_flush_writes_to_persistent_dir(tmp_path: Path,
+                                        monkeypatch: pytest.MonkeyPatch) -> None:
+    """DONE transition copies task-retrospective.json into the
+    persistent project dir; destination content matches the source
+    byte-for-byte (file is a straight text copy via _atomic_write_text)."""
+    _install_dynos_home(monkeypatch, tmp_path)
+    td = _setup_done_ready(tmp_path, slug="FLUSH-OK")
+    root = td.parent.parent
+
+    transition_task(td, "DONE")
+
+    persistent = _persistent_project_dir(root) / "retrospectives" / f"{td.name}.json"
+    assert persistent.exists(), f"persistent retro must exist at {persistent}"
+    src = (td / "task-retrospective.json").read_text()
+    dst = persistent.read_text()
+    assert src == dst, "persistent copy content must match source byte-for-byte"
+
+
+def test_flush_overwrites_existing_persistent_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later DONE transition for the same task_id replaces an older
+    persistent copy with the current source. Pre-populate the
+    persistent dir with stale content; run the DONE transition; assert
+    the persistent file now matches the source (new content), not the
+    stale one."""
+    _install_dynos_home(monkeypatch, tmp_path)
+    td = _setup_done_ready(tmp_path, slug="FLUSH-OVR", quality=0.77)
+    root = td.parent.parent
+
+    # Pre-populate the persistent copy with stale content.
+    pdir = _persistent_project_dir(root) / "retrospectives"
+    pdir.mkdir(parents=True, exist_ok=True)
+    stale = pdir / f"{td.name}.json"
+    stale.write_text(json.dumps({"task_id": td.name, "quality_score": 0.01}))
+
+    transition_task(td, "DONE")
+
+    reloaded = json.loads(stale.read_text())
+    assert reloaded["quality_score"] == 0.77, (
+        f"stale persistent copy was NOT overwritten — got {reloaded!r}"
+    )
+
+
+def test_flush_rejects_path_traversal_task_id(tmp_path: Path) -> None:
+    """SEC-001 regression: a crafted manifest task_id like '../../evil'
+    must NOT escape the persistent retrospectives dir. The flush helper
+    validates task_id against ^task-[A-Za-z0-9][A-Za-z0-9_.-]*$ and emits
+    retrospective_flush_failed when the slug is invalid."""
+    project = tmp_path / "proj"
+    (project / ".dynos").mkdir(parents=True)
+    td = project / ".dynos" / "task-20260419-XX"
+    td.mkdir()
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": "../../evil",
+        "stage": "CHECKPOINT_AUDIT",
+        "classification": {"risk_level": "low"},
+    }))
+    (td / "task-retrospective.json").write_text('{"task_id": "../../evil", "quality_score": 0.9}')
+
+    from lib_core import _flush_retrospective_on_done, _persistent_project_dir
+    manifest = json.loads((td / "manifest.json").read_text())
+    # Must not raise; slug validation blocks the write.
+    _flush_retrospective_on_done(task_dir=td, manifest=manifest)
+
+    pd = _persistent_project_dir(project)
+    retros_dir = pd / "retrospectives"
+    # The poisoned slug produces no file anywhere under retrospectives.
+    # (Directory may or may not exist — either way, no '../../evil.json'.)
+    if retros_dir.exists():
+        assert not any(p.name == "../../evil.json" or "evil" in p.name
+                       for p in retros_dir.iterdir())
+    # And absolutely nothing outside the project root.
+    assert not (project.parent / "evil.json").exists()
+
+
+def test_flush_emits_success_event(tmp_path: Path,
+                                    monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful DONE flush emits a `retrospective_flushed` event with
+    task_id, source, destination, and sha256 fields populated."""
+    _install_dynos_home(monkeypatch, tmp_path)
+    td = _setup_done_ready(tmp_path, slug="FLUSH-EVT")
+
+    transition_task(td, "DONE")
+
+    events = _read_events(td)
+    flushed = [e for e in events if e.get("event") == "retrospective_flushed"]
+    assert len(flushed) >= 1, (
+        f"expected a retrospective_flushed event — got events: "
+        f"{[e.get('event') for e in events]}"
+    )
+    ev = flushed[0]
+    assert ev.get("task_id") == td.name
+    assert str(ev.get("source", "")).endswith("task-retrospective.json")
+    assert str(ev.get("destination", "")).endswith(f"{td.name}.json")
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="read-only directory guard is ineffective for root — skip",
+)
+def test_flush_failure_does_not_block_done(tmp_path: Path,
+                                            monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the persistent retrospectives dir read-only so
+    `_atomic_write_text` raises OSError. The DONE transition MUST
+    still succeed (stage advances), and a `retrospective_flush_failed`
+    event MUST be emitted. This pins the "observability cannot block
+    the state machine" invariant."""
+    _install_dynos_home(monkeypatch, tmp_path)
+    td = _setup_done_ready(tmp_path, slug="FLUSH-FAIL")
+    root = td.parent.parent
+
+    # Pre-create a read-only persistent retrospectives dir so
+    # `_atomic_write_text`'s tempfile write inside it raises.
+    pdir = _persistent_project_dir(root) / "retrospectives"
+    pdir.mkdir(parents=True, exist_ok=True)
+    # Restrict to read+execute only (no write). os.chmod applies to
+    # directory entries; combined with exist_ok=True in the impl this
+    # surfaces an OSError at tempfile.mkstemp time.
+    original_mode = pdir.stat().st_mode
+    os.chmod(pdir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        transition_task(td, "DONE")
+        manifest = json.loads((td / "manifest.json").read_text())
+        assert manifest["stage"] == "DONE", (
+            "DONE transition MUST NOT be blocked by a flush-write failure"
+        )
+        events = _read_events(td)
+        failed = [e for e in events if e.get("event") == "retrospective_flush_failed"]
+        assert len(failed) >= 1, (
+            f"expected retrospective_flush_failed event — got events: "
+            f"{[e.get('event') for e in events]}"
+        )
+    finally:
+        # Restore so pytest can clean up the tmp tree.
+        os.chmod(pdir, original_mode)

--- a/tests/test_spec_review_iterations_from_receipts.py
+++ b/tests/test_spec_review_iterations_from_receipts.py
@@ -1,0 +1,128 @@
+"""Tests for spec_review_iterations counted from receipts (F9, CRITERION 9).
+
+Before F9, `compute_reward` walked `execution-log.md` looking for
+`[HUMAN] SPEC_REVIEW` lines. Log lines are unsigned, editable, and not
+a hash-bound audit record — a malicious or accidental log edit could
+manufacture arbitrary iteration counts. After F9, the source of truth
+is the glob `receipts/human-approval-SPEC_REVIEW*.json`. Log lines are
+ignored.
+
+The efficiency_score penalty formula is unchanged — only the INPUT
+source for `spec_review_iterations` moved. A task that has never been
+approved has 0 receipts → counter 0 → penalty 0 (formula untouched:
+`max(0, s - 1) * 0.1`).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+
+def _make_task_dir(tmp_path: Path, *, slug: str = "SRIR") -> Path:
+    """Minimal task dir that `compute_reward` can consume without
+    exploding on a missing manifest. `compute_reward` reads the
+    manifest for classification fields and token-usage for cost; the
+    minimum is a manifest with a classification subtree."""
+    td = tmp_path / ".dynos" / f"task-20260419-{slug}"
+    td.mkdir(parents=True)
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": "DONE",
+        "classification": {
+            "type": "feature",
+            "risk_level": "medium",
+            "domains": [],
+        },
+    }))
+    return td
+
+
+def _write_approval_receipt(td: Path, filename: str) -> None:
+    """Write a valid human-approval-SPEC_REVIEW* receipt file.
+    Payload shape mirrors real approvals (valid=true, step, ts),
+    so `read_receipt` would accept it too. The counter at F9 only
+    globs for the file; it does not read the payload."""
+    receipts = td / "receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "step": filename.removesuffix(".json"),
+        "valid": True,
+        "stage": "SPEC_REVIEW",
+        "artifact_sha256": "d" * 64,
+        "approver": "human",
+        "ts": "2026-04-19T00:00:00Z",
+    }
+    (receipts / filename).write_text(json.dumps(payload, indent=2))
+
+
+def _iterations(td: Path) -> int:
+    """Return the `spec_review_iterations` value computed by
+    `compute_reward` for the given task dir."""
+    from lib_validate import compute_reward
+    retro = compute_reward(td)
+    return int(retro["spec_review_iterations"])
+
+
+def test_counts_zero_when_no_receipts(tmp_path: Path) -> None:
+    """Fresh task dir with no receipts/ at all → counter is 0."""
+    td = _make_task_dir(tmp_path, slug="ZERO")
+    # receipts/ intentionally does not exist — tests the `is_dir()`
+    # short-circuit in compute_reward.
+    assert not (td / "receipts").exists()
+    assert _iterations(td) == 0
+
+
+def test_counts_one_when_single_receipt(tmp_path: Path) -> None:
+    """One `human-approval-SPEC_REVIEW.json` present → counter is 1."""
+    td = _make_task_dir(tmp_path, slug="ONE")
+    _write_approval_receipt(td, "human-approval-SPEC_REVIEW.json")
+    assert _iterations(td) == 1
+
+
+def test_counts_two_with_rotation_suffix(tmp_path: Path) -> None:
+    """Two receipts — the base filename and a `-002` rotation suffix —
+    both match the glob. The counter returns 2. This pins the
+    wildcard behavior documented in the spec as the forward-looking
+    hook for revision rotation."""
+    td = _make_task_dir(tmp_path, slug="TWO")
+    _write_approval_receipt(td, "human-approval-SPEC_REVIEW.json")
+    _write_approval_receipt(td, "human-approval-SPEC_REVIEW-002.json")
+    assert _iterations(td) == 2
+
+
+def test_log_lines_no_longer_counted(tmp_path: Path) -> None:
+    """Deliberately write several `[HUMAN] SPEC_REVIEW` lines into the
+    execution log but NO receipts. The old log-scanner would have
+    returned 3; the F9 counter MUST return 0. This is the core
+    regression — if someone restores the log scanner, this test fires."""
+    td = _make_task_dir(tmp_path, slug="LOG")
+    log = td / "execution-log.md"
+    log.write_text(
+        "[2026-04-19T00:00:00Z] [HUMAN] SPEC_REVIEW approved v1\n"
+        "[2026-04-19T00:00:01Z] [HUMAN] SPEC_REVIEW approved v2\n"
+        "[2026-04-19T00:00:02Z] [HUMAN] SPEC_REVIEW approved v3\n"
+    )
+    # No receipts directory at all.
+    assert not (td / "receipts").exists()
+    assert _iterations(td) == 0, (
+        "F9 regression: log lines must NOT feed spec_review_iterations"
+    )
+
+
+def test_unrelated_approval_files_not_counted(tmp_path: Path) -> None:
+    """Defensive: the glob uses the exact prefix `human-approval-SPEC_REVIEW*`.
+    A `human-approval-PLAN_REVIEW.json` must not leak into the counter.
+    This pins the glob scope — a wildcard bug turning `*_REVIEW*` into
+    the prefix would silently double-count."""
+    td = _make_task_dir(tmp_path, slug="UNREL")
+    _write_approval_receipt(td, "human-approval-SPEC_REVIEW.json")
+    _write_approval_receipt(td, "human-approval-PLAN_REVIEW.json")
+    _write_approval_receipt(td, "human-approval-TDD_REVIEW.json")
+    assert _iterations(td) == 1, (
+        "only human-approval-SPEC_REVIEW* should count — got a different value"
+    )

--- a/tests/test_tdd_required_default.py
+++ b/tests/test_tdd_required_default.py
@@ -10,7 +10,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
 
 from lib_core import get_tdd_required, transition_task  # noqa: E402
-from lib_receipts import receipt_plan_audit  # noqa: E402
+from lib_receipts import receipt_plan_audit, hash_file  # noqa: E402
 
 
 def test_missing_classification_returns_false():
@@ -43,6 +43,11 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
     project = tmp_path / "project"
     td = project / ".dynos" / "task-20260418-D"
     td.mkdir(parents=True)
+    # Create artifacts so the PLAN_AUDIT hash-bound freshness gate can
+    # match against them.
+    (td / "spec.md").write_text("# spec")
+    (td / "plan.md").write_text("# plan")
+    (td / "execution-graph.json").write_text('{"segments": []}')
     classification: dict = {"risk_level": risk}
     if tdd_required is not None:
         classification["tdd_required"] = tdd_required
@@ -56,7 +61,14 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
 
 def test_plan_audit_to_pre_exec_permitted_when_tdd_required_absent_critical(tmp_path: Path):
     td = _setup(tmp_path, risk="critical")  # no tdd_required field
-    receipt_plan_audit(td, tokens_used=100, finding_count=0)
+    receipt_plan_audit(
+        td,
+        tokens_used=100,
+        finding_count=0,
+        spec_sha256=hash_file(td / "spec.md"),
+        plan_sha256=hash_file(td / "plan.md"),
+        graph_sha256=hash_file(td / "execution-graph.json"),
+    )
     # Must succeed: tdd_required absent, plan-audit-check is present.
     transition_task(td, "PRE_EXECUTION_SNAPSHOT")
     manifest = json.loads((td / "manifest.json").read_text())


### PR DESCRIPTION
## Summary

Closes the six framework-level enforcement gaps surfaced by investigator `a6761177e98f68cfc` against main@`2ae9ed6` (post-PR-#123/#124/#125). Self-proved: task-20260419-001 itself transitioned DONE → CALIBRATED under the new code path, and F10 wrote the persistent retrospective copy at DONE time.

One commit: `close 6 framework enforcement gaps from investigator a6761177e98f68cfc`.

## What's closed

| Finding | Mechanism | Where |
|---|---|---|
| **F1** EXECUTION gate presence-only | Call `plan_validated_receipt_matches` instead of `is None`; drift vs missing produce distinct errors | `hooks/lib_core.py` |
| **F2** plan-audit-check no hash binding | `receipt_plan_audit` gains required `spec_sha256`/`plan_sha256`/`graph_sha256` kw-only | `hooks/lib_receipts.py` |
| **F3** no plan_audit_matches helper | New helper mirrors `plan_validated_receipt_matches` shape | `hooks/lib_receipts.py` |
| **F4** PLAN_AUDIT exit presence-only | High/critical-risk branch now calls `plan_audit_matches`; low-risk unchanged | `hooks/lib_core.py` |
| **F5** planner `None` legacy bypass | Explicit `None` now raises `ValueError("legacy None path removed")` | `hooks/lib_receipts.py` |
| **F6** no planner transition gates | New gates: SPEC_NORMALIZATION→SPEC_REVIEW needs `planner-spec` (unless fast-track); PLANNING→PLAN_REVIEW needs `planner-plan` | `hooks/lib_core.py` |
| **F7** `--force` silent bypass | Dry-run gate collection + `force_override` event + dedicated receipt | `hooks/lib_core.py` |
| **F8** no force-override receipt | New `receipt_force_override` writer exported via `__all__` | `hooks/lib_receipts.py` |
| **F9** `efficiency_score` dead input | `spec_review_iterations` now from `receipts/human-approval-SPEC_REVIEW*.json` glob | `hooks/lib_validate.py` |
| **F10** worktree retro never flushed | On DONE, atomic copy to `_persistent_project_dir(root)/retrospectives/{task_id}.json` | `hooks/lib_core.py` |
| **F11** `collect_retrospectives` not union | Reads both worktree + persistent sources; persistent wins on dedupe | `hooks/lib_core.py` |

## Security hardening (surfaced by security-auditor during this task's own audit)

- **SEC-001** path traversal via crafted `manifest["task_id"]` in F10 flush — fixed with strict slug regex `^task-[A-Za-z0-9][A-Za-z0-9_.-]*$`; regression test `test_flush_rejects_path_traversal_task_id`.
- **SEC-002** path traversal via crafted `manifest["stage"]` in F8 receipt filename — fixed with strict stage-name regex `^[A-Z][A-Z0-9_]*$`; regression test `test_receipt_writer_rejects_path_traversal_stage`.

Both had manifest-write preconditions (inside the task trust boundary), so neither was CVE-class. Defense-in-depth anyway.

## Self-proof

Task-20260419-001 drove the whole pipeline through FOUNDRY → EXECUTION → CHECKPOINT_AUDIT → DONE → CALIBRATED under the new code path. At DONE transition, F10 fired and wrote `~/.dynos/projects/Users-hassam-Documents-dynos-work/retrospectives/task-20260419-001.json` — the persistent retrospective copy. After worktree removal (post-merge), a nightly `compute_effectiveness_scores` call will observe this bugfix task via the F11 union read. Until this PR lands, worktree-based bugfix tasks vanish from the EMA on worktree removal.

Captured in `events.jsonl`:
```
{"event": "retrospective_flushed", "task_id": "task-20260419-001",
 "source": ".../fix-framework-enforcement-gaps/.dynos/task-20260419-001/task-retrospective.json",
 "destination": "~/.dynos/projects/Users-hassam-Documents-dynos-work/retrospectives/task-20260419-001.json",
 "sha256": "65baf31c8e4a9e44..."}
```

## Tests

- **8 new test files** (44 new tests) from seg-3:
  - `test_gate_execution_freshness.py` (4)
  - `test_receipt_plan_audit_hash.py` (9)
  - `test_gate_plan_audit_freshness.py` (4)
  - `test_gate_planner_receipts.py` (6)
  - `test_force_override_observability.py` (7 — including SEC-002 regression)
  - `test_spec_review_iterations_from_receipts.py` (5)
  - `test_retrospective_flush.py` (5 — including SEC-001 regression)
  - `test_collect_retrospectives_union.py` (6)
- **Updated existing tests** for caller migration: `test_receipt_planner_spawn_sidecar.py`, `test_receipt_contract_version.py`, `test_gate_plan_audit.py`, `test_tdd_required_default.py`, `test_plan_validated_receipt_freshness.py`.
- **Full suite: 1225 passed, 2 skipped** (up from 1181 on main; +44 from seg-3 + 2 SEC regression + 2 plan-validated-freshness from seg-1 caller migration).

## Non-blocking follow-ups documented in the audit reports

- CQ-001 — dry-run and live gate blocks are parallel but use different local helper names; future maintainers should enforce parity manually.
- CQ-002 — three identical `except` branches in `_flush_retrospective_on_done` could share a helper.
- CQ-003 — broad `except Exception` in force_override receipt-write path logs a static string instead of `str(exc)`.
- PERF-001..003 — double-hashing of artifacts on EXECUTION transition (≤3 small files); dual-scan of retrospectives in `collect_retrospectives` (O(N+M), fine at current scale).
- SEC-003..005 — minor attribution-drift and TOCTOU notes; acknowledged design trade-offs.

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/test_self_proof_task_004.py` exits 0
- [x] Task-20260419-001 reaches CALIBRATED under the new code
- [x] F10 retrospective flush observed in events.jsonl with matching sha256
- [ ] Reviewer spot-check: F7 dry-run scope isolation (no gate-state bleed into force=False path)
- [ ] Reviewer spot-check: F11 persistent-wins dedupe semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)