### PR TITLE
solve non-blocking audit findings from PR #126

### DIFF
--- a/cli/assets/templates/base/start.md
+++ b/cli/assets/templates/base/start.md
@@ -55,16 +55,14 @@ receipt_planner_spawn(
 )
 
 # After spec-completion auditor (plan audit):
-# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
-# the PLAN_AUDIT exit gate re-hashes these artifacts at transition time and
+# The writer re-hashes spec.md / plan.md / execution-graph.json from disk
+# at write time (SEC-004: no caller-supplied hashes, no TOCTOU window).
+# The PLAN_AUDIT exit gate re-hashes these artifacts at transition time and
 # refuses to advance when any has drifted since the audit was recorded.
 receipt_plan_audit(
     task_dir,
     tokens_used=TOTAL_TOKENS,
     finding_count=N,
-    spec_sha256=SPEC_SHA256,
-    plan_sha256=PLAN_SHA256,
-    graph_sha256=GRAPH_SHA256,
 )
 
 ```

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -630,7 +630,10 @@ def _compute_bypassed_gates_for_force(
             required_seg_ids: list[str] = []
             seen: set[str] = set()
 
-            def _add(seg_id: object) -> None:
+            # CQ-001: helper name matches the live gate's `_add_seg` in
+            # transition_task so drift between dry-run and live is
+            # mechanically obvious on review.
+            def _add_seg(seg_id: object) -> None:
                 if isinstance(seg_id, str) and seg_id and seg_id not in seen:
                     required_seg_ids.append(seg_id)
                     seen.add(seg_id)
@@ -646,12 +649,12 @@ def _compute_bypassed_gates_for_force(
                     if isinstance(graph_segments, list):
                         for entry in graph_segments:
                             if isinstance(entry, dict):
-                                _add(entry.get("id"))
+                                _add_seg(entry.get("id"))
             routing_segments = routing_payload.get("segments")
             if isinstance(routing_segments, list):
                 for entry in routing_segments:
                     if isinstance(entry, dict):
-                        _add(entry.get("segment_id"))
+                        _add_seg(entry.get("segment_id"))
             for seg_id in required_seg_ids:
                 if read_receipt(task_dir, f"executor-{seg_id}") is None:
                     errs.append(
@@ -750,14 +753,11 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
         return
     root = task_dir.parent.parent
     task_id = manifest.get("task_id") or task_dir.name
-    # SEC-001 hardening: validate task_id as a safe slug BEFORE path join.
-    # A crafted manifest with "task_id": "../../evil" would otherwise escape
-    # the persistent retrospectives dir. Accepts current dynos format
-    # (task-YYYYMMDD-NNN) plus test-style ids (task-T, task-A).
-    import re as _re_slug
-    if not isinstance(task_id, str) or not _re_slug.match(
-        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
-    ):
+
+    # CQ-002: single helper for the three identical failure-emit blocks
+    # below. Invariant: NEVER raises — best-effort log event with a
+    # swallow-all outer try/except.
+    def _log_flush_failed(destination: str, error: str) -> None:
         try:
             from lib_log import log_event as _log_flush
             _log_flush(
@@ -766,11 +766,21 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
                 task=str(task_id),
                 task_id=str(task_id),
                 source=str(src),
-                destination="",
-                error=f"invalid task_id slug: {task_id!r}",
+                destination=destination,
+                error=error,
             )
         except Exception:
             pass
+
+    # SEC-001 hardening: validate task_id as a safe slug BEFORE path join.
+    # A crafted manifest with "task_id": "../../evil" would otherwise escape
+    # the persistent retrospectives dir. Accepts current dynos format
+    # (task-YYYYMMDD-NNN) plus test-style ids (task-T, task-A).
+    import re as _re_slug
+    if not isinstance(task_id, str) or not _re_slug.match(
+        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
+    ):
+        _log_flush_failed(destination="", error=f"invalid task_id slug: {task_id!r}")
         return
     try:
         dst_dir = _persistent_project_dir(root) / "retrospectives"
@@ -783,53 +793,17 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
             raise OSError(f"resolved dst escapes retrospectives dir: {dst}")
     except OSError as exc:
         # Can't even compute or create the destination dir — log and bail.
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination="",
-                error=str(exc),
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination="", error=str(exc))
         return
     try:
         from lib_receipts import _atomic_write_text
         _atomic_write_text(dst, src.read_text("utf-8"))
     except OSError as exc:
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination=str(dst),
-                error=str(exc),
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination=str(dst), error=str(exc))
         return
     except Exception as exc:
         # Non-OSError (unexpected) — still must not block DONE.
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination=str(dst),
-                error=f"unexpected: {exc}",
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination=str(dst), error=f"unexpected: {exc}")
         return
     # Success path — hash the newly-written destination for the event.
     try:
@@ -1234,10 +1208,12 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                 )
             except Exception:
                 pass
-        except Exception:
+        except Exception as _force_rcpt_unexpected:
             # Non-OSError receipt-write failures are ALSO non-blocking
             # (e.g. validation bugs should not lock out recovery) — we
-            # log best-effort and proceed.
+            # log best-effort and proceed. CQ-003: include str(exc) so
+            # the event payload carries the actual failure detail
+            # (the OSError branch above already does).
             try:
                 from lib_log import log_event as _log_force_fail
                 _log_force_fail(
@@ -1245,7 +1221,7 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                     "force_override_receipt_write_failed",
                     task=_task_id_force,
                     task_id=_task_id_force,
-                    error="unexpected receipt writer failure",
+                    error=f"unexpected: {_force_rcpt_unexpected}",
                 )
             except Exception:
                 pass

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -61,16 +61,51 @@ INJECTED_AUDITOR_PROMPTS_DIR = "_injected-auditor-prompts"
 INJECTED_PLANNER_PROMPTS_DIR = "_injected-planner-prompts"
 
 
+# PERF-001: per-process memo for hash_file keyed by (abs_path, mtime_ns,
+# size). Repeated hashes of the same unchanged file in one Python process
+# (e.g. receipt_plan_audit write + plan_audit_matches gate check) now
+# share one disk read. Invalidated automatically when mtime or size
+# change, so writes between hashes are picked up. Bounded to 128 entries
+# to keep the cache small.
+_HASH_CACHE: dict[tuple[str, int, int], str] = {}
+_HASH_CACHE_MAX = 128
+
+
 def hash_file(path: Path) -> str:
     """Return sha256 hex digest of a file's contents.
 
     Raises FileNotFoundError if path does not exist.
+
+    Cached per (absolute-path, mtime_ns, size) within the Python process.
+    Any mutation changes mtime_ns or size and invalidates the entry on
+    the next call — no stale-hash risk.
     """
+    try:
+        st = path.stat()
+    except OSError:
+        # File missing → let open() raise the canonical error below.
+        st = None
+    if st is not None:
+        key = (str(path.resolve()), st.st_mtime_ns, st.st_size)
+        cached = _HASH_CACHE.get(key)
+        if cached is not None:
+            return cached
+
     h = hashlib.sha256()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+
+    if st is not None:
+        # Evict oldest if over cap (FIFO is fine; hot keys churn little).
+        if len(_HASH_CACHE) >= _HASH_CACHE_MAX:
+            try:
+                _HASH_CACHE.pop(next(iter(_HASH_CACHE)))
+            except StopIteration:
+                pass
+        _HASH_CACHE[(str(path.resolve()), st.st_mtime_ns, st.st_size)] = digest
+    return digest
 
 
 __all__ = [
@@ -877,30 +912,39 @@ def receipt_plan_audit(
     tokens_used: int | None,
     finding_count: int = 0,
     model_used: str | None = None,
-    *,
-    spec_sha256: str,
-    plan_sha256: str,
-    graph_sha256: str,
 ) -> Path:
     """Write receipt proving plan audit (spec-completion check) ran.
 
-    Hash-binding (F2): the three keyword-only arguments ``spec_sha256``,
-    ``plan_sha256``, and ``graph_sha256`` are REQUIRED. Each must be a
-    non-empty string (typically a sha256 hex digest of the corresponding
-    artifact at audit time). These hashes are embedded in the receipt
+    Hash-binding (SEC-004 + F2): the writer re-hashes ``spec.md``,
+    ``plan.md``, and ``execution-graph.json`` from the task directory at
+    write time. Those sha256 hex digests are embedded in the receipt
     payload so the PLAN_AUDIT exit gate can detect artifact drift via
     ``plan_audit_matches(task_dir)`` and refuse to advance when the audit
     was computed over a stale version of the artifacts.
 
+    Callers no longer supply the three hashes (breaking change vs. the
+    initial F2 signature). Closes the TOCTOU between a caller's
+    hash-read and the receipt write — the writer's own read is the
+    authoritative source. Missing artifact files land the literal
+    string ``missing`` in the corresponding payload slot, which always
+    fails ``plan_audit_matches`` downstream with a distinctive drift
+    reason.
+
     Also records token usage to ``token-usage.json`` when ``tokens_used``
     is positive.
     """
-    if not isinstance(spec_sha256, str) or not spec_sha256:
-        raise ValueError("spec_sha256 must be a non-empty string")
-    if not isinstance(plan_sha256, str) or not plan_sha256:
-        raise ValueError("plan_sha256 must be a non-empty string")
-    if not isinstance(graph_sha256, str) or not graph_sha256:
-        raise ValueError("graph_sha256 must be a non-empty string")
+    def _hash_or_missing(rel: str) -> str:
+        p = task_dir / rel
+        if not p.exists():
+            return "missing"
+        try:
+            return hash_file(p)
+        except OSError:
+            return "missing"
+
+    spec_sha256 = _hash_or_missing("spec.md")
+    plan_sha256 = _hash_or_missing("plan.md")
+    graph_sha256 = _hash_or_missing("execution-graph.json")
 
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, "plan-audit-check", model_used or "default", tokens_used)

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -72,21 +72,14 @@ receipt_plan_validated(
 )
 
 # After spec-completion auditor (plan audit; only invoked for high/critical risk):
-# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
-# compute them at audit time via:
-#   from lib_receipts import hash_file
-#   spec_sha256 = hash_file(task_dir / "spec.md")
-#   plan_sha256 = hash_file(task_dir / "plan.md")
-#   graph_sha256 = hash_file(task_dir / "execution-graph.json")
+# The writer re-hashes spec.md / plan.md / execution-graph.json from disk
+# at write time (SEC-004: no caller-supplied hashes, no TOCTOU window).
 # The PLAN_AUDIT exit gate re-hashes these artifacts and refuses to advance
 # when any has drifted since the audit was recorded.
 receipt_plan_audit(
     task_dir,
     tokens_used=TOTAL_TOKENS,
     finding_count=N,
-    spec_sha256=SPEC_SHA256,
-    plan_sha256=PLAN_SHA256,
-    graph_sha256=GRAPH_SHA256,
 )
 
 ```

--- a/tests/test_gate_plan_audit.py
+++ b/tests/test_gate_plan_audit.py
@@ -35,15 +35,9 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
 
 
 def _write_plan_audit(td: Path) -> None:
-    """Write a plan-audit-check receipt bound to the current artifact hashes."""
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    """Write a plan-audit-check receipt — the writer re-hashes artifacts
+    from disk (SEC-004, no caller-supplied hashes)."""
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 def test_critical_without_receipt_refuses(tmp_path: Path):

--- a/tests/test_gate_plan_audit_freshness.py
+++ b/tests/test_gate_plan_audit_freshness.py
@@ -36,14 +36,8 @@ def _setup(tmp_path: Path, *, risk: str) -> Path:
 
 
 def _write_fresh_audit(td: Path) -> None:
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    # SEC-004: writer re-hashes artifacts from disk; no caller args.
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 def test_refuses_when_plan_edited_after_audit(tmp_path: Path) -> None:

--- a/tests/test_hash_file_cache.py
+++ b/tests/test_hash_file_cache.py
@@ -1,0 +1,59 @@
+"""Tests for `hash_file` per-process memo (PERF-001).
+
+`hash_file` caches digests keyed by (absolute path, mtime_ns, size) so
+repeated calls against the same unchanged file share one disk read.
+Mutation of the file invalidates the entry automatically.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import _HASH_CACHE, hash_file  # noqa: E402
+
+
+def test_second_call_on_same_file_hits_cache(tmp_path: Path) -> None:
+    """Second hash of the same unchanged file must return the same digest
+    AND populate the module-level cache."""
+    f = tmp_path / "a.txt"
+    f.write_bytes(b"hello")
+    _HASH_CACHE.clear()
+    d1 = hash_file(f)
+    cache_size_after_first = len(_HASH_CACHE)
+    d2 = hash_file(f)
+    assert d1 == d2
+    # Second call must not grow the cache (already cached).
+    assert len(_HASH_CACHE) == cache_size_after_first
+    assert cache_size_after_first == 1
+
+
+def test_mutation_invalidates_cache(tmp_path: Path) -> None:
+    """Re-writing the file changes mtime_ns / size; the cached digest for
+    the old stat tuple stays in the dict but a new-stat read computes a
+    fresh digest. Stale-digest-returned-for-mutated-file is ruled out."""
+    f = tmp_path / "m.txt"
+    f.write_bytes(b"v1")
+    _HASH_CACHE.clear()
+    d1 = hash_file(f)
+    # Ensure mtime actually bumps (some FS have low resolution).
+    time.sleep(0.01)
+    os.utime(f, None)
+    f.write_bytes(b"v2 content bigger")  # also different size
+    d2 = hash_file(f)
+    assert d1 != d2, "digest must differ after content mutation"
+
+
+def test_cache_bounded(tmp_path: Path) -> None:
+    """Cache cap is bounded (FIFO eviction). Stuffing more than the cap
+    keeps the dict at/below the limit."""
+    from lib_receipts import _HASH_CACHE_MAX
+    _HASH_CACHE.clear()
+    for i in range(_HASH_CACHE_MAX + 20):
+        fp = tmp_path / f"f{i}.txt"
+        fp.write_bytes(f"body-{i}".encode())
+        hash_file(fp)
+    assert len(_HASH_CACHE) <= _HASH_CACHE_MAX

--- a/tests/test_receipt_contract_version.py
+++ b/tests/test_receipt_contract_version.py
@@ -111,14 +111,8 @@ def _exercise_writer(name: str, td: Path):
             td, "spec", 0, injected_prompt_sha256=digest
         )
     if name == "receipt_plan_audit":
-        return receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
+        # SEC-004: writer re-hashes disk; no caller-supplied hashes.
+        return receipt_plan_audit(td, tokens_used=0, finding_count=0)
     if name == "receipt_force_override":
         from lib_receipts import receipt_force_override
         return receipt_force_override(

--- a/tests/test_receipt_plan_audit_hash.py
+++ b/tests/test_receipt_plan_audit_hash.py
@@ -1,11 +1,13 @@
-"""Tests for receipt_plan_audit hash payload (F2) and plan_audit_matches
-helper (F3). CRITERIA 2 and 3.
+"""Tests for receipt_plan_audit hash payload and plan_audit_matches
+helper. CRITERIA 2 and 3 (F2/F3), with SEC-004 hardening applied.
 
-F2: `receipt_plan_audit(...)` now requires three kw-only string kwargs:
-`spec_sha256`, `plan_sha256`, `graph_sha256`. Each must be non-empty.
-The written payload carries all three.
+SEC-004 hardening: the writer no longer accepts caller-supplied hashes.
+It re-hashes `spec.md`, `plan.md`, and `execution-graph.json` from the
+task directory at write time. This closes the TOCTOU between a caller's
+hash read and the receipt write — the writer's own read is the
+authoritative source.
 
-F3: `plan_audit_matches(task_dir)` returns:
+F3: `plan_audit_matches(task_dir)` still returns:
   - True  when the receipt exists AND all three hashes match disk
   - a descriptive string (e.g. "plan.md hash drift") when the receipt
     is present but one of the artifacts drifted on disk
@@ -40,107 +42,58 @@ def _setup_artifacts(tmp_path: Path) -> Path:
 
 
 def _write_fresh_receipt(td: Path) -> None:
-    """Write a plan-audit-check receipt whose hashes match current disk."""
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    """Write a plan-audit-check receipt — the writer re-hashes current
+    disk contents (SEC-004: no caller-supplied hashes)."""
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 # ---------------------------------------------------------------------------
-# F2: receipt_plan_audit payload / signature
+# Payload / signature
 # ---------------------------------------------------------------------------
 
 
 def test_payload_contains_three_hashes(tmp_path: Path) -> None:
-    """Write a receipt with known hex digests; read the JSON back; assert
-    the three keys are present and match exactly what we passed in."""
+    """Write a receipt; read the JSON back; assert the three hash keys
+    are present AND match what `hash_file` says about the same files.
+
+    SEC-004: writer re-hashes internally — callers no longer supply
+    hashes — so the only way for the payload to be right is for the
+    writer to read the artifacts itself."""
     td = _setup_artifacts(tmp_path)
-    spec_h = "a" * 64
-    plan_h = "b" * 64
-    graph_h = "c" * 64
-    receipt_path = receipt_plan_audit(
-        td,
-        tokens_used=0,
-        finding_count=0,
-        spec_sha256=spec_h,
-        plan_sha256=plan_h,
-        graph_sha256=graph_h,
-    )
+    receipt_path = receipt_plan_audit(td, tokens_used=0, finding_count=0)
     payload = json.loads(receipt_path.read_text())
-    assert payload["spec_sha256"] == spec_h
-    assert payload["plan_sha256"] == plan_h
-    assert payload["graph_sha256"] == graph_h
+    assert payload["spec_sha256"] == hash_file(td / "spec.md")
+    assert payload["plan_sha256"] == hash_file(td / "plan.md")
+    assert payload["graph_sha256"] == hash_file(td / "execution-graph.json")
 
 
-def test_requires_spec_sha256(tmp_path: Path) -> None:
-    """Missing kwarg → TypeError (kw-only required argument).
-    Empty string → ValueError (explicit rejection of blank)."""
+def test_missing_artifact_writes_literal_missing(tmp_path: Path) -> None:
+    """When an artifact file is absent at write time, the corresponding
+    payload slot carries the literal string `missing`. Downstream
+    `plan_audit_matches` interprets that as a drift condition because it
+    never equals a real sha256 hex digest."""
     td = _setup_artifacts(tmp_path)
-    # Omission — kw-only required → TypeError.
-    with pytest.raises(TypeError):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
-    # Empty string — explicit ValueError naming the arg.
-    with pytest.raises(ValueError, match="spec_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="",
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
+    (td / "plan.md").unlink()
+    receipt_path = receipt_plan_audit(td, tokens_used=0, finding_count=0)
+    payload = json.loads(receipt_path.read_text())
+    assert payload["plan_sha256"] == "missing"
+    # Spec and graph are still real hashes.
+    assert payload["spec_sha256"] == hash_file(td / "spec.md")
+    assert payload["graph_sha256"] == hash_file(td / "execution-graph.json")
 
 
-def test_requires_plan_sha256(tmp_path: Path) -> None:
+def test_signature_rejects_caller_supplied_hashes(tmp_path: Path) -> None:
+    """SEC-004 regression: callers that still try to pass the old
+    kwargs (spec_sha256/plan_sha256/graph_sha256) hit a TypeError for
+    unexpected-kwarg. The three args are no longer part of the
+    public signature."""
     td = _setup_artifacts(tmp_path)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="spec_sha256"):
         receipt_plan_audit(
             td,
             tokens_used=0,
             finding_count=0,
-            spec_sha256="a" * 64,
-            graph_sha256="c" * 64,
-        )
-    with pytest.raises(ValueError, match="plan_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="",
-            graph_sha256="c" * 64,
-        )
-
-
-def test_requires_graph_sha256(tmp_path: Path) -> None:
-    td = _setup_artifacts(tmp_path)
-    with pytest.raises(TypeError):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-        )
-    with pytest.raises(ValueError, match="graph_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-            graph_sha256="",
+            spec_sha256="a" * 64,  # type: ignore[call-arg]
         )
 
 

--- a/tests/test_tdd_required_default.py
+++ b/tests/test_tdd_required_default.py
@@ -61,14 +61,7 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
 
 def test_plan_audit_to_pre_exec_permitted_when_tdd_required_absent_critical(tmp_path: Path):
     td = _setup(tmp_path, risk="critical")  # no tdd_required field
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
     # Must succeed: tdd_required absent, plan-audit-check is present.
     transition_task(td, "PRE_EXECUTION_SNAPSHOT")
     manifest = json.loads((td / "manifest.json").read_text())


### PR DESCRIPTION
## Summary

Five quality-of-life follow-ups from the 5-auditor pass on PR #126. All non-blocking — the enforcement semantics from #126 are unchanged; these are internal cleanups + one signature simplification (SEC-004) that closes a real TOCTOU window.

One commit: `c0b24d1 — solve non-blocking audit findings from PR #126 review`.

## What's fixed

| ID | Finding | Fix |
|---|---|---|
| **CQ-001** | Dry-run `_add` vs live `_add_seg` helper-name drift | Rename dry-run to `_add_seg` for parity |
| **CQ-002** | 3 identical `try/except` log blocks in `_flush_retrospective_on_done` | Extract to one nested `_log_flush_failed(destination, error)` helper |
| **CQ-003** | Broad `except Exception` in force-override receipt path logged static string | Capture `exc` and log `f"unexpected: {exc}"` like the OSError branch |
| **PERF-001** | Potential dual-hash of 3 plan artifacts in one process | `hash_file` memoized by `(abs_path, mtime_ns, size)`; bounded at 128 entries with FIFO eviction |
| **SEC-004** | `receipt_plan_audit` took caller-supplied hashes — TOCTOU between hash-read and write | Writer now re-hashes `spec.md` / `plan.md` / `execution-graph.json` from disk internally. Caller kwargs removed; TypeError on unexpected kwarg enforces migration |

## Breaking change (SEC-004 only)

`receipt_plan_audit` signature drops `spec_sha256` / `plan_sha256` / `graph_sha256` kwargs. Every caller migrated in the same commit:
- `skills/start/SKILL.md` + `cli/assets/templates/base/start.md`
- `tests/test_gate_plan_audit.py`, `tests/test_tdd_required_default.py`, `tests/test_gate_plan_audit_freshness.py`, `tests/test_receipt_contract_version.py`
- `tests/test_receipt_plan_audit_hash.py` — rewritten to verify the new writer-re-hashes contract; adds `test_missing_artifact_writes_literal_missing` and `test_signature_rejects_caller_supplied_hashes`

Any downstream project that had a hand-rolled `receipt_plan_audit(...)` call passing the three hashes will now hit a clean `TypeError` — point them at the simpler signature.

## New tests

- `tests/test_hash_file_cache.py` (3 tests)
  - `test_second_call_on_same_file_hits_cache` — cache-size-unchanged on second call (PERF-001 proof)
  - `test_mutation_invalidates_cache` — mtime/size change forces re-hash
  - `test_cache_bounded` — FIFO eviction keeps dict ≤ 128

- `tests/test_receipt_plan_audit_hash.py` (rewritten; 3 new tests)
  - `test_payload_contains_three_hashes` — writer-computed hashes match disk
  - `test_missing_artifact_writes_literal_missing` — SEC-004 drift signal
  - `test_signature_rejects_caller_supplied_hashes` — SEC-004 regression

**Full suite: 1227 passed, 2 skipped, 0 failed** (up from 1225 on main after #126).

## Deliberately NOT addressed

| ID | Why deferred |
|---|---|
| **SEC-003** | Persistent-dir-wins dedupe (F11). Trust boundary is already the persistent dir itself; if an attacker has write access there, much worse attacks are possible. |
| **SEC-005** | F9 receipt-count glob can be inflated by planting empty files matching the pattern. `receipts/` is already inside the task trust boundary. |
| **PERF-002** | `force=True` dry-run reruns the gate block. Rare break-glass path; the dual-read is acceptable. |
| **PERF-003** | `collect_retrospectives` union is O(N+M). Dedup is correct linear; no quadratic behavior. Fine at current scale. |

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/test_self_proof_task_004.py` exits 0
- [x] Full suite 1227 passed, +3 new hash-cache regression tests
- [x] Every caller of `receipt_plan_audit` migrated in-tree
- [ ] Reviewer sanity-check: `hash_file` cache key includes `mtime_ns` (high-resolution on all supported platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)