### PR TITLE
stop the postmortem-skip trust-me-bro pattern (G1-G4 structural guardrails)

### DIFF
--- a/cli/assets/templates/base/audit.md
+++ b/cli/assets/templates/base/audit.md
@@ -302,6 +302,14 @@ Append to log:
 {timestamp} [DONE] reflect — task-retrospective.json written
 ```
 
+**Postmortem skip decision (deterministic):** Before the LLM postmortem runs, the deterministic engine decides whether a skip receipt may be written. The decision is:
+
+- ≥2 auditors ran AND every auditor reported `findings: []` → emit `receipt_postmortem_skipped(task_dir, reason="clean-task", retrospective_sha256=..., subsumed_by=[])`.
+- Exactly 1 auditor ran AND it reported `findings: []` → emit `receipt_postmortem_skipped(task_dir, reason="no-findings", retrospective_sha256=..., subsumed_by=[])`.
+- Any auditor reported ≥1 finding → do NOT skip; run the LLM postmortem and write `receipt_postmortem_generated(...)`.
+
+If ANY auditor reports ≥1 finding (blocking or not), the LLM postmortem runs — no "quality-above-threshold" bypass. The `subsumed_by` argument is required on every skip receipt write; the empty list `[]` is valid only for `reason="clean-task"` or `reason="no-findings"`.
+
 **Post-completion processing:** Learn, trajectory rebuild, evolve, postmortems, and dashboard refresh are handled automatically by the `task-completed` hook via the event bus. Do not run them inline. The hook fires after this skill completes and the task reaches DONE.
 
 Write `completion.json`. Transition the task to `DONE` by calling `transition_task(task_dir, "DONE")` from `dynoslib.py` (this sets both `stage` and `completion_at`). If calling the function directly is not possible, manually set both `"stage": "DONE"` and `"completion_at": "{ISO timestamp}"` in `manifest.json`. Append to log:

--- a/cli/assets/templates/base/start.md
+++ b/cli/assets/templates/base/start.md
@@ -55,16 +55,14 @@ receipt_planner_spawn(
 )
 
 # After spec-completion auditor (plan audit):
-# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
-# the PLAN_AUDIT exit gate re-hashes these artifacts at transition time and
+# The writer re-hashes spec.md / plan.md / execution-graph.json from disk
+# at write time (SEC-004: no caller-supplied hashes, no TOCTOU window).
+# The PLAN_AUDIT exit gate re-hashes these artifacts at transition time and
 # refuses to advance when any has drifted since the audit was recorded.
 receipt_plan_audit(
     task_dir,
     tokens_used=TOTAL_TOKENS,
     finding_count=N,
-    spec_sha256=SPEC_SHA256,
-    plan_sha256=PLAN_SHA256,
-    graph_sha256=GRAPH_SHA256,
 )
 
 ```

--- a/hooks/check_deferred_findings.py
+++ b/hooks/check_deferred_findings.py
@@ -1,0 +1,194 @@
+"""Deferred-findings TTL check (task-20260419-002 G4).
+
+Exposes BOTH an importable Python function AND a thin argparse CLI that
+delegates to that function. Both paths return/emit the same data — the
+module-level helper is the source of truth; the CLI is a shell wrapper
+for CI and for operators running ``python3 hooks/check_deferred_findings.py``.
+
+Failure mode is deliberately fail-open for MISSING signal:
+  - registry file absent        → returns ``[]``, exits 0 (cold start).
+  - registry file malformed     → returns ``[]``, exits 0 (operator will
+                                   be told by ``append_deferred_findings``
+                                   when they next try to write; we don't
+                                   want a corrupt registry to wedge the
+                                   DONE gate and block unrelated tasks).
+  - registry present, healthy,
+    but no intersecting entries → returns ``[]``, exits 0.
+  - intersecting entry still
+    within TTL                  → returns ``[]``, exits 0.
+  - intersecting entry PAST TTL → returned in the list with an ``elapsed``
+                                   field; CLI exits 1 and prints one line
+                                   per expired entry.
+
+``transition_task`` imports the Python function directly (no subprocess
+spawn) so the gate behaves deterministically in tests and does not
+inherit shell / PYTHONPATH surprises from the caller's environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Support both ``python3 hooks/check_deferred_findings.py`` (script mode,
+# hooks/ is on sys.path because the file lives there) and ``from hooks
+# import check_deferred_findings`` (package-ish import from tests). The
+# ``_persistent_project_dir`` import is the only thing we need from
+# lib_core; we fail open if it is missing so the gate never wedges on a
+# half-installed framework.
+try:
+    from lib_core import _persistent_project_dir  # type: ignore
+except ImportError:
+    try:
+        from hooks.lib_core import _persistent_project_dir  # type: ignore
+    except ImportError:
+        _persistent_project_dir = None  # type: ignore
+
+
+def _current_retrospective_count(root: Path) -> int:
+    """Return the count of ``retrospectives/*.json`` files under the
+    persistent project dir for ``root``. Returns 0 on any error — the
+    TTL baseline is simply "no tasks yet", matching cold-start behavior.
+    """
+    if _persistent_project_dir is None:
+        return 0
+    try:
+        retro_dir = _persistent_project_dir(root) / "retrospectives"
+    except Exception:
+        return 0
+    if not retro_dir.exists():
+        return 0
+    try:
+        return len(list(retro_dir.glob("*.json")))
+    except OSError:
+        return 0
+
+
+def _load_registry(root: Path) -> dict[str, Any] | None:
+    """Load ``root/.dynos/deferred-findings.json``. Returns None on any
+    failure (missing file, unreadable, malformed JSON, wrong shape).
+    The caller treats None as "no signal → fail open → exit 0"."""
+    registry_path = root / ".dynos" / "deferred-findings.json"
+    if not registry_path.exists():
+        return None
+    try:
+        text = registry_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def check_deferred_findings(
+    root: Path,
+    changed_files: list[str],
+) -> list[dict]:
+    """Return TTL-expired deferred findings whose ``files`` intersect
+    ``changed_files``.
+
+    Each returned dict is the original registry entry augmented with an
+    ``elapsed`` field (int) so callers can surface the overshoot.
+
+    Never raises. Missing or malformed registry → empty list (fail open
+    for missing signal). A malformed entry within an otherwise-valid
+    registry is skipped individually without poisoning the other entries.
+    """
+    root = Path(root)
+    if not isinstance(changed_files, list):
+        # Defensive: the CLI guarantees a list, but an in-process caller
+        # might hand us something else. Fail open.
+        return []
+    changed_set = {f for f in changed_files if isinstance(f, str) and f}
+    if not changed_set:
+        return []
+
+    registry = _load_registry(root)
+    if registry is None:
+        return []
+    entries = registry.get("findings")
+    if not isinstance(entries, list):
+        return []
+
+    current_count = _current_retrospective_count(root)
+
+    expired: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_files = entry.get("files")
+        if not isinstance(entry_files, list):
+            continue
+        # Intersection: any exact-string match between entry.files and
+        # changed_files. We do NOT normalize paths here — callers pass
+        # project-relative paths on both sides.
+        if not any(
+            isinstance(f, str) and f in changed_set for f in entry_files
+        ):
+            continue
+        first_seen = entry.get("first_seen_at_task_count")
+        ttl = entry.get("acknowledged_until_task_count")
+        if not isinstance(first_seen, int) or not isinstance(ttl, int):
+            # Malformed registry entry — skip rather than fail the gate.
+            continue
+        elapsed = current_count - first_seen
+        if elapsed >= ttl:
+            expired.append({**entry, "elapsed": elapsed})
+
+    return expired
+
+
+def _format_expired_line(entry: dict) -> str:
+    """Format one expired-entry line for the CLI. Keys are sorted in a
+    stable, human-readable order; ``files`` is rendered as a JSON array
+    so the output is unambiguous for downstream parsers."""
+    return (
+        f"DEFERRED FINDING EXPIRED: "
+        f"id={entry.get('id', '')} "
+        f"category={entry.get('category', '')} "
+        f"task_id={entry.get('task_id', '')} "
+        f"files={json.dumps(entry.get('files', []))}"
+    )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_deferred_findings",
+        description=(
+            "Check the project deferred-findings registry against a list "
+            "of changed files. Exits 1 if any TTL-expired finding intersects."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Project root (default: current directory).",
+    )
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=[],
+        help="One or more file paths, project-relative, to check.",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    changed_files = list(args.changed_files or [])
+
+    expired = check_deferred_findings(root, changed_files)
+
+    for entry in expired:
+        print(_format_expired_line(entry))
+
+    return 1 if expired else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -630,7 +630,10 @@ def _compute_bypassed_gates_for_force(
             required_seg_ids: list[str] = []
             seen: set[str] = set()
 
-            def _add(seg_id: object) -> None:
+            # CQ-001: helper name matches the live gate's `_add_seg` in
+            # transition_task so drift between dry-run and live is
+            # mechanically obvious on review.
+            def _add_seg(seg_id: object) -> None:
                 if isinstance(seg_id, str) and seg_id and seg_id not in seen:
                     required_seg_ids.append(seg_id)
                     seen.add(seg_id)
@@ -646,12 +649,12 @@ def _compute_bypassed_gates_for_force(
                     if isinstance(graph_segments, list):
                         for entry in graph_segments:
                             if isinstance(entry, dict):
-                                _add(entry.get("id"))
+                                _add_seg(entry.get("id"))
             routing_segments = routing_payload.get("segments")
             if isinstance(routing_segments, list):
                 for entry in routing_segments:
                     if isinstance(entry, dict):
-                        _add(entry.get("segment_id"))
+                        _add_seg(entry.get("segment_id"))
             for seg_id in required_seg_ids:
                 if read_receipt(task_dir, f"executor-{seg_id}") is None:
                     errs.append(
@@ -750,14 +753,11 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
         return
     root = task_dir.parent.parent
     task_id = manifest.get("task_id") or task_dir.name
-    # SEC-001 hardening: validate task_id as a safe slug BEFORE path join.
-    # A crafted manifest with "task_id": "../../evil" would otherwise escape
-    # the persistent retrospectives dir. Accepts current dynos format
-    # (task-YYYYMMDD-NNN) plus test-style ids (task-T, task-A).
-    import re as _re_slug
-    if not isinstance(task_id, str) or not _re_slug.match(
-        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
-    ):
+
+    # CQ-002: single helper for the three identical failure-emit blocks
+    # below. Invariant: NEVER raises — best-effort log event with a
+    # swallow-all outer try/except.
+    def _log_flush_failed(destination: str, error: str) -> None:
         try:
             from lib_log import log_event as _log_flush
             _log_flush(
@@ -766,11 +766,21 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
                 task=str(task_id),
                 task_id=str(task_id),
                 source=str(src),
-                destination="",
-                error=f"invalid task_id slug: {task_id!r}",
+                destination=destination,
+                error=error,
             )
         except Exception:
             pass
+
+    # SEC-001 hardening: validate task_id as a safe slug BEFORE path join.
+    # A crafted manifest with "task_id": "../../evil" would otherwise escape
+    # the persistent retrospectives dir. Accepts current dynos format
+    # (task-YYYYMMDD-NNN) plus test-style ids (task-T, task-A).
+    import re as _re_slug
+    if not isinstance(task_id, str) or not _re_slug.match(
+        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
+    ):
+        _log_flush_failed(destination="", error=f"invalid task_id slug: {task_id!r}")
         return
     try:
         dst_dir = _persistent_project_dir(root) / "retrospectives"
@@ -783,53 +793,17 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
             raise OSError(f"resolved dst escapes retrospectives dir: {dst}")
     except OSError as exc:
         # Can't even compute or create the destination dir — log and bail.
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination="",
-                error=str(exc),
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination="", error=str(exc))
         return
     try:
         from lib_receipts import _atomic_write_text
         _atomic_write_text(dst, src.read_text("utf-8"))
     except OSError as exc:
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination=str(dst),
-                error=str(exc),
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination=str(dst), error=str(exc))
         return
     except Exception as exc:
         # Non-OSError (unexpected) — still must not block DONE.
-        try:
-            from lib_log import log_event as _log_flush
-            _log_flush(
-                root,
-                "retrospective_flush_failed",
-                task=task_id,
-                task_id=task_id,
-                source=str(src),
-                destination=str(dst),
-                error=f"unexpected: {exc}",
-            )
-        except Exception:
-            pass
+        _log_flush_failed(destination=str(dst), error=f"unexpected: {exc}")
         return
     # Success path — hash the newly-written destination for the event.
     try:
@@ -1234,10 +1208,12 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                 )
             except Exception:
                 pass
-        except Exception:
+        except Exception as _force_rcpt_unexpected:
             # Non-OSError receipt-write failures are ALSO non-blocking
             # (e.g. validation bugs should not lock out recovery) — we
-            # log best-effort and proceed.
+            # log best-effort and proceed. CQ-003: include str(exc) so
+            # the event payload carries the actual failure detail
+            # (the OSError branch above already does).
             try:
                 from lib_log import log_event as _log_force_fail
                 _log_force_fail(
@@ -1245,7 +1221,7 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                     "force_override_receipt_write_failed",
                     task=_task_id_force,
                     task_id=_task_id_force,
-                    error="unexpected receipt writer failure",
+                    error=f"unexpected: {_force_rcpt_unexpected}",
                 )
             except Exception:
                 pass

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -1423,6 +1423,99 @@ def find_active_tasks(root: Path) -> list[Path]:
 # Retrospective helpers
 # ---------------------------------------------------------------------------
 
+def _flushed_sha_by_task_id(root: Path) -> dict[str, str]:
+    """Parse ``.dynos/events.jsonl`` once and return
+    ``{task_id: last_flushed_sha256}`` from ``retrospective_flushed``
+    events. LAST event wins — re-plays overwrite.
+
+    Malformed lines are skipped silently. Missing file → empty dict.
+    Used by SEC-003 cross-check on persistent retrospectives.
+    """
+    out: dict[str, str] = {}
+    events_path = root / ".dynos" / "events.jsonl"
+    if not events_path.exists():
+        return out
+    try:
+        with events_path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(ev, dict):
+                    continue
+                if ev.get("event") != "retrospective_flushed":
+                    continue
+                tid = ev.get("task_id")
+                sha = ev.get("sha256")
+                if isinstance(tid, str) and tid and isinstance(sha, str) and sha:
+                    out[tid] = sha
+    except OSError:
+        return {}
+    return out
+
+
+# PERF-003: per-process memo for collect_retrospectives. Key is a stat
+# fingerprint of the two source dirs + events.jsonl so any mutation
+# invalidates. Small dict — at most one entry per unique root path.
+_COLLECT_RETRO_CACHE: dict[Path, tuple[tuple, list[dict]]] = {}
+
+
+def _retros_stat_fingerprint(root: Path) -> tuple:
+    """Return a tuple summarizing the current on-disk state of the three
+    inputs to collect_retrospectives. Any change (new file, edit, delete)
+    changes the tuple, invalidating the cache.
+
+    The fingerprint is cheap — stat() calls only, no reads.
+    """
+    def _dir_sig(d: Path) -> tuple:
+        if not d.exists():
+            return ("MISSING",)
+        try:
+            entries = sorted(d.iterdir())
+        except OSError:
+            return ("UNREADABLE",)
+        parts: list[tuple] = []
+        for p in entries:
+            try:
+                st = p.stat()
+                parts.append((p.name, st.st_mtime_ns, st.st_size))
+            except OSError:
+                continue
+        return tuple(parts)
+
+    worktree = _dir_sig(root / ".dynos")
+    # Also fingerprint every task-* subdir's retrospective file.
+    try:
+        worktree_retros = tuple(
+            (p.name, p.stat().st_mtime_ns, p.stat().st_size)
+            for p in sorted((root / ".dynos").glob("task-*/task-retrospective.json"))
+        )
+    except OSError:
+        worktree_retros = ()
+
+    try:
+        pd = _persistent_project_dir(root) / "retrospectives"
+        persistent = _dir_sig(pd)
+    except OSError:
+        persistent = ("ERROR",)
+
+    events_path = root / ".dynos" / "events.jsonl"
+    try:
+        if events_path.exists():
+            est = events_path.stat()
+            events_sig = (est.st_mtime_ns, est.st_size)
+        else:
+            events_sig = ("MISSING",)
+    except OSError:
+        events_sig = ("UNREADABLE",)
+
+    return (worktree, worktree_retros, persistent, events_sig)
+
+
 def collect_retrospectives(root: Path) -> list[dict]:
     """Collect all task retrospective JSON files from both the worktree
     and the project-persistent directory.
@@ -1440,11 +1533,34 @@ def collect_retrospectives(root: Path) -> list[dict]:
     worktree copy may have been edited post-DONE (not supposed to
     happen, but possible).
 
+    SEC-003 hardening: for each persistent retro, the content sha256 is
+    re-computed and compared to the ``retrospective_flushed`` event
+    recorded in ``.dynos/events.jsonl`` at DONE time. A mismatch means
+    someone tampered with the persistent file after flush; that retro
+    is SKIPPED (the worktree copy, if present, is used instead). Absence
+    of a flush event for a given task_id is NOT a rejection — cold-
+    start / pre-SEC-003-code retros are trusted by default.
+
+    PERF-003 hardening: results are memoized per-root, keyed by a stat
+    fingerprint of the two source dirs and events.jsonl. Any mutation
+    of any file in those paths invalidates the cache on the next call.
+
     Missing persistent dir (new project, no DONE tasks yet) is treated
     as empty. Malformed JSON is skipped silently on either side. Entries
     without a string ``task_id`` are kept under synthetic keys so a
     malformed registry cannot drop a legitimate worktree entry.
     """
+    root = Path(root)
+    fingerprint = _retros_stat_fingerprint(root)
+    cached = _COLLECT_RETRO_CACHE.get(root)
+    if cached is not None and cached[0] == fingerprint:
+        return list(cached[1])
+
+    flushed_shas = _flushed_sha_by_task_id(root)
+
+    # Import locally to avoid hashlib-at-top-level cost on import
+    from lib_receipts import hash_file
+
     by_task_id: dict[str, dict] = {}
     synth_counter = 0
 
@@ -1456,10 +1572,27 @@ def collect_retrospectives(root: Path) -> list[dict]:
             return
         if not isinstance(data, dict):
             return
+
+        tid = data.get("task_id")
+
+        # SEC-003: verify persistent retros against the flushed-event
+        # sha256. Tampered content (content-hash != event-hash) →
+        # skip. No-event-known → trust (cold-start compat).
+        if persistent and isinstance(tid, str) and tid:
+            expected = flushed_shas.get(tid)
+            if expected:
+                try:
+                    actual = hash_file(path)
+                except OSError:
+                    actual = ""
+                if actual != expected:
+                    # Skip this persistent copy entirely — the worktree
+                    # copy (if present) will stand.
+                    return
+
         data["_path"] = str(path)
         data["_source"] = "persistent" if persistent else "worktree"
 
-        tid = data.get("task_id")
         if isinstance(tid, str) and tid:
             key = tid
         else:
@@ -1502,7 +1635,9 @@ def collect_retrospectives(root: Path) -> list[dict]:
     except OSError:
         pass
 
-    return list(by_task_id.values())
+    result = list(by_task_id.values())
+    _COLLECT_RETRO_CACHE[root] = (fingerprint, result)
+    return list(result)
 
 
 def retrospective_task_ids(root: Path) -> list[str]:

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -1159,6 +1159,112 @@ def transition_task(task_dir: Path, next_stage: str, *, force: bool = False) -> 
                 + "\n".join(f"  - {e}" for e in gate_errors)
             )
 
+        # ---- task-20260419-002 G4: deferred-findings TTL gate on DONE ----
+        # Fire AFTER every other gate has passed. If ANY deferred finding
+        # whose `files` intersects THIS task's changed files has exceeded
+        # its TTL without re-acknowledgment, refuse the transition. The
+        # check module is imported inline (not subprocess) for test
+        # determinism; a missing module (broken install) is fail-open so
+        # a busted framework does not wedge unrelated DONE transitions.
+        if next_stage == "DONE":
+            try:
+                from check_deferred_findings import (
+                    check_deferred_findings as _check_deferred,
+                )
+            except ImportError:
+                _check_deferred = None  # type: ignore
+
+            if _check_deferred is not None:
+                # Build the changed-files list. Primary source: the
+                # executor-{seg} receipts' files_expected payloads (the
+                # routing receipt names the segments that actually ran).
+                # Fallback source: execution-graph.json's segments — so
+                # the gate still fires when the executor receipt schema
+                # did not yet carry files_expected at the time those
+                # segments ran.
+                changed_files: list[str] = []
+                seen_files: set[str] = set()
+
+                def _add_files(paths: object) -> None:
+                    if not isinstance(paths, list):
+                        return
+                    for p in paths:
+                        if isinstance(p, str) and p and p not in seen_files:
+                            seen_files.add(p)
+                            changed_files.append(p)
+
+                # (1) Walk executor-routing → executor-{seg} receipts.
+                try:
+                    _exec_routing = read_receipt(task_dir, "executor-routing")
+                except Exception:
+                    _exec_routing = None
+                if isinstance(_exec_routing, dict):
+                    _routing_segments = _exec_routing.get("segments")
+                    if isinstance(_routing_segments, list):
+                        # SEC-002 hardening: seg_id is interpolated into the
+                        # receipt step_name. Validate against a strict slug
+                        # regex so a crafted routing payload cannot inject
+                        # path separators or unexpected chars into the
+                        # receipt filename construction.
+                        import re as _re_seg
+                        _SEG_RE = r"^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+                        for _entry in _routing_segments:
+                            if not isinstance(_entry, dict):
+                                continue
+                            _seg_id = _entry.get("segment_id")
+                            if not isinstance(_seg_id, str) or not _seg_id:
+                                continue
+                            if not _re_seg.match(_SEG_RE, _seg_id):
+                                # Crafted / invalid seg_id — skip silently.
+                                # A legitimate segment follows the slug rule.
+                                continue
+                            try:
+                                _seg_receipt = read_receipt(
+                                    task_dir, f"executor-{_seg_id}"
+                                )
+                            except Exception:
+                                _seg_receipt = None
+                            if isinstance(_seg_receipt, dict):
+                                _add_files(_seg_receipt.get("files_expected"))
+
+                # (2) Fallback: execution-graph.json segments.
+                _graph_path = task_dir / "execution-graph.json"
+                if _graph_path.exists():
+                    try:
+                        _graph = load_json(_graph_path)
+                    except (OSError, ValueError):
+                        _graph = None
+                    if isinstance(_graph, dict):
+                        _graph_segments = _graph.get("segments")
+                        if isinstance(_graph_segments, list):
+                            for _entry in _graph_segments:
+                                if isinstance(_entry, dict):
+                                    _add_files(_entry.get("files_expected"))
+
+                try:
+                    _expired = _check_deferred(
+                        task_dir.parent.parent, changed_files
+                    )
+                except Exception:
+                    # check_deferred_findings is designed to never raise;
+                    # if it does (unforeseen bug), treat as no signal and
+                    # fail open rather than wedge the DONE gate.
+                    _expired = []
+
+                if _expired:
+                    _ids = [
+                        str(e.get("id", ""))
+                        for e in _expired
+                        if isinstance(e, dict)
+                    ]
+                    _refuse(
+                        f"Cannot transition {current_stage} -> {next_stage}: "
+                        f"deferred findings expired: {_ids}. "
+                        f"Close them, re-acknowledge via "
+                        f".dynos/deferred-findings.json, or use --force "
+                        f"(which writes a force_override receipt)."
+                    )
+
     # ---- F7: force_override observability ----
     # When force=True, compute what gate errors WOULD have fired had
     # force been False, emit a dedicated `force_override` event, and
@@ -1514,6 +1620,157 @@ def _retros_stat_fingerprint(root: Path) -> tuple:
         events_sig = ("UNREADABLE",)
 
     return (worktree, worktree_retros, persistent, events_sig)
+
+
+def append_deferred_findings(
+    root: Path,
+    task_id: str,
+    findings: list[dict],
+) -> None:
+    """Append non-blocking findings to ``root/.dynos/deferred-findings.json``.
+
+    task-20260419-002 G4: this is the persistence path for the deferred-
+    findings registry. Each entry in ``findings`` must be a dict shaped as:
+
+        {"id": <non-empty str>,
+         "category": <non-empty str>,
+         "files": [<non-empty str>, ...]}  # non-empty list of non-empty strs
+
+    The writer augments every entry with:
+      - ``task_id``            (from the ``task_id`` arg)
+      - ``first_seen_at``      (ISO-8601 UTC from ``now_iso()``)
+      - ``first_seen_at_task_count``
+            (count of ``_persistent_project_dir(root)/retrospectives/*.json``
+             files at append time)
+      - ``acknowledged_until_task_count``  (constant ``3``)
+
+    Validation is all-or-nothing: every entry is validated BEFORE any write
+    happens. The FIRST invalid entry raises ``ValueError`` and the registry
+    file on disk is unchanged (no partial mutation). The four validation
+    rules fire in order: (a) top-level ``findings`` must be a list;
+    (b) each entry must be a dict; (c) each entry must carry the required
+    keys with the correct types; (d) registry file, if present, must parse.
+
+    Missing registry file (cold start) is treated as ``{"findings": []}``
+    and a new registry is created. Malformed existing registry raises
+    ``ValueError`` — operator must repair; dropping entries silently would
+    erase prior work.
+
+    Atomic write via ``_atomic_write_text`` so a crash mid-write cannot
+    tear the registry file. The read→mutate→write sequence itself is NOT
+    locked; in the single-orchestrator invariant model this is fine.
+    """
+    # Import _atomic_write_text lazily — lib_receipts imports lib_core at
+    # module load time (circular otherwise).
+    from lib_receipts import _atomic_write_text
+
+    # SEC-003 hardening: task_id is used to tag every appended entry.
+    # A malicious caller supplying "../../evil" or "" would poison the
+    # registry with entries that reference invalid task ids. Validate
+    # against the same slug regex used for F10 / SEC-001 / planner-
+    # inject-prompt.
+    import re as _re_tid
+    if not isinstance(task_id, str) or not _re_tid.match(
+        r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$", task_id
+    ):
+        raise ValueError(
+            f"task_id must match ^task-[A-Za-z0-9][A-Za-z0-9_.-]*$ (got {task_id!r})"
+        )
+
+    # Rule (a): findings must be a list.
+    if not isinstance(findings, list):
+        raise ValueError("findings must be a list")
+
+    # Rules (b) + (c): validate every entry up front — no partial write.
+    for i, entry in enumerate(findings):
+        if not isinstance(entry, dict):
+            raise ValueError(f"findings[{i}] must be a dict")
+        # Required-key presence check — raise with the first missing key.
+        for key in ("id", "category", "files"):
+            if key not in entry:
+                raise ValueError(
+                    f"findings[{i}] missing required key: {key!r}"
+                )
+        # Type + non-empty checks.
+        id_val = entry["id"]
+        if not isinstance(id_val, str) or not id_val:
+            raise ValueError(f"findings[{i}].id must be a non-empty str")
+        cat_val = entry["category"]
+        if not isinstance(cat_val, str) or not cat_val:
+            raise ValueError(
+                f"findings[{i}].category must be a non-empty str"
+            )
+        files_val = entry["files"]
+        if not isinstance(files_val, list) or not files_val:
+            raise ValueError(
+                f"findings[{i}].files must be a non-empty list"
+            )
+        for j, f in enumerate(files_val):
+            if not isinstance(f, str) or not f:
+                raise ValueError(
+                    f"findings[{i}].files[{j}] must be a non-empty str"
+                )
+
+    registry_path = Path(root) / ".dynos" / "deferred-findings.json"
+
+    # Load existing registry (or cold-start). Parse failure → hard error
+    # per spec (operator repairs; silent drop would erase prior entries).
+    if registry_path.exists():
+        try:
+            registry_text = registry_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(
+                f"cannot parse .dynos/deferred-findings.json: {exc}"
+            ) from exc
+        try:
+            registry = json.loads(registry_text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"cannot parse .dynos/deferred-findings.json: {exc}"
+            ) from exc
+        if not isinstance(registry, dict):
+            raise ValueError(
+                "cannot parse .dynos/deferred-findings.json: "
+                "root value must be an object"
+            )
+        existing = registry.get("findings")
+        if not isinstance(existing, list):
+            # Cold-start-ish: missing or malformed `findings` key. We
+            # treat this as an empty list rather than a hard error so a
+            # file with other keys but no findings can still be appended.
+            registry["findings"] = []
+    else:
+        registry = {"findings": []}
+
+    # Count retrospectives AT append time — the snapshot anchors the TTL
+    # baseline for every entry added in this call.
+    try:
+        retro_dir = _persistent_project_dir(Path(root)) / "retrospectives"
+        first_seen_at_task_count = (
+            len(list(retro_dir.glob("*.json"))) if retro_dir.exists() else 0
+        )
+    except OSError:
+        first_seen_at_task_count = 0
+
+    first_seen_at = now_iso()
+
+    for entry in findings:
+        # Copy + augment so the caller's dict is NOT mutated (safer for
+        # callers that reuse the list).
+        registry["findings"].append({
+            "id": entry["id"],
+            "category": entry["category"],
+            "files": list(entry["files"]),
+            "task_id": task_id,
+            "first_seen_at": first_seen_at,
+            "first_seen_at_task_count": first_seen_at_task_count,
+            "acknowledged_until_task_count": 3,
+        })
+
+    _atomic_write_text(
+        registry_path,
+        json.dumps(registry, indent=2) + "\n",
+    )
 
 
 def collect_retrospectives(root: Path) -> list[dict]:

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -61,16 +61,51 @@ INJECTED_AUDITOR_PROMPTS_DIR = "_injected-auditor-prompts"
 INJECTED_PLANNER_PROMPTS_DIR = "_injected-planner-prompts"
 
 
+# PERF-001: per-process memo for hash_file keyed by (abs_path, mtime_ns,
+# size). Repeated hashes of the same unchanged file in one Python process
+# (e.g. receipt_plan_audit write + plan_audit_matches gate check) now
+# share one disk read. Invalidated automatically when mtime or size
+# change, so writes between hashes are picked up. Bounded to 128 entries
+# to keep the cache small.
+_HASH_CACHE: dict[tuple[str, int, int], str] = {}
+_HASH_CACHE_MAX = 128
+
+
 def hash_file(path: Path) -> str:
     """Return sha256 hex digest of a file's contents.
 
     Raises FileNotFoundError if path does not exist.
+
+    Cached per (absolute-path, mtime_ns, size) within the Python process.
+    Any mutation changes mtime_ns or size and invalidates the entry on
+    the next call — no stale-hash risk.
     """
+    try:
+        st = path.stat()
+    except OSError:
+        # File missing → let open() raise the canonical error below.
+        st = None
+    if st is not None:
+        key = (str(path.resolve()), st.st_mtime_ns, st.st_size)
+        cached = _HASH_CACHE.get(key)
+        if cached is not None:
+            return cached
+
     h = hashlib.sha256()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
-    return h.hexdigest()
+    digest = h.hexdigest()
+
+    if st is not None:
+        # Evict oldest if over cap (FIFO is fine; hot keys churn little).
+        if len(_HASH_CACHE) >= _HASH_CACHE_MAX:
+            try:
+                _HASH_CACHE.pop(next(iter(_HASH_CACHE)))
+            except StopIteration:
+                pass
+        _HASH_CACHE[(str(path.resolve()), st.st_mtime_ns, st.st_size)] = digest
+    return digest
 
 
 __all__ = [
@@ -877,30 +912,39 @@ def receipt_plan_audit(
     tokens_used: int | None,
     finding_count: int = 0,
     model_used: str | None = None,
-    *,
-    spec_sha256: str,
-    plan_sha256: str,
-    graph_sha256: str,
 ) -> Path:
     """Write receipt proving plan audit (spec-completion check) ran.
 
-    Hash-binding (F2): the three keyword-only arguments ``spec_sha256``,
-    ``plan_sha256``, and ``graph_sha256`` are REQUIRED. Each must be a
-    non-empty string (typically a sha256 hex digest of the corresponding
-    artifact at audit time). These hashes are embedded in the receipt
+    Hash-binding (SEC-004 + F2): the writer re-hashes ``spec.md``,
+    ``plan.md``, and ``execution-graph.json`` from the task directory at
+    write time. Those sha256 hex digests are embedded in the receipt
     payload so the PLAN_AUDIT exit gate can detect artifact drift via
     ``plan_audit_matches(task_dir)`` and refuse to advance when the audit
     was computed over a stale version of the artifacts.
 
+    Callers no longer supply the three hashes (breaking change vs. the
+    initial F2 signature). Closes the TOCTOU between a caller's
+    hash-read and the receipt write — the writer's own read is the
+    authoritative source. Missing artifact files land the literal
+    string ``missing`` in the corresponding payload slot, which always
+    fails ``plan_audit_matches`` downstream with a distinctive drift
+    reason.
+
     Also records token usage to ``token-usage.json`` when ``tokens_used``
     is positive.
     """
-    if not isinstance(spec_sha256, str) or not spec_sha256:
-        raise ValueError("spec_sha256 must be a non-empty string")
-    if not isinstance(plan_sha256, str) or not plan_sha256:
-        raise ValueError("plan_sha256 must be a non-empty string")
-    if not isinstance(graph_sha256, str) or not graph_sha256:
-        raise ValueError("graph_sha256 must be a non-empty string")
+    def _hash_or_missing(rel: str) -> str:
+        p = task_dir / rel
+        if not p.exists():
+            return "missing"
+        try:
+            return hash_file(p)
+        except OSError:
+            return "missing"
+
+    spec_sha256 = _hash_or_missing("spec.md")
+    plan_sha256 = _hash_or_missing("plan.md")
+    graph_sha256 = _hash_or_missing("execution-graph.json")
 
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, "plan-audit-check", model_used or "default", tokens_used)

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from lib_core import now_iso, append_execution_log
+from lib_core import now_iso, append_execution_log, _persistent_project_dir
 from lib_log import log_event
 
 
@@ -43,11 +44,24 @@ CALIBRATION_POLICY_FILES = [
 
 # Allowed reasons for receipt_postmortem_skipped. Enum-validated at write
 # time so callers cannot silently drift the skip taxonomy.
+#
+# A prior "quality-over-gate" skip reason was removed
+# (task-20260419-002 G1): it was being used to silently skip LLM
+# postmortems on tasks that had real non-blocking findings. The
+# remaining two reasons ONLY permit a skip when there is literally
+# nothing to learn (clean-task) or nothing the auditors found
+# (no-findings). Every other skip path must cite prior postmortem work
+# via the required `subsumed_by` argument on
+# `receipt_postmortem_skipped` (see G2).
 _POSTMORTEM_SKIP_REASONS = frozenset({
     "clean-task",
     "no-findings",
-    "quality-above-threshold",
 })
+
+# Regex for the task_id slug shape — matches SEC-001's regex from PR #126.
+# Used to validate entries in the `subsumed_by` list on
+# `receipt_postmortem_skipped`.
+_SUBSUMED_BY_TASK_ID_RE = re.compile(r"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
 # Sidecar directory names. These names are the filename schema for the
@@ -1085,24 +1099,104 @@ def receipt_postmortem_skipped(
     task_dir: Path,
     reason: str,
     retrospective_sha256: str,
+    subsumed_by: list[str],
 ) -> Path:
     """Write receipt proving postmortem was deliberately skipped.
 
-    `reason` is enum-validated against {"clean-task", "no-findings",
-    "quality-above-threshold"}.
+    `reason` is enum-validated against {"clean-task", "no-findings"}.
+    A prior quality-over-gate skip reason has been removed
+    (task-20260419-002 G1) — callers that previously used it must
+    either (a) pass `"clean-task"` when the task genuinely had zero
+    findings, or (b) stop skipping and let the LLM postmortem run.
+
+    `subsumed_by` is REQUIRED (task-20260419-002 G2): every skip must
+    cite specific prior postmortem task_ids whose derived rules cover
+    this task's finding categories. Empty list `[]` is valid ONLY when
+    `reason` is `"clean-task"` or `"no-findings"`.
+
+    Validation rules, applied IN ORDER; the first failure short-circuits:
+
+      (a) `subsumed_by` must be a list of strings (any non-list shape
+          raises `ValueError("subsumed_by must be a list of task_id
+          strings")`).
+      (b) Each entry MUST match the task_id regex
+          `^task-[A-Za-z0-9][A-Za-z0-9_.-]*$`; failures raise
+          `ValueError` whose message contains `subsumed_by[<i>]` and
+          `must match`.
+      (c) If `reason` is NOT in `{"clean-task", "no-findings"}`, the
+          list MUST be non-empty; empty raises `ValueError` whose
+          message contains `subsumed_by must be non-empty when reason=`.
+          After G1 this case is unreachable via the `reason` enum check
+          above, but the rule is retained for defensive coverage.
+      (d) For each entry in a non-empty list, the expected postmortem
+          file at `_persistent_project_dir(root) / "postmortems" /
+          f"{entry}.json"` (where `root = task_dir.parent.parent`) MUST
+          exist; missing files raise `ValueError` whose message contains
+          `missing postmortem file for` and the offending task_id.
+
+    `subsumed_by` is written verbatim into the receipt payload
+    alongside `reason` so downstream consumers can audit which prior
+    work the skip rests on.
     """
     if reason not in _POSTMORTEM_SKIP_REASONS:
         raise ValueError(
             f"invalid postmortem skip reason: {reason!r} "
-            f"(allowed: {sorted(_POSTMORTEM_SKIP_REASONS)})"
+            f"(allowed: {', '.join(sorted(_POSTMORTEM_SKIP_REASONS))})"
         )
     if not isinstance(retrospective_sha256, str) or not retrospective_sha256:
         raise ValueError("retrospective_sha256 must be a non-empty string")
+
+    # Rule (a): subsumed_by must be a list. `isinstance(..., list)`
+    # rejects tuples, sets, dicts, strings, None, ints, etc. — the
+    # message pins the expected shape so callers know the contract.
+    if not isinstance(subsumed_by, list):
+        raise ValueError("subsumed_by must be a list of task_id strings")
+
+    # Rule (b): every entry must match the task_id slug regex. We
+    # iterate with index so the failure message can cite the specific
+    # offending position. Non-string entries fail the regex match
+    # (re.match rejects non-str input via TypeError, which we preempt
+    # by coercing to the regex-based check — `re.match` called on
+    # non-str raises TypeError; convert that to ValueError with the
+    # same bracket+must-match shape so the test pattern still holds).
+    for i, entry in enumerate(subsumed_by):
+        if not isinstance(entry, str) or not _SUBSUMED_BY_TASK_ID_RE.match(entry):
+            raise ValueError(
+                f"subsumed_by[{i}] must match "
+                f"^task-[A-Za-z0-9][A-Za-z0-9_.-]*$ (got {entry!r})"
+            )
+
+    # Rule (c): non-empty required when reason is not one of the
+    # "nothing to cite" reasons. After G1 this branch is effectively
+    # unreachable because the reason enum above rejects any other
+    # value, but the defensive rule stays — if the enum grows back we
+    # want subsumed_by enforcement to follow immediately.
+    if reason not in {"clean-task", "no-findings"} and not subsumed_by:
+        raise ValueError(
+            f"subsumed_by must be non-empty when reason={reason!r}"
+        )
+
+    # Rule (d): every cited task_id must have a corresponding
+    # postmortem file on disk under the project-persistent postmortems
+    # directory. This is the "cite something real" rule — callers
+    # cannot hand-wave arbitrary task_ids. The path resolution mirrors
+    # `receipt_postmortem_generated`'s write path (see lib_core.py).
+    if subsumed_by:
+        root = task_dir.parent.parent
+        postmortems_dir = _persistent_project_dir(root) / "postmortems"
+        for entry in subsumed_by:
+            pm_path = postmortems_dir / f"{entry}.json"
+            if not pm_path.exists():
+                raise ValueError(
+                    f"missing postmortem file for {entry!r} at {pm_path}"
+                )
+
     return write_receipt(
         task_dir,
         "postmortem-skipped",
         reason=reason,
         retrospective_sha256=retrospective_sha256,
+        subsumed_by=list(subsumed_by),
     )
 
 

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -581,10 +581,30 @@ def compute_reward(task_dir: Path) -> dict:
     # (e.g. `human-approval-SPEC_REVIEW-002.json`). No fallback to
     # `execution-log.md` scanning — the log-line scanner was deprecated
     # because log lines are not a hash-bound audit record.
+    #
+    # SEC-005 hardening: plain `touch human-approval-SPEC_REVIEW-fake.json`
+    # (empty file, no content) no longer inflates the count. Each
+    # candidate must parse as a JSON object AND carry the expected
+    # `step == "human-approval-SPEC_REVIEW"` field (and non-empty
+    # `artifact_sha256`). Receipts written by `receipt_human_approval`
+    # satisfy this automatically; planted files do not.
     receipts_dir = task_dir / "receipts"
     spec_review_iterations = 0
     if receipts_dir.is_dir():
-        spec_review_iterations = len(list(receipts_dir.glob("human-approval-SPEC_REVIEW*.json")))
+        for candidate in receipts_dir.glob("human-approval-SPEC_REVIEW*.json"):
+            try:
+                payload = json.loads(candidate.read_text("utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            step = payload.get("step")
+            if not isinstance(step, str) or not step.startswith("human-approval-SPEC_REVIEW"):
+                continue
+            art_hash = payload.get("artifact_sha256")
+            if not isinstance(art_hash, str) or not art_hash:
+                continue
+            spec_review_iterations += 1
 
     # execution-log.md path is still needed below for DORA recovery-time
     # tracking and subagent-spawn counting (sections 4b and 6).

--- a/memory/postmortem.py
+++ b/memory/postmortem.py
@@ -342,23 +342,49 @@ def write_postmortem(root: Path, task_id: str) -> dict:
     quality_score = float(postmortem.get("quality_summary", {}).get("quality_score", 0) or 0)
     total_findings = int(postmortem.get("quality_summary", {}).get("total_findings", 0) or 0)
 
-    # SKIP branch: a task that produced no findings, no anomalies, no recurring
-    # patterns, AND scored at/above the quality threshold cannot teach us
-    # anything new. Emit the skipped receipt against the task dir and return
-    # without writing postmortem files.
+    # SKIP branch: a task that produced literally zero findings, zero anomalies,
+    # and zero recurring patterns cannot teach us anything new. G1 removed
+    # `quality-above-threshold` as a valid skip reason — tasks with findings
+    # but high quality score NOW run the LLM postmortem (exactly the
+    # "skip-postmortem, rationalize-later" pattern this task was created to
+    # stop). Only two skip reasons remain:
+    #   - clean-task: ≥2 auditors ran, all zero findings (counted via
+    #     audit-reports/*.json per spec criterion 5; NOT based on quality_score)
+    #   - no-findings: exactly 1 auditor ran, zero findings
+    # CQ-001 fix: discriminator is auditor count (per spec criterion 5), not
+    # quality_score. quality_score alone is not a sufficient signal — a task
+    # can score 0.9 with findings, or score 0.7 with none.
     skip_reason: str | None = None
-    if quality_score >= 0.8 and anomaly_count == 0 and pattern_count == 0 and total_findings == 0:
-        skip_reason = "clean-task"
-    elif total_findings == 0 and anomaly_count == 0 and pattern_count == 0:
-        skip_reason = "no-findings"
-    elif quality_score >= 0.8 and anomaly_count == 0 and pattern_count == 0:
-        skip_reason = "quality-above-threshold"
+    is_zero_findings = (
+        total_findings == 0
+        and anomaly_count == 0
+        and pattern_count == 0
+    )
+    if is_zero_findings:
+        audit_reports_dir = task_dir / "audit-reports"
+        auditor_count = (
+            len(list(audit_reports_dir.glob("*.json")))
+            if audit_reports_dir.is_dir()
+            else 0
+        )
+        if auditor_count >= 2:
+            skip_reason = "clean-task"
+        elif auditor_count == 1:
+            skip_reason = "no-findings"
+        # auditor_count == 0 → no audit ran; do NOT skip. Falling through
+        # lets the LLM postmortem run (or errors downstream if that's also
+        # unavailable — better signal than a silent claim of cleanliness).
+    # No elif for quality-above-threshold — removed by G1. If a task has
+    # anomalies, recurring patterns, or findings (even non-blocking), the
+    # LLM postmortem MUST run.
 
     if skip_reason is not None and retro_path.exists() and task_dir.is_dir():
         try:
             retro_sha = hash_file(retro_path)
-            receipt_postmortem_skipped(task_dir, skip_reason, retro_sha)
-        except (FileNotFoundError, OSError, ValueError) as exc:
+            # G2: subsumed_by=[] is valid for clean-task / no-findings
+            # (there's nothing to subsume — nothing was found).
+            receipt_postmortem_skipped(task_dir, skip_reason, retro_sha, subsumed_by=[])
+        except (FileNotFoundError, OSError, ValueError, TypeError) as exc:
             log_event(root, "postmortem_skip_receipt_failed", task=task_id, error=str(exc))
         return {
             "task_id": task_id,

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -607,8 +607,11 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
         if retro_path.exists() and task_dir.is_dir():
             try:
                 retro_sha = hash_file(retro_path)
-                receipt_postmortem_skipped(task_dir, "no-findings", retro_sha)
-            except (FileNotFoundError, OSError, ValueError) as exc:
+                # G2: subsumed_by=[] is valid for no-findings reason.
+                receipt_postmortem_skipped(
+                    task_dir, "no-findings", retro_sha, subsumed_by=[]
+                )
+            except (FileNotFoundError, OSError, ValueError, TypeError) as exc:
                 log_event(root, "postmortem_analysis_skip_receipt_failed", task=task_id, error=str(exc))
         return {"task_id": task_id, "rules_added": 0, "analysis_written": False, "skipped": True, "skip_reason": "no-findings"}
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -365,7 +365,7 @@ PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/postmortem
 `memory/postmortem.py:generate_postmortem` (called by `postmortem.py generate`) now writes its own receipt internally as part of the same call. You do NOT need to write a receipt from this skill:
 
 - On successful generation it hashes the written `{task-id}.json` and `{task-id}.md` files and writes `receipt_postmortem_generated(task_dir, json_sha256, md_sha256, anomaly_count, pattern_count)` to `.dynos/task-{id}/receipts/postmortem-generated.json`.
-- When the deterministic engine determines there is nothing to learn (clean task, no findings, or quality above threshold) it short-circuits the postmortem write and instead emits `receipt_postmortem_skipped(task_dir, reason, retrospective_sha256)` with `reason` from the enum `{"clean-task", "no-findings", "quality-above-threshold"}`. The `task-retrospective.json` is hashed at receipt-emission time.
+- When the deterministic engine determines there is literally nothing to learn, it short-circuits the postmortem write and instead emits `receipt_postmortem_skipped(task_dir, reason, retrospective_sha256, subsumed_by)` with `reason` from the enum `{"clean-task", "no-findings"}` and `subsumed_by` as a required list argument. The decision is deterministic: (a) `reason="clean-task"`, `subsumed_by=[]` when ≥2 auditors ran AND every auditor reported `findings: []`; (b) `reason="no-findings"`, `subsumed_by=[]` when exactly 1 auditor ran AND it reported `findings: []`; (c) in every other case — any auditor reporting ≥1 finding — the engine does NOT skip; it runs the LLM postmortem and writes `receipt_postmortem_generated` instead. If ANY auditor reports ≥1 finding (blocking or not), the LLM postmortem runs — no "quality-above-threshold" bypass. The `task-retrospective.json` is hashed at receipt-emission time.
 - A receipt-write failure is logged as `postmortem_receipt_failed` / `postmortem_skip_receipt_failed` and does NOT corrupt the postmortem files themselves; the script returns its normal result so the audit pipeline keeps moving.
 
 This writes `postmortems/{task-id}.json` and `postmortems/{task-id}.md` to the persistent project directory. Append to log:
@@ -391,7 +391,7 @@ This writes `postmortem-analysis.json` to the task dir and merges new prevention
 
 `memory/postmortem_analysis.py:apply_analysis` (called by `postmortem_analysis.py apply`) emits its own receipt internally — do NOT write one from this skill:
 
-- When the agent JSON is empty or non-dict (the orchestrator passed nothing to apply), it emits `receipt_postmortem_skipped(task_dir, "no-findings", retrospective_sha256)`.
+- When the agent JSON is empty or non-dict (the orchestrator passed nothing to apply), it emits `receipt_postmortem_skipped(task_dir, "no-findings", retrospective_sha256, subsumed_by=[])`.
 - When the sanitized analysis yields zero usable rules, it emits `receipt_postmortem_analysis(task_dir, analysis_sha256, rules_added=0, rules_sha256_after=...)` (using the current on-disk hash of `prevention-rules.json`, or 64 zeros when the file does not exist).
 - When the merge appends rules, it emits `receipt_postmortem_analysis(task_dir, analysis_sha256, rules_added, rules_sha256_after)` AFTER the fcntl lock is released so the recorded hash captures the on-disk state visible to other readers.
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -72,21 +72,14 @@ receipt_plan_validated(
 )
 
 # After spec-completion auditor (plan audit; only invoked for high/critical risk):
-# spec_sha256 / plan_sha256 / graph_sha256 are REQUIRED keyword-only args —
-# compute them at audit time via:
-#   from lib_receipts import hash_file
-#   spec_sha256 = hash_file(task_dir / "spec.md")
-#   plan_sha256 = hash_file(task_dir / "plan.md")
-#   graph_sha256 = hash_file(task_dir / "execution-graph.json")
+# The writer re-hashes spec.md / plan.md / execution-graph.json from disk
+# at write time (SEC-004: no caller-supplied hashes, no TOCTOU window).
 # The PLAN_AUDIT exit gate re-hashes these artifacts and refuses to advance
 # when any has drifted since the audit was recorded.
 receipt_plan_audit(
     task_dir,
     tokens_used=TOTAL_TOKENS,
     finding_count=N,
-    spec_sha256=SPEC_SHA256,
-    plan_sha256=PLAN_SHA256,
-    graph_sha256=GRAPH_SHA256,
 )
 
 ```

--- a/tests/test_append_deferred_findings.py
+++ b/tests/test_append_deferred_findings.py
@@ -1,0 +1,359 @@
+"""Tests for task-20260419-002 G4.a: ``append_deferred_findings``.
+
+Covers acceptance criteria 9, 10, and 16 from the task spec:
+
+  - cold-start creation of ``<root>/.dynos/deferred-findings.json``
+  - happy-path append with all 7 augmented keys
+    (id, category, files, task_id, first_seen_at,
+     first_seen_at_task_count, acknowledged_until_task_count)
+  - multi-entry single-call append
+  - input validation failure modes:
+      (a) top-level findings must be a list
+      (b) each entry must be a dict
+      (c) each entry must carry `id`, `category`, `files`
+      (d) `id` / `category` must be non-empty strings
+      (e) `files` must be a non-empty list
+  - no-partial-write guarantee: first invalid entry raises, file on
+    disk is unchanged from its pre-call state
+
+These tests write directly against the function and inspect the
+registry file on disk — no mocks of internal logic.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import append_deferred_findings  # noqa: E402
+
+
+REQUIRED_ENTRY_KEYS = frozenset({
+    "id",
+    "category",
+    "files",
+    "task_id",
+    "first_seen_at",
+    "first_seen_at_task_count",
+    "acknowledged_until_task_count",
+})
+
+
+def _make_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a clean project root under ``tmp_path/project`` with an
+    empty ``.dynos/`` already created. Pins ``DYNOS_HOME`` so that
+    ``_persistent_project_dir`` resolves inside the test sandbox."""
+    monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
+    root = tmp_path / "project"
+    (root / ".dynos").mkdir(parents=True)
+    return root
+
+
+def _registry_path(root: Path) -> Path:
+    return root / ".dynos" / "deferred-findings.json"
+
+
+def _valid_finding(
+    *,
+    id: str = "SEC-003",
+    category: str = "security",
+    files: list[str] | None = None,
+) -> dict:
+    return {
+        "id": id,
+        "category": category,
+        "files": list(files) if files is not None else ["hooks/lib_core.py"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cold start
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_creates_empty_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the registry file does not exist, the first append must
+    create it. After calling with an empty findings list, the file
+    exists and parses as ``{"findings": []}``."""
+    root = _make_root(tmp_path, monkeypatch)
+    reg = _registry_path(root)
+    assert not reg.exists(), "precondition: registry must not exist yet"
+
+    append_deferred_findings(root, "task-20260419-001", [])
+
+    assert reg.exists(), "registry file was not created on cold-start append"
+    data = json.loads(reg.read_text())
+    assert data == {"findings": []}
+
+
+# ---------------------------------------------------------------------------
+# Happy-path appends (criterion 9 — all 7 augmented keys)
+# ---------------------------------------------------------------------------
+
+
+def test_appends_single_finding_with_augmented_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A single valid finding is appended with ALL seven required
+    keys (id/category/files from the input + task_id, first_seen_at,
+    first_seen_at_task_count, acknowledged_until_task_count from the
+    writer).
+
+    Also verifies that ``acknowledged_until_task_count`` defaults to 3
+    (per criterion 9) and that ``first_seen_at_task_count`` is 0 on a
+    fresh project (no retrospectives yet).
+    """
+    root = _make_root(tmp_path, monkeypatch)
+    append_deferred_findings(
+        root,
+        "task-20260419-001",
+        [_valid_finding(id="SEC-003", category="security",
+                        files=["hooks/lib_core.py"])],
+    )
+    data = json.loads(_registry_path(root).read_text())
+    assert isinstance(data["findings"], list)
+    assert len(data["findings"]) == 1
+
+    entry = data["findings"][0]
+    # All 7 required keys present.
+    missing = REQUIRED_ENTRY_KEYS - set(entry.keys())
+    assert not missing, f"missing required keys in entry: {missing}"
+
+    # Input fields preserved verbatim.
+    assert entry["id"] == "SEC-003"
+    assert entry["category"] == "security"
+    assert entry["files"] == ["hooks/lib_core.py"]
+    # Augmented fields.
+    assert entry["task_id"] == "task-20260419-001"
+    assert entry["acknowledged_until_task_count"] == 3
+    # No retrospectives yet → baseline is 0.
+    assert entry["first_seen_at_task_count"] == 0
+    # ISO-8601 timestamp — must be a non-empty string with a Z suffix
+    # (now_iso's contract).
+    assert isinstance(entry["first_seen_at"], str)
+    assert entry["first_seen_at"].endswith("Z")
+    assert "T" in entry["first_seen_at"]
+
+
+def test_appends_multiple_findings_in_one_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Two findings in one call → two registry entries. Both must
+    carry the full augmented shape; both must share the same
+    ``task_id`` AND the same ``first_seen_at`` snapshot (single
+    append call = single timestamp baseline)."""
+    root = _make_root(tmp_path, monkeypatch)
+    findings = [
+        _valid_finding(id="SEC-003", category="security",
+                       files=["hooks/lib_core.py"]),
+        _valid_finding(id="PERF-002", category="performance",
+                       files=["hooks/lib_receipts.py",
+                              "hooks/rules_engine.py"]),
+    ]
+    append_deferred_findings(root, "task-20260419-001", findings)
+
+    data = json.loads(_registry_path(root).read_text())
+    assert len(data["findings"]) == 2
+
+    # Both entries share the same task_id + timestamp snapshot.
+    ts = {e["first_seen_at"] for e in data["findings"]}
+    assert len(ts) == 1, "both entries from one call must share timestamp"
+    tids = {e["task_id"] for e in data["findings"]}
+    assert tids == {"task-20260419-001"}
+
+    # Input-level fields preserved per-entry.
+    ids = [e["id"] for e in data["findings"]]
+    assert ids == ["SEC-003", "PERF-002"]
+    # Multi-file entry preserves full list.
+    perf = next(e for e in data["findings"] if e["id"] == "PERF-002")
+    assert perf["files"] == ["hooks/lib_receipts.py", "hooks/rules_engine.py"]
+
+
+def test_second_append_preserves_existing_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Appending again on an existing non-empty registry must not
+    drop or mutate prior entries — the helper is append-only."""
+    root = _make_root(tmp_path, monkeypatch)
+    append_deferred_findings(
+        root, "task-20260419-001",
+        [_valid_finding(id="SEC-003", files=["hooks/lib_core.py"])],
+    )
+    append_deferred_findings(
+        root, "task-20260419-002",
+        [_valid_finding(id="SEC-004", files=["hooks/lib_receipts.py"])],
+    )
+    data = json.loads(_registry_path(root).read_text())
+    ids = [e["id"] for e in data["findings"]]
+    assert ids == ["SEC-003", "SEC-004"], (
+        f"expected both entries preserved in append order; got {ids}"
+    )
+    tids = [e["task_id"] for e in data["findings"]]
+    assert tids == ["task-20260419-001", "task-20260419-002"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation (criterion 10)
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_list_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (a): findings must be a list. A dict / str / None / tuple
+    all fail with the same literal message."""
+    root = _make_root(tmp_path, monkeypatch)
+    for bad in ({}, "SEC-003", None, (_valid_finding(),), 42):
+        with pytest.raises(ValueError) as excinfo:
+            append_deferred_findings(
+                root, "task-20260419-001", bad,  # type: ignore[arg-type]
+            )
+        assert "findings must be a list" in str(excinfo.value)
+
+
+def test_rejects_non_dict_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (b): each entry must be a dict. A string / None / list all
+    fail; the message names the offending index."""
+    root = _make_root(tmp_path, monkeypatch)
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(
+            root, "task-20260419-001",
+            [_valid_finding(), "not a dict"],  # type: ignore[list-item]
+        )
+    assert "findings[1] must be a dict" in str(excinfo.value)
+
+
+def test_rejects_entry_missing_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (c): missing ``id`` key raises with the specific key named
+    in the error message."""
+    root = _make_root(tmp_path, monkeypatch)
+    bad_entry = {"category": "security", "files": ["hooks/lib_core.py"]}
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(root, "task-20260419-001", [bad_entry])
+    msg = str(excinfo.value)
+    assert "findings[0]" in msg
+    assert "'id'" in msg or "missing required key: id" in msg, (
+        f"expected the key 'id' to be named in the message; got: {msg}"
+    )
+
+
+def test_rejects_entry_missing_category(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (c): missing ``category`` key raises with the specific
+    key named in the error message."""
+    root = _make_root(tmp_path, monkeypatch)
+    bad_entry = {"id": "SEC-003", "files": ["hooks/lib_core.py"]}
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(root, "task-20260419-001", [bad_entry])
+    msg = str(excinfo.value)
+    assert "findings[0]" in msg
+    assert "'category'" in msg or "missing required key: category" in msg, (
+        f"expected 'category' to be named in the message; got: {msg}"
+    )
+
+
+def test_rejects_entry_with_empty_files_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (e): ``files`` must be a non-empty list. Empty list
+    triggers a validator error naming the field."""
+    root = _make_root(tmp_path, monkeypatch)
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(
+            root, "task-20260419-001",
+            [{"id": "SEC-003", "category": "security", "files": []}],
+        )
+    msg = str(excinfo.value)
+    assert "findings[0]" in msg
+    assert "files" in msg
+
+
+def test_rejects_entry_with_empty_id_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Non-empty str rule on ``id``: empty string is rejected."""
+    root = _make_root(tmp_path, monkeypatch)
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(
+            root, "task-20260419-001",
+            [{"id": "", "category": "security", "files": ["a.py"]}],
+        )
+    msg = str(excinfo.value)
+    assert "findings[0]" in msg
+    assert "id" in msg
+
+
+# ---------------------------------------------------------------------------
+# No-partial-write guarantee (criterion 10, final clause)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_entry_does_not_partial_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A mixed batch with one valid entry followed by one invalid
+    entry must raise AND leave the on-disk registry byte-identical to
+    its pre-call state. This proves the writer validates the whole
+    batch BEFORE touching disk.
+
+    We pre-seed the registry with one prior entry so we have a
+    non-trivial byte stream to compare against — a naïve implementation
+    that appends the valid entry before discovering the invalid second
+    entry would change those bytes.
+    """
+    root = _make_root(tmp_path, monkeypatch)
+    append_deferred_findings(
+        root, "task-20260419-000",
+        [_valid_finding(id="SEC-001", files=["hooks/lib_core.py"])],
+    )
+    reg = _registry_path(root)
+    snapshot_bytes = reg.read_bytes()
+    snapshot_mtime = reg.stat().st_mtime_ns
+
+    findings = [
+        _valid_finding(id="SEC-003", files=["hooks/lib_receipts.py"]),
+        {"id": "BAD-002", "category": "security"},  # missing `files`
+    ]
+    with pytest.raises(ValueError):
+        append_deferred_findings(root, "task-20260419-001", findings)
+
+    # Registry file contents unchanged, byte-for-byte.
+    assert reg.read_bytes() == snapshot_bytes, (
+        "registry was modified on validator failure — no-partial-write "
+        "guarantee broken"
+    )
+    # mtime likely unchanged too (atomic write would rename a temp file;
+    # if nothing touched disk, mtime stays frozen). We assert byte
+    # equality above as the hard contract; mtime is a secondary tell.
+    assert reg.stat().st_mtime_ns == snapshot_mtime
+
+
+def test_malformed_existing_registry_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A pre-existing registry file with corrupt JSON must raise (not
+    silently overwrite). Criterion 9/10 explicitly requires that parse
+    failure does not drop prior entries."""
+    root = _make_root(tmp_path, monkeypatch)
+    reg = _registry_path(root)
+    reg.write_text("{this is not json")
+    with pytest.raises(ValueError) as excinfo:
+        append_deferred_findings(
+            root, "task-20260419-001",
+            [_valid_finding()],
+        )
+    assert "cannot parse" in str(excinfo.value).lower()
+    # And the corrupt file must be untouched (operator manually repairs).
+    assert reg.read_text() == "{this is not json"

--- a/tests/test_check_deferred_findings.py
+++ b/tests/test_check_deferred_findings.py
@@ -1,0 +1,329 @@
+"""Tests for task-20260419-002 G4.b: ``check_deferred_findings``
+(importable helper + CLI).
+
+Covers acceptance criteria 11 and 16 from the task spec:
+
+  - missing registry → empty result / exit 0 (cold start, fail-open)
+  - no intersection between entry.files and changed_files → empty /
+    exit 0
+  - intersection but still within TTL → empty / exit 0
+  - intersection AND TTL-expired → entry returned (with ``elapsed``
+    field) / exit 1, with stdout printing one line per expired entry
+  - multiple expired findings → all reported
+  - CLI wrapper: exercises the argparse entry point via subprocess to
+    verify stdout format and exit code independently of in-process
+    test state
+
+These tests write the registry file directly (not via
+``append_deferred_findings``) so they control the TTL baseline
+exactly. For the retrospectives-count side they write files directly
+under ``DYNOS_HOME/projects/<slug>/retrospectives/*.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+from check_deferred_findings import check_deferred_findings  # noqa: E402
+from lib_core import _persistent_project_dir  # noqa: E402
+
+
+def _make_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path]:
+    """Create a project root at ``tmp_path/project`` AND pin a test
+    DYNOS_HOME. Returns (root, persistent_dir) — the persistent dir is
+    NOT yet materialized so the test can control retrospective count."""
+    dynos_home = tmp_path / "dynos-home"
+    monkeypatch.setenv("DYNOS_HOME", str(dynos_home))
+    root = tmp_path / "project"
+    (root / ".dynos").mkdir(parents=True)
+    persistent = _persistent_project_dir(root)
+    return root, persistent
+
+
+def _write_registry(root: Path, entries: list[dict]) -> Path:
+    """Write ``.dynos/deferred-findings.json`` verbatim."""
+    reg = root / ".dynos" / "deferred-findings.json"
+    reg.write_text(json.dumps({"findings": entries}))
+    return reg
+
+
+def _set_retro_count(persistent: Path, n: int) -> None:
+    """Materialize ``n`` retrospective JSON files so the current-count
+    computation returns ``n``. Empty files are fine; the check just
+    counts glob matches."""
+    retro_dir = persistent / "retrospectives"
+    retro_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (retro_dir / f"task-retro-{i:04d}.json").write_text("{}")
+
+
+def _entry(
+    *,
+    id: str = "SEC-003",
+    category: str = "security",
+    task_id: str = "task-20260319-001",
+    files: list[str] | None = None,
+    first_seen: int = 0,
+    ttl: int = 3,
+) -> dict:
+    return {
+        "id": id,
+        "category": category,
+        "task_id": task_id,
+        "files": list(files) if files is not None else ["hooks/lib_core.py"],
+        "first_seen_at": "2026-03-19T00:00:00Z",
+        "first_seen_at_task_count": first_seen,
+        "acknowledged_until_task_count": ttl,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) missing registry → empty result / exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_missing_registry_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Cold start: no registry file anywhere → helper returns ``[]``.
+    The caller (CLI or DONE gate) sees an empty list = clean pass."""
+    root, _ = _make_root(tmp_path, monkeypatch)
+    expired = check_deferred_findings(root, ["hooks/lib_core.py"])
+    assert expired == []
+
+
+# ---------------------------------------------------------------------------
+# (b) no intersection → empty / exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_no_intersection_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A deferred entry exists but its ``files`` do not overlap the
+    ``changed_files`` argument. The TTL is already expired — but
+    without intersection, the entry is not reported."""
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 10)  # TTL would have fired if intersected
+    _write_registry(root, [
+        _entry(files=["hooks/lib_core.py"], first_seen=0, ttl=3),
+    ])
+    expired = check_deferred_findings(root, ["some/other/file.py"])
+    assert expired == []
+
+
+# ---------------------------------------------------------------------------
+# (c) intersection within TTL → empty / exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_intersection_within_ttl_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Entry.files intersects changed_files, but elapsed < ttl so the
+    TTL has not fired yet. Nothing to report."""
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 2)  # elapsed = 2 - 0 = 2 < ttl=3
+    _write_registry(root, [
+        _entry(files=["hooks/lib_core.py"], first_seen=0, ttl=3),
+    ])
+    expired = check_deferred_findings(root, ["hooks/lib_core.py"])
+    assert expired == []
+
+
+# ---------------------------------------------------------------------------
+# (d) intersection AND TTL-expired → entry returned / exit 1 with citation
+# ---------------------------------------------------------------------------
+
+
+def test_intersection_ttl_expired_exits_one_with_citation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The canonical failure: a deferred entry whose files overlap
+    the touched changed_files, AND elapsed >= ttl. The helper must
+    return the entry; the CLI would print one line + exit 1."""
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 3)  # elapsed = 3 - 0 = 3 >= ttl=3
+    _write_registry(root, [
+        _entry(id="SEC-003", category="security",
+               task_id="task-20260319-001",
+               files=["hooks/lib_core.py"],
+               first_seen=0, ttl=3),
+    ])
+    expired = check_deferred_findings(root, ["hooks/lib_core.py"])
+    assert len(expired) == 1
+    entry = expired[0]
+    # All source fields preserved.
+    assert entry["id"] == "SEC-003"
+    assert entry["category"] == "security"
+    assert entry["task_id"] == "task-20260319-001"
+    assert entry["files"] == ["hooks/lib_core.py"]
+    # Augmented `elapsed` field is set to the overshoot.
+    assert entry["elapsed"] == 3
+
+
+def test_boundary_elapsed_equals_ttl_reports_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Boundary: ``elapsed >= ttl`` (spec uses ``>=``, not ``>``).
+    When elapsed==ttl exactly, the entry is TTL-expired."""
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 5)  # elapsed = 5 - 2 = 3 == ttl=3
+    _write_registry(root, [
+        _entry(files=["hooks/lib_core.py"], first_seen=2, ttl=3),
+    ])
+    expired = check_deferred_findings(root, ["hooks/lib_core.py"])
+    assert len(expired) == 1
+    assert expired[0]["elapsed"] == 3
+
+
+def test_multiple_expired_findings_all_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Three entries; two intersect and are expired; one intersects
+    but is within TTL; one does not intersect at all. The result
+    must contain exactly the two expired entries, in registry
+    order, with correct ids."""
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 5)
+    _write_registry(root, [
+        _entry(id="SEC-003", files=["hooks/lib_core.py"],
+               first_seen=0, ttl=3),    # elapsed=5 → expired
+        _entry(id="SEC-004", files=["hooks/lib_receipts.py"],
+               first_seen=4, ttl=3),    # elapsed=1 < 3 → within TTL
+        _entry(id="PERF-002", files=["hooks/rules_engine.py"],
+               first_seen=1, ttl=2),    # elapsed=4 → expired
+        _entry(id="DOC-001", files=["docs/readme.md"],
+               first_seen=0, ttl=3),    # does NOT intersect
+    ])
+    changed = [
+        "hooks/lib_core.py",
+        "hooks/lib_receipts.py",
+        "hooks/rules_engine.py",
+    ]
+    expired = check_deferred_findings(root, changed)
+    ids = [e["id"] for e in expired]
+    assert ids == ["SEC-003", "PERF-002"], (
+        f"expected the two expired + intersecting entries; got {ids}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI wrapper — subprocess test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_prints_one_line_per_expired_and_exits_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Run the CLI as a real subprocess: it must exit 1, print one
+    line per expired entry in the exact format
+    ``DEFERRED FINDING EXPIRED: id=... category=... task_id=... files=...``,
+    and print nothing else.
+
+    We pass DYNOS_HOME through the env dict so the subprocess sees
+    the same persistent-dir slug derivation as the in-process
+    helper test above. The CLI expects ``--changed-files`` as a
+    nargs="*" space-separated list after ``--root``.
+    """
+    root, persistent = _make_root(tmp_path, monkeypatch)
+    _set_retro_count(persistent, 5)
+    _write_registry(root, [
+        _entry(id="SEC-003", category="security",
+               task_id="task-20260319-001",
+               files=["hooks/lib_core.py"],
+               first_seen=0, ttl=3),
+        _entry(id="PERF-002", category="performance",
+               task_id="task-20260319-007",
+               files=["hooks/rules_engine.py"],
+               first_seen=1, ttl=2),
+    ])
+
+    cli = REPO_ROOT / "hooks" / "check_deferred_findings.py"
+    env = {
+        **os.environ,
+        "DYNOS_HOME": str(tmp_path / "dynos-home"),
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(cli),
+            "--root", str(root),
+            "--changed-files",
+            "hooks/lib_core.py",
+            "hooks/rules_engine.py",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1, (
+        f"expected exit 1 on TTL-expired; got {proc.returncode}\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    )
+    # Exactly two output lines — one per expired entry.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 2, (
+        f"expected 2 expired lines; got {len(lines)}:\n{proc.stdout}"
+    )
+    # Every line must carry the exact header + id/category/task_id/files
+    # in the documented order.
+    assert all(
+        ln.startswith("DEFERRED FINDING EXPIRED:") for ln in lines
+    ), f"bad header line format: {lines}"
+    sec = next(ln for ln in lines if "id=SEC-003" in ln)
+    assert "category=security" in sec
+    assert "task_id=task-20260319-001" in sec
+    # ``files`` is rendered as a JSON array so downstream parsers get
+    # an unambiguous structure.
+    assert 'files=["hooks/lib_core.py"]' in sec
+
+    perf = next(ln for ln in lines if "id=PERF-002" in ln)
+    assert "category=performance" in perf
+    assert "task_id=task-20260319-007" in perf
+    assert 'files=["hooks/rules_engine.py"]' in perf
+
+
+def test_cli_missing_registry_exits_zero_silently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """CLI cold-start: no registry → exit 0, no stdout. The fail-open
+    behavior means missing signal never wedges DONE in CI."""
+    root, _ = _make_root(tmp_path, monkeypatch)
+    cli = REPO_ROOT / "hooks" / "check_deferred_findings.py"
+    env = {
+        **os.environ,
+        "DYNOS_HOME": str(tmp_path / "dynos-home"),
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(cli),
+            "--root", str(root),
+            "--changed-files", "hooks/lib_core.py",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"expected exit 0 on cold start; got {proc.returncode}\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    )
+    assert proc.stdout == "", (
+        f"expected empty stdout on cold start; got: {proc.stdout!r}"
+    )

--- a/tests/test_collect_retrospectives_sec003_and_cache.py
+++ b/tests/test_collect_retrospectives_sec003_and_cache.py
@@ -1,0 +1,232 @@
+"""Tests for SEC-003 (flush-event hash cross-check) and PERF-003
+(per-process mtime-based memo) on `collect_retrospectives`.
+
+SEC-003: a persistent retrospective at
+`~/.dynos/projects/{slug}/retrospectives/{task_id}.json` whose content
+sha256 does not match the sha256 recorded in `retrospective_flushed`
+events in `events.jsonl` is SKIPPED by `collect_retrospectives`.
+Rationale: the persistent dir is outside the worktree trust boundary;
+post-flush tampering is invisible without the cross-check. Events are
+append-only and co-located with the flush, so the sha256 recorded there
+is the anchor.
+
+PERF-003: `collect_retrospectives` memoizes by a stat fingerprint of
+(worktree .dynos/, persistent retros dir, events.jsonl). Any mutation
+of any input path invalidates the cache on the next call. Same-state
+calls share one read pass.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import (  # noqa: E402
+    _COLLECT_RETRO_CACHE,
+    _flushed_sha_by_task_id,
+    _persistent_project_dir,
+    _retros_stat_fingerprint,
+    collect_retrospectives,
+)
+from lib_receipts import hash_file  # noqa: E402
+
+
+def _project(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    (root / ".dynos").mkdir(parents=True)
+    return root
+
+
+def _emit_flush_event(root: Path, task_id: str, sha: str) -> None:
+    line = json.dumps({
+        "ts": "2026-04-19T00:00:00Z",
+        "event": "retrospective_flushed",
+        "task_id": task_id,
+        "source": "x",
+        "destination": "y",
+        "sha256": sha,
+    })
+    ev = root / ".dynos" / "events.jsonl"
+    with ev.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+# ---------------------------------------------------------------------------
+# SEC-003: flush-event hash cross-check
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_retro_with_matching_flush_event_accepted(tmp_path: Path) -> None:
+    """Write a persistent retro AND a matching `retrospective_flushed`
+    event with its sha256. collect_retrospectives returns the retro."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    retro = {"task_id": "task-OK", "quality_score": 0.9}
+    path = pd / "task-OK.json"
+    path.write_text(json.dumps(retro))
+    _emit_flush_event(root, "task-OK", hash_file(path))
+
+    _COLLECT_RETRO_CACHE.clear()
+    result = collect_retrospectives(root)
+    assert any(r.get("task_id") == "task-OK" for r in result)
+
+
+def test_persistent_retro_with_mismatched_flush_event_skipped(tmp_path: Path) -> None:
+    """Write a persistent retro AND a `retrospective_flushed` event with
+    a DIFFERENT sha256 (simulates someone tampering with the persistent
+    file after flush). collect_retrospectives must skip the tampered
+    retro — the worktree copy (if present) stands alone."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    retro = {"task_id": "task-BAD", "quality_score": 0.9}
+    path = pd / "task-BAD.json"
+    path.write_text(json.dumps(retro))
+    # Wrong sha — tamper detected.
+    _emit_flush_event(root, "task-BAD", "0" * 64)
+
+    _COLLECT_RETRO_CACHE.clear()
+    result = collect_retrospectives(root)
+    assert not any(r.get("task_id") == "task-BAD" for r in result), (
+        f"tampered persistent retro must be skipped; got {result}"
+    )
+
+
+def test_persistent_retro_without_flush_event_trusted(tmp_path: Path) -> None:
+    """Cold-start / pre-SEC-003 retros have no matching flush event in
+    events.jsonl. Those are TRUSTED (not skipped) so existing
+    retrospectives pre-dating this code continue to feed the EMA."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    retro = {"task_id": "task-COLD", "quality_score": 0.9}
+    (pd / "task-COLD.json").write_text(json.dumps(retro))
+    # events.jsonl does not exist — no flush record for task-COLD.
+
+    _COLLECT_RETRO_CACHE.clear()
+    result = collect_retrospectives(root)
+    assert any(r.get("task_id") == "task-COLD" for r in result)
+
+
+def test_tampered_persistent_falls_back_to_worktree(tmp_path: Path) -> None:
+    """If the persistent copy is tampered AND a worktree copy for the
+    same task_id exists, the worktree copy should be returned (not
+    skipped along with the persistent)."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    # Worktree copy — legitimate.
+    wt_task_dir = root / ".dynos" / "task-MIX"
+    wt_task_dir.mkdir(parents=True)
+    wt_retro = {"task_id": "task-MIX", "quality_score": 0.88, "source_marker": "worktree"}
+    (wt_task_dir / "task-retrospective.json").write_text(json.dumps(wt_retro))
+    # Persistent copy — tampered (claims wrong hash).
+    ptd = pd / "task-MIX.json"
+    ptd.write_text(json.dumps({"task_id": "task-MIX", "quality_score": 0.1, "source_marker": "persistent_tampered"}))
+    _emit_flush_event(root, "task-MIX", "0" * 64)
+
+    _COLLECT_RETRO_CACHE.clear()
+    result = collect_retrospectives(root)
+    mix = [r for r in result if r.get("task_id") == "task-MIX"]
+    assert len(mix) == 1, f"expected exactly one task-MIX row, got {mix}"
+    assert mix[0].get("source_marker") == "worktree", (
+        f"tampered persistent should be skipped; worktree should stand: {mix[0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PERF-003: per-process memo
+# ---------------------------------------------------------------------------
+
+
+def test_second_call_returns_cached_result(tmp_path: Path) -> None:
+    """Two calls with no file changes return lists with identical
+    contents (content equality) AND the fingerprint is computed from the
+    filesystem — so a no-op second call is cheap."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    retro = {"task_id": "task-CACHE", "quality_score": 0.9}
+    path = pd / "task-CACHE.json"
+    path.write_text(json.dumps(retro))
+    _emit_flush_event(root, "task-CACHE", hash_file(path))
+
+    _COLLECT_RETRO_CACHE.clear()
+    r1 = collect_retrospectives(root)
+    # Without touching anything, second call should use cache.
+    r2 = collect_retrospectives(root)
+    assert r1 == r2
+    assert root in _COLLECT_RETRO_CACHE
+
+
+def test_cache_invalidates_on_new_persistent_retro(tmp_path: Path) -> None:
+    """Adding a new persistent retro changes the stat fingerprint and
+    invalidates the cache. The second call sees the new row."""
+    root = _project(tmp_path)
+    pd = _persistent_project_dir(root) / "retrospectives"
+    pd.mkdir(parents=True)
+    p1 = pd / "task-A.json"
+    p1.write_text(json.dumps({"task_id": "task-A", "quality_score": 0.9}))
+    _emit_flush_event(root, "task-A", hash_file(p1))
+
+    _COLLECT_RETRO_CACHE.clear()
+    r1 = collect_retrospectives(root)
+    assert {r.get("task_id") for r in r1} == {"task-A"}
+
+    # Add a new retro + matching event.
+    p2 = pd / "task-B.json"
+    p2.write_text(json.dumps({"task_id": "task-B", "quality_score": 0.9}))
+    _emit_flush_event(root, "task-B", hash_file(p2))
+
+    r2 = collect_retrospectives(root)
+    assert {r.get("task_id") for r in r2} == {"task-A", "task-B"}
+
+
+def test_cache_invalidates_on_worktree_retro_mutation(tmp_path: Path) -> None:
+    """Mutating a worktree retro file must invalidate the cache even if
+    no new files are added."""
+    root = _project(tmp_path)
+    wt = root / ".dynos" / "task-MUT"
+    wt.mkdir(parents=True)
+    retro_path = wt / "task-retrospective.json"
+    retro_path.write_text(json.dumps({"task_id": "task-MUT", "quality_score": 0.5}))
+
+    _COLLECT_RETRO_CACHE.clear()
+    r1 = collect_retrospectives(root)
+    assert r1 and r1[0].get("quality_score") == 0.5
+
+    # Mutate in place. _retros_stat_fingerprint picks up mtime/size.
+    import time
+    time.sleep(0.01)
+    retro_path.write_text(json.dumps({"task_id": "task-MUT", "quality_score": 0.9}))
+
+    r2 = collect_retrospectives(root)
+    assert r2 and r2[0].get("quality_score") == 0.9, (
+        f"cache did not invalidate on mutation: {r2}"
+    )
+
+
+def test_fingerprint_tuple_structure(tmp_path: Path) -> None:
+    """Regression: the fingerprint must capture worktree, persistent,
+    and events — three distinct inputs. An attacker-edited events.jsonl
+    must change the fingerprint."""
+    root = _project(tmp_path)
+    fp1 = _retros_stat_fingerprint(root)
+
+    _emit_flush_event(root, "task-X", "a" * 64)
+    fp2 = _retros_stat_fingerprint(root)
+
+    assert fp1 != fp2, "events.jsonl change must alter the fingerprint"
+
+
+def test_flushed_sha_by_task_id_last_event_wins(tmp_path: Path) -> None:
+    """If a task is flushed multiple times (re-play), the last recorded
+    sha256 is authoritative (matches the current persistent file)."""
+    root = _project(tmp_path)
+    _emit_flush_event(root, "task-R", "a" * 64)
+    _emit_flush_event(root, "task-R", "b" * 64)
+    result = _flushed_sha_by_task_id(root)
+    assert result.get("task-R") == "b" * 64

--- a/tests/test_force_dry_run_parity.py
+++ b/tests/test_force_dry_run_parity.py
@@ -1,0 +1,162 @@
+"""Parity test for force=True dry-run vs force=False live gate.
+
+The two code paths in `transition_task` — the live gate block (raises
+ValueError on first `_refuse(...)` or accumulates `gate_errors` and
+raises at the end) and the dry-run helper `_compute_bypassed_gates_for_force`
+(pure-function error collector) — must produce the same set of error
+strings for the same inputs.
+
+This test pins the invariant mechanically. Any future gate addition that
+forgets to mirror into the dry-run helper will fail this parity test —
+closing the drift risk PERF-002 flagged as "acceptable duplication but
+maintainer hazard."
+
+Why we don't just refactor: the live gate uses `_refuse()` which raises
+immediately for hash-bound checks (human approval, plan audit). The
+dry-run inherently cannot raise. Threading a `dry_run` flag through every
+`_refuse` call site risks subtle behavioral changes; the duplication is
+the lesser evil. This test guards it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import (  # noqa: E402
+    _compute_bypassed_gates_for_force,
+    transition_task,
+)
+
+
+def _task_dir(tmp_path: Path, *, stage: str, risk: str = "medium") -> Path:
+    td = tmp_path / ".dynos" / "task-20260419-PAR"
+    td.mkdir(parents=True)
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": td.name,
+        "stage": stage,
+        "classification": {"risk_level": risk},
+    }))
+    return td
+
+
+def _manifest(td: Path) -> dict:
+    return json.loads((td / "manifest.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Per-edge parity tests. For every edge where the live gate would refuse,
+# verify the dry-run helper returns an error list that contains the same
+# substring(s) the live gate would have raised.
+# ---------------------------------------------------------------------------
+
+
+def test_parity_execution_missing_plan_validated(tmp_path: Path) -> None:
+    """EXECUTION edge with no plan-validated receipt → both paths name
+    the missing receipt."""
+    td = _task_dir(tmp_path, stage="PRE_EXECUTION_SNAPSHOT")
+
+    with pytest.raises(ValueError) as exc_info:
+        transition_task(td, "EXECUTION")
+    live_msg = str(exc_info.value)
+
+    bypassed = _compute_bypassed_gates_for_force(
+        task_dir=td,
+        manifest=_manifest(td),
+        current_stage="PRE_EXECUTION_SNAPSHOT",
+        next_stage="EXECUTION",
+    )
+    # The live error names the receipt; at least one dry-run entry must too.
+    assert "plan-validated" in live_msg
+    assert any("plan-validated" in b for b in bypassed), (
+        f"dry-run omits the plan-validated error found in live path: {bypassed}"
+    )
+
+
+def test_parity_spec_review_missing_planner_spec(tmp_path: Path) -> None:
+    """SPEC_NORMALIZATION→SPEC_REVIEW with no planner-spec receipt and
+    non-fast-track task: both paths cite planner-spec."""
+    td = _task_dir(tmp_path, stage="SPEC_NORMALIZATION")
+    # classification.fast_track absent → non-fast-track.
+
+    with pytest.raises(ValueError) as exc_info:
+        transition_task(td, "SPEC_REVIEW")
+    live_msg = str(exc_info.value)
+
+    bypassed = _compute_bypassed_gates_for_force(
+        task_dir=td,
+        manifest=_manifest(td),
+        current_stage="SPEC_NORMALIZATION",
+        next_stage="SPEC_REVIEW",
+    )
+    assert "planner-spec" in live_msg
+    assert any("planner-spec" in b for b in bypassed), (
+        f"dry-run omits planner-spec: {bypassed}"
+    )
+
+
+def test_parity_plan_review_missing_planner_plan(tmp_path: Path) -> None:
+    """PLANNING→PLAN_REVIEW with no planner-plan receipt: parity."""
+    td = _task_dir(tmp_path, stage="PLANNING")
+
+    with pytest.raises(ValueError) as exc_info:
+        transition_task(td, "PLAN_REVIEW")
+    live_msg = str(exc_info.value)
+
+    bypassed = _compute_bypassed_gates_for_force(
+        task_dir=td,
+        manifest=_manifest(td),
+        current_stage="PLANNING",
+        next_stage="PLAN_REVIEW",
+    )
+    assert "planner-plan" in live_msg
+    assert any("planner-plan" in b for b in bypassed)
+
+
+def test_parity_checkpoint_audit_missing_executor_routing(tmp_path: Path) -> None:
+    """TEST_EXECUTION→CHECKPOINT_AUDIT with no executor-routing: parity.
+    The live gate emits only the one routing-missing error (no per-segment
+    double-complaint); dry-run must match."""
+    td = _task_dir(tmp_path, stage="TEST_EXECUTION")
+
+    with pytest.raises(ValueError) as exc_info:
+        transition_task(td, "CHECKPOINT_AUDIT")
+    live_msg = str(exc_info.value)
+
+    bypassed = _compute_bypassed_gates_for_force(
+        task_dir=td,
+        manifest=_manifest(td),
+        current_stage="TEST_EXECUTION",
+        next_stage="CHECKPOINT_AUDIT",
+    )
+    assert "executor-routing" in live_msg
+    assert any("executor-routing" in b for b in bypassed)
+    # And — no per-segment piggyback in either path.
+    assert "executor-seg-" not in live_msg
+    assert not any("executor-seg-" in b for b in bypassed)
+
+
+def test_parity_dry_run_returns_empty_when_live_would_pass(tmp_path: Path) -> None:
+    """When no gate would refuse, both paths agree: live passes silently
+    (no ValueError) and dry-run returns an empty list.
+
+    Uses an edge that has no preconditions on receipts/files."""
+    # FOUNDRY_INITIALIZED → SPEC_NORMALIZATION is unconditional.
+    td = _task_dir(tmp_path, stage="FOUNDRY_INITIALIZED")
+
+    bypassed = _compute_bypassed_gates_for_force(
+        task_dir=td,
+        manifest=_manifest(td),
+        current_stage="FOUNDRY_INITIALIZED",
+        next_stage="SPEC_NORMALIZATION",
+    )
+    assert bypassed == [], f"dry-run reported errors where live would pass: {bypassed}"
+
+    # And live actually passes.
+    transition_task(td, "SPEC_NORMALIZATION")
+    manifest = _manifest(td)
+    assert manifest["stage"] == "SPEC_NORMALIZATION"

--- a/tests/test_gate_done.py
+++ b/tests/test_gate_done.py
@@ -43,7 +43,9 @@ def _setup(tmp_path: Path) -> Path:
 
 
 def _write_postmortem_skipped(td: Path):
-    receipt_postmortem_skipped(td, "no-findings", "deadbeef" * 8)
+    # task-20260419-002 G2: subsumed_by is required; empty list is
+    # valid because reason is `no-findings`.
+    receipt_postmortem_skipped(td, "no-findings", "deadbeef" * 8, subsumed_by=[])
 
 
 def test_missing_audit_routing_refuses(tmp_path: Path):

--- a/tests/test_gate_done_postmortem.py
+++ b/tests/test_gate_done_postmortem.py
@@ -38,7 +38,9 @@ def test_neither_generated_nor_skipped_is_gap(tmp_path: Path):
 
 def test_skipped_alone_passes(tmp_path: Path):
     td = _setup(tmp_path, quality=0.95)
-    receipt_postmortem_skipped(td, "no-findings", "f" * 64)
+    # task-20260419-002 G2: subsumed_by required; empty list is valid
+    # because reason is `no-findings`.
+    receipt_postmortem_skipped(td, "no-findings", "f" * 64, subsumed_by=[])
     gaps = require_receipts_for_done(td)
     assert gaps == []
 
@@ -81,7 +83,9 @@ def test_generated_with_anomalies_plus_skipped_passes(tmp_path: Path):
     td = _setup(tmp_path, quality=0.95)
     receipt_postmortem_generated(td, "a" * 64, "b" * 64,
                                  anomaly_count=4, pattern_count=0)
-    receipt_postmortem_skipped(td, "clean-task", "f" * 64)
+    # task-20260419-002 G2: subsumed_by required; empty list is valid
+    # because reason is `clean-task`.
+    receipt_postmortem_skipped(td, "clean-task", "f" * 64, subsumed_by=[])
     gaps = require_receipts_for_done(td)
     assert gaps == []
 
@@ -91,6 +95,8 @@ def test_skipped_variant_short_circuits_anomaly_branch(tmp_path: Path):
     td = _setup(tmp_path, quality=0.4)
     receipt_postmortem_generated(td, "a" * 64, "b" * 64,
                                  anomaly_count=99, pattern_count=0)
-    receipt_postmortem_skipped(td, "no-findings", "f" * 64)
+    # task-20260419-002 G2: subsumed_by required; empty list is valid
+    # because reason is `no-findings`.
+    receipt_postmortem_skipped(td, "no-findings", "f" * 64, subsumed_by=[])
     gaps = require_receipts_for_done(td)
     assert gaps == []

--- a/tests/test_gate_plan_audit.py
+++ b/tests/test_gate_plan_audit.py
@@ -35,15 +35,9 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
 
 
 def _write_plan_audit(td: Path) -> None:
-    """Write a plan-audit-check receipt bound to the current artifact hashes."""
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    """Write a plan-audit-check receipt — the writer re-hashes artifacts
+    from disk (SEC-004, no caller-supplied hashes)."""
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 def test_critical_without_receipt_refuses(tmp_path: Path):

--- a/tests/test_gate_plan_audit_freshness.py
+++ b/tests/test_gate_plan_audit_freshness.py
@@ -36,14 +36,8 @@ def _setup(tmp_path: Path, *, risk: str) -> Path:
 
 
 def _write_fresh_audit(td: Path) -> None:
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    # SEC-004: writer re-hashes artifacts from disk; no caller args.
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 def test_refuses_when_plan_edited_after_audit(tmp_path: Path) -> None:

--- a/tests/test_hash_file_cache.py
+++ b/tests/test_hash_file_cache.py
@@ -1,0 +1,59 @@
+"""Tests for `hash_file` per-process memo (PERF-001).
+
+`hash_file` caches digests keyed by (absolute path, mtime_ns, size) so
+repeated calls against the same unchanged file share one disk read.
+Mutation of the file invalidates the entry automatically.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import _HASH_CACHE, hash_file  # noqa: E402
+
+
+def test_second_call_on_same_file_hits_cache(tmp_path: Path) -> None:
+    """Second hash of the same unchanged file must return the same digest
+    AND populate the module-level cache."""
+    f = tmp_path / "a.txt"
+    f.write_bytes(b"hello")
+    _HASH_CACHE.clear()
+    d1 = hash_file(f)
+    cache_size_after_first = len(_HASH_CACHE)
+    d2 = hash_file(f)
+    assert d1 == d2
+    # Second call must not grow the cache (already cached).
+    assert len(_HASH_CACHE) == cache_size_after_first
+    assert cache_size_after_first == 1
+
+
+def test_mutation_invalidates_cache(tmp_path: Path) -> None:
+    """Re-writing the file changes mtime_ns / size; the cached digest for
+    the old stat tuple stays in the dict but a new-stat read computes a
+    fresh digest. Stale-digest-returned-for-mutated-file is ruled out."""
+    f = tmp_path / "m.txt"
+    f.write_bytes(b"v1")
+    _HASH_CACHE.clear()
+    d1 = hash_file(f)
+    # Ensure mtime actually bumps (some FS have low resolution).
+    time.sleep(0.01)
+    os.utime(f, None)
+    f.write_bytes(b"v2 content bigger")  # also different size
+    d2 = hash_file(f)
+    assert d1 != d2, "digest must differ after content mutation"
+
+
+def test_cache_bounded(tmp_path: Path) -> None:
+    """Cache cap is bounded (FIFO eviction). Stuffing more than the cap
+    keeps the dict at/below the limit."""
+    from lib_receipts import _HASH_CACHE_MAX
+    _HASH_CACHE.clear()
+    for i in range(_HASH_CACHE_MAX + 20):
+        fp = tmp_path / f"f{i}.txt"
+        fp.write_bytes(f"body-{i}".encode())
+        hash_file(fp)
+    assert len(_HASH_CACHE) <= _HASH_CACHE_MAX

--- a/tests/test_postmortem_skip_reasons.py
+++ b/tests/test_postmortem_skip_reasons.py
@@ -1,0 +1,296 @@
+"""Tests for task-20260419-002 G1+G2: `_POSTMORTEM_SKIP_REASONS` enum
+shrink and the required ``subsumed_by`` argument on
+``receipt_postmortem_skipped``.
+
+Covers acceptance criteria 1, 3, and 4 from the task spec.
+
+Failure modes exercised (in the order the validator applies them):
+  (a) ``subsumed_by`` must be a list
+  (b) every entry must match the task_id slug regex
+  (c) empty ``subsumed_by`` is rejected when the reason is NOT one of
+      {clean-task, no-findings} — unreachable in production after G1's
+      enum shrink, so we use monkeypatch to temporarily expand the
+      enum and prove the rule still fires
+  (d) every entry must have a corresponding postmortem file on disk
+      under ``_persistent_project_dir(root)/postmortems/{task_id}.json``
+
+The happy-path test round-trips a real subsumed_by entry by
+pre-creating the postmortem file where the validator expects it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+import lib_receipts  # noqa: E402
+from lib_core import _persistent_project_dir  # noqa: E402
+from lib_receipts import receipt_postmortem_skipped  # noqa: E402
+
+
+def _task_dir(tmp_path: Path) -> Path:
+    """Create a task dir under ``<tmp>/project/.dynos/task-*/`` so that
+    ``task_dir.parent.parent == <tmp>/project`` — the shape the
+    validator expects when resolving the persistent project dir."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / "task-20260419-TEST"
+    td.mkdir(parents=True)
+    return td
+
+
+def _pre_create_postmortem(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    td: Path,
+    task_id: str,
+) -> Path:
+    """Write a valid postmortem JSON at the exact path the validator
+    will stat. Returns the path that was written so callers can make
+    extra assertions on it.
+
+    We pin ``DYNOS_HOME`` under ``tmp_path`` first so that
+    ``_persistent_project_dir`` resolves inside the test sandbox
+    (instead of the developer's real ``~/.dynos``).
+    """
+    monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
+    root = td.parent.parent
+    pm_dir = _persistent_project_dir(root) / "postmortems"
+    pm_dir.mkdir(parents=True, exist_ok=True)
+    pm_path = pm_dir / f"{task_id}.json"
+    pm_path.write_text(json.dumps({"task_id": task_id}))
+    return pm_path
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1: `quality-above-threshold` must be rejected
+# ---------------------------------------------------------------------------
+
+
+def test_quality_above_threshold_rejected(tmp_path: Path):
+    """The literal reason removed by G1 must now raise a ValueError whose
+    message enumerates both remaining valid reasons (`clean-task` AND
+    `no-findings`) and contains the literal substring `invalid`."""
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        receipt_postmortem_skipped(
+            td,
+            reason="quality-above-threshold",
+            retrospective_sha256="a" * 64,
+            subsumed_by=[],
+        )
+    msg = str(excinfo.value)
+    assert "invalid" in msg, f"expected 'invalid' in message; got: {msg}"
+    # Both remaining valid reasons must be enumerated in the message so
+    # the caller can self-correct without reading source.
+    assert "clean-task, no-findings" in msg, (
+        f"expected the literal substring 'clean-task, no-findings' "
+        f"in the message; got: {msg}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3(a): `subsumed_by` must be a list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "task-20260418-001",            # string is not a list
+        ("task-20260418-001",),         # tuple is not a list
+        {"task-20260418-001"},          # set is not a list
+        {"0": "task-20260418-001"},     # dict is not a list
+        None,                            # None is not a list
+        42,                              # int is not a list
+    ],
+)
+def test_subsumed_by_must_be_list(tmp_path: Path, bad_value):
+    """Rule (a): anything other than `list` must raise. The error
+    message pins the expected shape so downstream callers know what
+    the validator wants."""
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        receipt_postmortem_skipped(
+            td,
+            reason="clean-task",
+            retrospective_sha256="a" * 64,
+            subsumed_by=bad_value,  # type: ignore[arg-type]
+        )
+    assert "subsumed_by must be a list" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3(b): every entry must match the task_id regex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_entry",
+    [
+        "not-a-task-id",        # wrong prefix
+        "task-",                 # missing body
+        "task-_underscore",      # first body char must be alphanumeric
+        "task-20260418 001",     # whitespace is rejected
+        "task-20260418/001",     # slash is not in the allowed set
+        "",                      # empty string
+        123,                      # non-string entry
+        None,                     # None entry
+    ],
+)
+def test_subsumed_by_entry_must_match_task_regex(tmp_path: Path, bad_entry):
+    """Rule (b): every entry must match ``^task-[A-Za-z0-9][A-Za-z0-9_.-]*$``.
+    The error message must contain BOTH the bracketed index
+    ``subsumed_by[...]`` and the literal ``must match``.
+
+    Non-string entries are rejected with the same error (the validator
+    must not raise a TypeError from re.match on a non-str).
+    """
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        receipt_postmortem_skipped(
+            td,
+            reason="clean-task",
+            retrospective_sha256="a" * 64,
+            subsumed_by=[bad_entry],  # type: ignore[list-item]
+        )
+    msg = str(excinfo.value)
+    assert "subsumed_by[" in msg, (
+        f"expected bracketed index 'subsumed_by[' in message; got: {msg}"
+    )
+    assert "must match" in msg, (
+        f"expected literal 'must match' in message; got: {msg}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3(c): non-empty required when reason is not clean-task / no-findings
+# ---------------------------------------------------------------------------
+
+
+def test_subsumed_by_empty_rejected_when_reason_not_clean_or_no_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (c): when the reason is NOT one of the "nothing to cite"
+    reasons, ``subsumed_by`` MUST be non-empty.
+
+    After G1's enum shrink this branch is unreachable via the reason
+    enum check, so we temporarily expand ``_POSTMORTEM_SKIP_REASONS``
+    to include a test-only reason; this proves the defensive rule
+    still fires and is not dead code.
+    """
+    td = _task_dir(tmp_path)
+    # Expand the enum to include a test-only reason so we can reach
+    # rule (c). The original frozenset is restored automatically by
+    # monkeypatch at teardown.
+    extended = frozenset(
+        set(lib_receipts._POSTMORTEM_SKIP_REASONS) | {"test-reason-expansion"}
+    )
+    monkeypatch.setattr(lib_receipts, "_POSTMORTEM_SKIP_REASONS", extended)
+
+    with pytest.raises(ValueError) as excinfo:
+        receipt_postmortem_skipped(
+            td,
+            reason="test-reason-expansion",
+            retrospective_sha256="a" * 64,
+            subsumed_by=[],
+        )
+    msg = str(excinfo.value)
+    assert "subsumed_by must be non-empty when reason=" in msg, (
+        f"expected 'subsumed_by must be non-empty when reason=' in "
+        f"message; got: {msg}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3(d): every entry must have a postmortem file on disk
+# ---------------------------------------------------------------------------
+
+
+def test_subsumed_by_missing_postmortem_file_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Rule (d): every entry in a non-empty ``subsumed_by`` must point
+    to a real postmortem file under
+    ``_persistent_project_dir(root)/postmortems/{task_id}.json``.
+    A missing file raises ValueError whose message names both the
+    literal ``missing postmortem file for`` AND the offending task_id.
+    """
+    monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
+    td = _task_dir(tmp_path)
+    bogus_task_id = "task-20260418-DOES-NOT-EXIST"
+    with pytest.raises(ValueError) as excinfo:
+        receipt_postmortem_skipped(
+            td,
+            reason="clean-task",  # enum-valid; rule (d) fires due to non-empty list
+            retrospective_sha256="a" * 64,
+            subsumed_by=[bogus_task_id],
+        )
+    msg = str(excinfo.value)
+    assert "missing postmortem file for" in msg, (
+        f"expected 'missing postmortem file for' in message; got: {msg}"
+    )
+    assert bogus_task_id in msg, (
+        f"expected offending task_id {bogus_task_id!r} in message; got: {msg}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4: payload records reason + subsumed_by verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_payload_records_reason_and_subsumed_by(tmp_path: Path):
+    """Skip receipt with reason=clean-task and empty subsumed_by must
+    round-trip through JSON with both fields intact. This is the
+    minimal case — no postmortem file is needed because the list is
+    empty so rule (d) does not apply."""
+    td = _task_dir(tmp_path)
+    out = receipt_postmortem_skipped(
+        td,
+        reason="clean-task",
+        retrospective_sha256="e" * 64,
+        subsumed_by=[],
+    )
+    assert out.exists(), f"receipt file was not written at {out}"
+    payload = json.loads(out.read_text())
+    assert payload["reason"] == "clean-task"
+    assert payload["subsumed_by"] == []
+    # Also confirm the retrospective sha is carried — guards against
+    # a regression that silently drops a sibling field.
+    assert payload["retrospective_sha256"] == "e" * 64
+
+
+def test_happy_path_with_real_subsumed_postmortem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """End-to-end: reason=no-findings, subsumed_by cites a real prior
+    task whose postmortem file exists on disk at the expected path.
+    The written receipt must round-trip both fields."""
+    td = _task_dir(tmp_path)
+    prior_task = "task-20260418-005"
+    _pre_create_postmortem(monkeypatch, tmp_path, td, prior_task)
+
+    out = receipt_postmortem_skipped(
+        td,
+        reason="no-findings",
+        retrospective_sha256="f" * 64,
+        subsumed_by=[prior_task],
+    )
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["reason"] == "no-findings"
+    # The receipt stores a shallow copy (list()) of the input; content
+    # must match exactly.
+    assert payload["subsumed_by"] == [prior_task]
+    # Sanity: extra-safe mutation of the caller's list must NOT
+    # retroactively corrupt the receipt (the writer stores a copy).
+    # We re-read the file after a would-be mutation; the payload on
+    # disk does not change (that is enforced by file immutability
+    # after write_receipt — we are proving the stored value is the
+    # captured snapshot).
+    assert payload["retrospective_sha256"] == "f" * 64

--- a/tests/test_receipt_contract_version.py
+++ b/tests/test_receipt_contract_version.py
@@ -71,7 +71,9 @@ def _exercise_writer(name: str, td: Path):
     if name == "receipt_postmortem_analysis":
         return receipt_postmortem_analysis(td, "a" * 64, 0, "b" * 64)
     if name == "receipt_postmortem_skipped":
-        return receipt_postmortem_skipped(td, "no-findings", "a" * 64)
+        # task-20260419-002 G2: subsumed_by is required; empty list is
+        # valid because reason is `no-findings`.
+        return receipt_postmortem_skipped(td, "no-findings", "a" * 64, subsumed_by=[])
     if name == "receipt_calibration_applied":
         return receipt_calibration_applied(td, 0, 0, "a" * 64, "b" * 64)
     if name == "receipt_plan_routing":

--- a/tests/test_receipt_contract_version.py
+++ b/tests/test_receipt_contract_version.py
@@ -111,14 +111,8 @@ def _exercise_writer(name: str, td: Path):
             td, "spec", 0, injected_prompt_sha256=digest
         )
     if name == "receipt_plan_audit":
-        return receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
+        # SEC-004: writer re-hashes disk; no caller-supplied hashes.
+        return receipt_plan_audit(td, tokens_used=0, finding_count=0)
     if name == "receipt_force_override":
         from lib_receipts import receipt_force_override
         return receipt_force_override(

--- a/tests/test_receipt_plan_audit_hash.py
+++ b/tests/test_receipt_plan_audit_hash.py
@@ -1,11 +1,13 @@
-"""Tests for receipt_plan_audit hash payload (F2) and plan_audit_matches
-helper (F3). CRITERIA 2 and 3.
+"""Tests for receipt_plan_audit hash payload and plan_audit_matches
+helper. CRITERIA 2 and 3 (F2/F3), with SEC-004 hardening applied.
 
-F2: `receipt_plan_audit(...)` now requires three kw-only string kwargs:
-`spec_sha256`, `plan_sha256`, `graph_sha256`. Each must be non-empty.
-The written payload carries all three.
+SEC-004 hardening: the writer no longer accepts caller-supplied hashes.
+It re-hashes `spec.md`, `plan.md`, and `execution-graph.json` from the
+task directory at write time. This closes the TOCTOU between a caller's
+hash read and the receipt write — the writer's own read is the
+authoritative source.
 
-F3: `plan_audit_matches(task_dir)` returns:
+F3: `plan_audit_matches(task_dir)` still returns:
   - True  when the receipt exists AND all three hashes match disk
   - a descriptive string (e.g. "plan.md hash drift") when the receipt
     is present but one of the artifacts drifted on disk
@@ -40,107 +42,58 @@ def _setup_artifacts(tmp_path: Path) -> Path:
 
 
 def _write_fresh_receipt(td: Path) -> None:
-    """Write a plan-audit-check receipt whose hashes match current disk."""
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    """Write a plan-audit-check receipt — the writer re-hashes current
+    disk contents (SEC-004: no caller-supplied hashes)."""
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
 
 
 # ---------------------------------------------------------------------------
-# F2: receipt_plan_audit payload / signature
+# Payload / signature
 # ---------------------------------------------------------------------------
 
 
 def test_payload_contains_three_hashes(tmp_path: Path) -> None:
-    """Write a receipt with known hex digests; read the JSON back; assert
-    the three keys are present and match exactly what we passed in."""
+    """Write a receipt; read the JSON back; assert the three hash keys
+    are present AND match what `hash_file` says about the same files.
+
+    SEC-004: writer re-hashes internally — callers no longer supply
+    hashes — so the only way for the payload to be right is for the
+    writer to read the artifacts itself."""
     td = _setup_artifacts(tmp_path)
-    spec_h = "a" * 64
-    plan_h = "b" * 64
-    graph_h = "c" * 64
-    receipt_path = receipt_plan_audit(
-        td,
-        tokens_used=0,
-        finding_count=0,
-        spec_sha256=spec_h,
-        plan_sha256=plan_h,
-        graph_sha256=graph_h,
-    )
+    receipt_path = receipt_plan_audit(td, tokens_used=0, finding_count=0)
     payload = json.loads(receipt_path.read_text())
-    assert payload["spec_sha256"] == spec_h
-    assert payload["plan_sha256"] == plan_h
-    assert payload["graph_sha256"] == graph_h
+    assert payload["spec_sha256"] == hash_file(td / "spec.md")
+    assert payload["plan_sha256"] == hash_file(td / "plan.md")
+    assert payload["graph_sha256"] == hash_file(td / "execution-graph.json")
 
 
-def test_requires_spec_sha256(tmp_path: Path) -> None:
-    """Missing kwarg → TypeError (kw-only required argument).
-    Empty string → ValueError (explicit rejection of blank)."""
+def test_missing_artifact_writes_literal_missing(tmp_path: Path) -> None:
+    """When an artifact file is absent at write time, the corresponding
+    payload slot carries the literal string `missing`. Downstream
+    `plan_audit_matches` interprets that as a drift condition because it
+    never equals a real sha256 hex digest."""
     td = _setup_artifacts(tmp_path)
-    # Omission — kw-only required → TypeError.
-    with pytest.raises(TypeError):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
-    # Empty string — explicit ValueError naming the arg.
-    with pytest.raises(ValueError, match="spec_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="",
-            plan_sha256="b" * 64,
-            graph_sha256="c" * 64,
-        )
+    (td / "plan.md").unlink()
+    receipt_path = receipt_plan_audit(td, tokens_used=0, finding_count=0)
+    payload = json.loads(receipt_path.read_text())
+    assert payload["plan_sha256"] == "missing"
+    # Spec and graph are still real hashes.
+    assert payload["spec_sha256"] == hash_file(td / "spec.md")
+    assert payload["graph_sha256"] == hash_file(td / "execution-graph.json")
 
 
-def test_requires_plan_sha256(tmp_path: Path) -> None:
+def test_signature_rejects_caller_supplied_hashes(tmp_path: Path) -> None:
+    """SEC-004 regression: callers that still try to pass the old
+    kwargs (spec_sha256/plan_sha256/graph_sha256) hit a TypeError for
+    unexpected-kwarg. The three args are no longer part of the
+    public signature."""
     td = _setup_artifacts(tmp_path)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="spec_sha256"):
         receipt_plan_audit(
             td,
             tokens_used=0,
             finding_count=0,
-            spec_sha256="a" * 64,
-            graph_sha256="c" * 64,
-        )
-    with pytest.raises(ValueError, match="plan_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="",
-            graph_sha256="c" * 64,
-        )
-
-
-def test_requires_graph_sha256(tmp_path: Path) -> None:
-    td = _setup_artifacts(tmp_path)
-    with pytest.raises(TypeError):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-        )
-    with pytest.raises(ValueError, match="graph_sha256"):
-        receipt_plan_audit(
-            td,
-            tokens_used=0,
-            finding_count=0,
-            spec_sha256="a" * 64,
-            plan_sha256="b" * 64,
-            graph_sha256="",
+            spec_sha256="a" * 64,  # type: ignore[call-arg]
         )
 
 

--- a/tests/test_receipt_postmortem.py
+++ b/tests/test_receipt_postmortem.py
@@ -72,22 +72,25 @@ def test_postmortem_analysis_rejects_invalid(tmp_path: Path):
 
 def test_postmortem_skipped_happy(tmp_path: Path):
     td = _task_dir(tmp_path)
-    for reason in ("clean-task", "no-findings", "quality-above-threshold"):
-        out = receipt_postmortem_skipped(td, reason, "e" * 64)
+    # After task-20260419-002 G1 the enum is reduced to two reasons;
+    # `quality-above-threshold` is no longer valid.
+    for reason in ("clean-task", "no-findings"):
+        out = receipt_postmortem_skipped(td, reason, "e" * 64, subsumed_by=[])
         payload = json.loads(out.read_text())
         assert payload["reason"] == reason
         assert payload["retrospective_sha256"] == "e" * 64
+        assert payload["subsumed_by"] == []
 
 
 def test_postmortem_skipped_rejects_invalid_reason(tmp_path: Path):
     td = _task_dir(tmp_path)
     with pytest.raises(ValueError, match="invalid postmortem skip reason"):
-        receipt_postmortem_skipped(td, "made-up-reason", "e" * 64)
+        receipt_postmortem_skipped(td, "made-up-reason", "e" * 64, subsumed_by=[])
     with pytest.raises(ValueError, match="invalid postmortem skip reason"):
-        receipt_postmortem_skipped(td, "", "e" * 64)
+        receipt_postmortem_skipped(td, "", "e" * 64, subsumed_by=[])
 
 
 def test_postmortem_skipped_rejects_empty_retro_sha(tmp_path: Path):
     td = _task_dir(tmp_path)
     with pytest.raises(ValueError, match="retrospective_sha256"):
-        receipt_postmortem_skipped(td, "no-findings", "")
+        receipt_postmortem_skipped(td, "no-findings", "", subsumed_by=[])

--- a/tests/test_receipt_writer_reader_parity.py
+++ b/tests/test_receipt_writer_reader_parity.py
@@ -1,0 +1,551 @@
+"""Parity test for receipt writers and readers (task-20260419-002 G3).
+
+Acceptance criteria 6, 7, 8 of the spec. This test enforces:
+
+  1. Every receipt writer in ``hooks/lib_receipts.py`` (any ``^def receipt_``
+     function that calls ``write_receipt(task_dir, "<literal>", ...)`` with
+     a literal string first-positional step_name) has at least one reader
+     (``read_receipt(..., "<literal>")``) somewhere under ``hooks/``,
+     ``skills/``, ``memory/``, or ``cli/assets/templates/base/`` — OR
+     the step_name is explicitly allowlisted in ``_INTENTIONALLY_WRITE_ONLY``
+     below with a non-empty reason string.
+
+  2. Every literal-string ``read_receipt(..., "<literal>")`` call site has a
+     matching writer in ``hooks/lib_receipts.py``. Writers may be literal
+     strings OR f-string prefixes (e.g. ``f"planner-{phase}"`` supplies
+     both ``planner-spec`` and ``planner-plan`` via the ``planner-``
+     prefix). NO allowlist on this side — a reader-without-writer is a
+     hard failure because it indicates a caller reading a step that was
+     never produced.
+
+  3. Every ``receipt: <step>`` citation inside
+     ``gate_errors.append(...)`` or ``_refuse(...)`` call sites in
+     ``hooks/lib_core.py`` MUST have BOTH a writer AND a reader (or
+     allowlist entry for the reader-side fallback). Dynamic gate citations
+     (e.g. ``f"receipt: executor-{seg_id} ..."``) surface as the captured
+     prefix (``executor-``) and pass when the f-string writer/reader
+     prefix covers them.
+
+  4. Every entry in ``_INTENTIONALLY_WRITE_ONLY`` carries a non-empty
+     reason string. Adding an entry therefore requires touching this file
+     AND documenting why — no silent allowlist growth.
+
+The allowlist was populated from a live repo scan at task execution time
+(see ``.dynos/task-20260419-002/evidence/seg-2-evidence.md``) — every
+entry corresponds to a grep-verified writer step_name that has zero
+literal-string readers across the searched directories. Future receipts
+added by follow-up work that are genuinely write-only must be added here
+EXPLICITLY with a reason. Guessing is forbidden.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_RECEIPTS = ROOT / "hooks" / "lib_receipts.py"
+LIB_CORE = ROOT / "hooks" / "lib_core.py"
+READER_SEARCH_DIRS = [
+    ROOT / "hooks",
+    ROOT / "skills",
+    ROOT / "memory",
+    ROOT / "cli" / "assets" / "templates" / "base",
+]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — grep-verified write-only receipts (see evidence file).
+#
+# Populated from a live repo scan at 2026-04-18 (task-20260419-002, seg-2):
+#   * literal writers enumerated via AST walk of hooks/lib_receipts.py
+#   * literal readers enumerated via grep for
+#       read_receipt(..., "<literal>") across
+#       hooks/, skills/, memory/, cli/assets/templates/base/
+#   * writers - readers = candidate write-only set
+#   * each candidate manually confirmed to have no dynamic reader
+#     reachable via prefix match (i.e. not covered by an f-string reader)
+#
+# Dict (not set) so each entry MUST carry a reason string. Adding a new
+# entry is an explicit review touch: the CI diff will show both the
+# step_name and the justification.
+# ---------------------------------------------------------------------------
+_INTENTIONALLY_WRITE_ONLY: dict[str, str] = {
+    # Written by receipt_plan_routing (hooks/lib_receipts.py:receipt_plan_routing).
+    # Observability-only: captures which agent the plan skill routed to so
+    # the audit trail records the routing decision. No runtime gate reads
+    # it directly — the validate_chain helper walks it via a variable
+    # dispatch (`for receipt_name in required: read_receipt(...,
+    # receipt_name)`) which literal-grep cannot see.
+    "plan-routing": (
+        "observability-only; written by receipt_plan_routing, no literal "
+        "reader in hooks/skills/memory/cli-templates (validate_chain reads "
+        "via a loop variable which the parity grep cannot detect)"
+    ),
+    # Written by receipt_post_completion (hooks/lib_receipts.py:receipt_post_completion).
+    # End-of-pipeline observational receipt proving post-DONE handlers ran.
+    # validate_chain references it through its `required` list but via a
+    # loop variable, so literal grep does not see a reader. No gate reads
+    # it directly; downstream dashboards inspect the receipt file on disk
+    # rather than via read_receipt().
+    "post-completion": (
+        "written by receipt_post_completion as end-of-pipeline marker; "
+        "validate_chain reads it via loop variable (invisible to literal "
+        "grep); no gate or skill reads it directly"
+    ),
+    # Written by receipt_tdd_tests (hooks/lib_receipts.py:receipt_tdd_tests).
+    # TDD_REVIEW exit gate reads `human-approval-TDD_REVIEW` for the
+    # actual approval signal; the tdd-tests receipt itself is an
+    # observational marker that tests were committed and tokens recorded.
+    # No literal reader exists in any searched directory.
+    "tdd-tests": (
+        "observability-only; written by receipt_tdd_tests to record token "
+        "usage and evidence path, but TDD_REVIEW exit gate reads "
+        "human-approval-TDD_REVIEW not tdd-tests — no reader exists"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Writer extraction — AST walk of hooks/lib_receipts.py
+# ---------------------------------------------------------------------------
+
+
+def _writer_step_info() -> tuple[set[str], set[str]]:
+    """Return ``(literal_writers, fstring_writer_prefixes)``.
+
+    Walks every ``^def receipt_`` function in ``hooks/lib_receipts.py``.
+    For each ``write_receipt(task_dir, <arg>, ...)`` call found inside
+    the function body:
+
+    * If ``<arg>`` is an ``ast.Constant`` string, the literal value is
+      added to ``literal_writers``.
+    * If ``<arg>`` is an ``ast.JoinedStr`` (an f-string), the constant
+      prefix (text before the first ``FormattedValue`` hole) is added
+      to ``fstring_writer_prefixes``. A prefix like ``"executor-"``
+      matches every family member ``executor-seg-1``, ``executor-seg-2``,
+      etc.
+    * If ``<arg>`` is any other expression (``Name``, etc.), it is
+      ignored — such call sites produce step_names we cannot statically
+      enumerate. This is an accepted limitation; the receipt writer
+      functions wrapping them each have a stable literal or f-string
+      branch that we DO capture (e.g. ``receipt_planner_spawn`` uses
+      ``step_name = f"planner-{phase}"`` and then passes ``step_name``;
+      we pick up the f-string prefix via the assignment walk below).
+
+    The second pass scans ``Assign`` nodes of shape ``step_name = <f">"``
+    inside the same receipt_ function so we do not miss the
+    ``step_name = f"planner-{phase}"; write_receipt(task_dir, step_name,
+    ...)`` idiom used in ``receipt_planner_spawn``.
+    """
+    src = LIB_RECEIPTS.read_text()
+    tree = ast.parse(src)
+
+    literal_writers: set[str] = set()
+    fstring_writer_prefixes: set[str] = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("receipt_"):
+            continue
+
+        # Pass 1: collect Assigns of shape `step_name = <expr>` so we can
+        # resolve the variable when write_receipt is called with
+        # `step_name` rather than the literal.
+        local_name_bindings: dict[str, ast.expr] = {}
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Assign):
+                for tgt in sub.targets:
+                    if isinstance(tgt, ast.Name):
+                        local_name_bindings[tgt.id] = sub.value
+
+        # Pass 2: every write_receipt(task_dir, <arg>, ...) call.
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            if not isinstance(sub.func, ast.Name) or sub.func.id != "write_receipt":
+                continue
+            if len(sub.args) < 2:
+                continue
+            arg = sub.args[1]
+
+            # If the arg is a Name, try to resolve to its assignment.
+            if isinstance(arg, ast.Name) and arg.id in local_name_bindings:
+                arg = local_name_bindings[arg.id]
+
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                literal_writers.add(arg.value)
+            elif isinstance(arg, ast.JoinedStr):
+                prefix = _fstring_constant_prefix(arg)
+                if prefix:
+                    fstring_writer_prefixes.add(prefix)
+
+    return literal_writers, fstring_writer_prefixes
+
+
+def _fstring_constant_prefix(joined: ast.JoinedStr) -> str:
+    """Return the constant-string prefix of an f-string, up to the first
+    ``FormattedValue`` hole. Returns ``""`` if the f-string starts with
+    a hole.
+    """
+    prefix_parts: list[str] = []
+    for part in joined.values:
+        if isinstance(part, ast.Constant) and isinstance(part.value, str):
+            prefix_parts.append(part.value)
+        else:
+            break
+    return "".join(prefix_parts)
+
+
+def _writer_step_names() -> set[str]:
+    """Public surface used by tests: literal writers only.
+
+    The symmetric-reader-has-writer check uses the richer
+    ``_writer_step_info`` to handle f-string prefixes separately.
+    """
+    literals, _prefixes = _writer_step_info()
+    return literals
+
+
+# ---------------------------------------------------------------------------
+# Reader extraction — text-search for read_receipt(..., "<literal>")
+# ---------------------------------------------------------------------------
+
+# Captures the first string-literal arg of read_receipt — either a normal
+# double-quoted string OR a double-quoted f-string prefix before the first
+# `{`. Single-quoted forms are also accepted.
+#
+# Shape: read_receipt(<anything, including task_dir or other expr>, <lit>)
+# We keep the regex permissive on the gap between `(` and the quote because
+# call sites span multiple lines (AST would be stricter but the target is
+# plain-text search — consistent with the grep-based parity the plan asks
+# for).
+_READ_RECEIPT_LITERAL_RE = re.compile(
+    r"""read_receipt\s*\(
+        [^)"']*                 # everything up to the step_name arg
+        (?:"([^"{}]+)"|'([^'{}]+)')
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# f-string readers: `f"executor-{...}"` → capture the prefix up to `{`.
+_READ_RECEIPT_FSTRING_RE = re.compile(
+    r"""read_receipt\s*\(
+        [^)"']*
+        f(?:"([^"{}]*)\{|'([^'{}]*)\{)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _iter_search_files() -> list[Path]:
+    """Enumerate every text file under the reader search dirs whose
+    extension is .py or .md. Skips __pycache__, binary files.
+    """
+    files: list[Path] = []
+    for base in READER_SEARCH_DIRS:
+        if not base.exists():
+            continue
+        for p in base.rglob("*"):
+            if not p.is_file():
+                continue
+            if "__pycache__" in p.parts:
+                continue
+            if p.suffix not in {".py", ".md"}:
+                continue
+            files.append(p)
+    return files
+
+
+def _reader_step_info() -> tuple[set[str], set[str], list[tuple[Path, int, str]]]:
+    """Return ``(literal_readers, fstring_reader_prefixes, citations)``.
+
+    * ``literal_readers``: set of step_name strings that appear as the
+      literal second arg of ``read_receipt(..., "<lit>")`` — with some
+      permissive regex fudge for multi-line calls (see
+      ``_READ_RECEIPT_LITERAL_RE``).
+    * ``fstring_reader_prefixes``: constant prefixes of f-string reader
+      call sites (e.g. ``executor-`` from ``f"executor-{seg_id}"``).
+    * ``citations``: list of (file, line_number, step_name) triples for
+      use in failure messages.
+    """
+    literal_readers: set[str] = set()
+    fstring_reader_prefixes: set[str] = set()
+    citations: list[tuple[Path, int, str]] = []
+
+    for f in _iter_search_files():
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for m in _READ_RECEIPT_LITERAL_RE.finditer(text):
+            lit = m.group(1) or m.group(2)
+            # Skip the literal capture if the preceding 'f' makes this an
+            # f-string — the f-string regex handles those.
+            start = m.start()
+            # The `f` (if present) sits immediately before the opening quote.
+            # Locate the quote the regex matched.
+            quote_offset = m.start(1) - 1 if m.group(1) else m.start(2) - 1
+            is_fstring = quote_offset > 0 and text[quote_offset - 1] == "f"
+            if is_fstring:
+                continue
+            literal_readers.add(lit)
+            line_no = text.count("\n", 0, start) + 1
+            citations.append((f, line_no, lit))
+        for m in _READ_RECEIPT_FSTRING_RE.finditer(text):
+            prefix = m.group(1) or m.group(2) or ""
+            if prefix:
+                fstring_reader_prefixes.add(prefix)
+
+    return literal_readers, fstring_reader_prefixes, citations
+
+
+def _reader_step_names() -> set[str]:
+    """Public surface: literal reader step_names only."""
+    literals, _prefixes, _cites = _reader_step_info()
+    return literals
+
+
+# ---------------------------------------------------------------------------
+# Gate citation extraction — `receipt: <step>` inside
+# gate_errors.append(...) or _refuse(...)
+# ---------------------------------------------------------------------------
+
+
+_GATE_CITATION_RE = re.compile(
+    r"""(?:gate_errors\.append|_refuse)\s*\(
+        [^)]*?
+        receipt:\s+([a-z][a-z0-9-]*)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _gate_citation_step_names() -> set[tuple[str, int, str]]:
+    """Return set of (file, line_no, step_name) for every
+    ``receipt: <step>`` citation inside
+    ``gate_errors.append(...)`` or ``_refuse(...)`` in hooks/lib_core.py.
+
+    Step_name is the regex capture; for dynamic f-string citations such
+    as ``f"receipt: executor-{seg_id} ..."``, the capture is the literal
+    prefix (``executor-``). Downstream coverage checks treat a trailing
+    hyphen as an f-string family marker and match it against writer /
+    reader f-string prefixes.
+    """
+    text = LIB_CORE.read_text()
+    results: set[tuple[str, int, str]] = set()
+    for m in _GATE_CITATION_RE.finditer(text):
+        step = m.group(1)
+        line_no = text.count("\n", 0, m.start()) + 1
+        results.add((str(LIB_CORE), line_no, step))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Coverage helpers
+# ---------------------------------------------------------------------------
+
+
+def _reader_covers(
+    step: str,
+    literal_readers: set[str],
+    fstring_reader_prefixes: set[str],
+) -> bool:
+    """Does any reader (literal or f-string prefix) cover ``step``?
+
+    Coverage semantics:
+      * exact literal match, OR
+      * some f-string reader prefix P where ``step.startswith(P)`` and
+        ``step != P`` (family member covered by dynamic reader), OR
+      * ``step`` itself ends in ``-`` (meaning ``step`` is a dynamic
+        prefix extracted from an f-string citation) and some literal
+        reader starts with ``step``.
+    """
+    if step in literal_readers:
+        return True
+    for prefix in fstring_reader_prefixes:
+        if prefix and step != prefix and step.startswith(prefix):
+            return True
+    if step.endswith("-"):
+        if any(lit.startswith(step) for lit in literal_readers):
+            return True
+        if step in fstring_reader_prefixes:
+            return True
+    return False
+
+
+def _writer_covers(
+    step: str,
+    literal_writers: set[str],
+    fstring_writer_prefixes: set[str],
+) -> bool:
+    """Does any writer (literal or f-string prefix) cover ``step``?"""
+    if step in literal_writers:
+        return True
+    for prefix in fstring_writer_prefixes:
+        if prefix and step != prefix and step.startswith(prefix):
+            return True
+    if step.endswith("-"):
+        if any(lit.startswith(step) for lit in literal_writers):
+            return True
+        if step in fstring_writer_prefixes:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_every_writer_has_reader_or_is_allowlisted():
+    """AC 6 (writer-side): every literal ``write_receipt(task_dir,
+    "<step>", ...)`` step_name in ``hooks/lib_receipts.py`` has a
+    matching reader under the searched directories, OR is in
+    ``_INTENTIONALLY_WRITE_ONLY`` with a non-empty reason.
+
+    Failure names the exact step_names that have no reader and no
+    allowlist entry.
+    """
+    literal_writers, _fstring_writers = _writer_step_info()
+    literal_readers, fstring_reader_prefixes, _cites = _reader_step_info()
+
+    # Sanity: the writer set cannot be empty — if AST extraction broke,
+    # we would silently pass. Guard against that regression.
+    assert literal_writers, (
+        "AST extraction returned zero literal writers from "
+        f"{LIB_RECEIPTS}. Either the file is empty or the AST walk is "
+        "broken; either way the parity test has lost its teeth."
+    )
+
+    missing: list[str] = []
+    for step in sorted(literal_writers):
+        if _reader_covers(step, literal_readers, fstring_reader_prefixes):
+            continue
+        if step in _INTENTIONALLY_WRITE_ONLY:
+            continue
+        missing.append(step)
+
+    assert not missing, (
+        "writer without reader and no allowlist entry: "
+        f"{missing}\n"
+        "Either add a read_receipt(..., \"<step>\") call-site under "
+        "hooks/, skills/, memory/, or cli/assets/templates/base/, OR add "
+        "the step_name to _INTENTIONALLY_WRITE_ONLY in this test file "
+        "with a documented reason. Guessing the allowlist is forbidden."
+    )
+
+
+def test_every_reader_has_writer():
+    """AC 6 (reader-side): every literal ``read_receipt(..., "<step>")``
+    call-site step_name has a matching writer in
+    ``hooks/lib_receipts.py`` (literal or f-string prefix). NO ALLOWLIST
+    ON THIS SIDE — a reader without a writer indicates a caller reading
+    a step that never gets produced and is a hard failure.
+    """
+    literal_writers, fstring_writer_prefixes = _writer_step_info()
+    _literal_readers, _prefixes, citations = _reader_step_info()
+
+    assert citations, (
+        "reader extraction found zero read_receipt(..., \"<lit>\") call "
+        "sites. Either the search regex is broken or the entire codebase "
+        "stopped reading receipts — either is a severe regression the "
+        "parity test should refuse to silently pass."
+    )
+
+    missing: list[tuple[str, Path, int]] = []
+    seen: set[str] = set()
+    for path, line_no, step in citations:
+        if step in seen:
+            continue
+        seen.add(step)
+        if _writer_covers(step, literal_writers, fstring_writer_prefixes):
+            continue
+        missing.append((step, path, line_no))
+
+    assert not missing, (
+        "reader without writer: "
+        + "; ".join(
+            f"read_receipt(..., {s!r}) at {p}:{ln}"
+            for s, p, ln in missing
+        )
+        + "\nAdd a matching write_receipt() call in hooks/lib_receipts.py "
+        "or remove the read."
+    )
+
+
+def test_every_transition_gate_step_has_writer_and_reader():
+    """AC 7: every ``receipt: <step>`` citation inside
+    ``gate_errors.append(...)`` or ``_refuse(...)`` in
+    ``hooks/lib_core.py`` must be backed by BOTH a writer AND a reader
+    (or allowlist entry for the reader). A gate that cites a missing
+    receipt is a liar — its error message points the operator at a
+    receipt the code never produces, making the failure mode opaque.
+    """
+    literal_writers, fstring_writer_prefixes = _writer_step_info()
+    literal_readers, fstring_reader_prefixes, _cites = _reader_step_info()
+    citations = _gate_citation_step_names()
+
+    assert citations, (
+        "gate-citation extraction found zero `receipt: <step>` citations "
+        "in hooks/lib_core.py. Either the regex is broken or every gate "
+        "stopped citing receipts — either case is a severe regression."
+    )
+
+    writer_missing: list[tuple[str, str, int]] = []
+    reader_missing: list[tuple[str, str, int]] = []
+    for path, line_no, step in sorted(citations):
+        if not _writer_covers(step, literal_writers, fstring_writer_prefixes):
+            writer_missing.append((step, path, line_no))
+        has_reader = _reader_covers(step, literal_readers, fstring_reader_prefixes)
+        if not has_reader and step not in _INTENTIONALLY_WRITE_ONLY:
+            # Allow the dynamic-family case: if step ends in `-`, we
+            # already attempted prefix match inside _reader_covers, so
+            # falling through here means genuinely no reader exists.
+            reader_missing.append((step, path, line_no))
+
+    errs: list[str] = []
+    if writer_missing:
+        errs.append(
+            "gate cites receipt without writer: "
+            + "; ".join(
+                f"{step!r} at {p}:{ln}" for step, p, ln in writer_missing
+            )
+        )
+    if reader_missing:
+        errs.append(
+            "gate cites receipt without reader: "
+            + "; ".join(
+                f"{step!r} at {p}:{ln}" for step, p, ln in reader_missing
+            )
+        )
+    assert not errs, "\n".join(errs)
+
+
+def test_allowlist_entries_have_comments():
+    """AC 8: each entry in ``_INTENTIONALLY_WRITE_ONLY`` carries a
+    non-empty reason string. Entries are a dict — not a set — expressly
+    so reasons are mandatory. An empty-string reason (whitespace only
+    counts as empty after strip) defeats the documentation purpose; we
+    reject it here at test time so the review diff cannot sneak past a
+    vague or missing justification.
+    """
+    bad: list[str] = []
+    for step, reason in _INTENTIONALLY_WRITE_ONLY.items():
+        if not isinstance(reason, str):
+            bad.append(f"{step}: reason is not a string ({type(reason).__name__})")
+            continue
+        if not reason.strip():
+            bad.append(f"{step}: reason is empty or whitespace-only")
+            continue
+        # A one-line reason is fine but it must be substantive. Guard
+        # against lazy placeholders like "TODO" or "n/a".
+        low = reason.strip().lower()
+        if low in {"todo", "tbd", "n/a", "na", "write-only", "write only"}:
+            bad.append(
+                f"{step}: reason is a placeholder ({reason!r}); "
+                "write a substantive explanation"
+            )
+    assert not bad, (
+        "_INTENTIONALLY_WRITE_ONLY entries with missing / weak reasons:\n"
+        + "\n".join(f"  - {b}" for b in bad)
+    )

--- a/tests/test_retrospective_flush.py
+++ b/tests/test_retrospective_flush.py
@@ -73,7 +73,9 @@ def _setup_done_ready(tmp_path: Path, slug: str = "RF",
         error_violations=0, mode="all",
     )
     receipt_audit_routing(td, [])
-    receipt_postmortem_skipped(td, "no-findings", "a" * 64)
+    # task-20260419-002 G2: subsumed_by is required; empty list is
+    # valid because reason is `no-findings`.
+    receipt_postmortem_skipped(td, "no-findings", "a" * 64, subsumed_by=[])
     return td
 
 

--- a/tests/test_spec_review_iterations_from_receipts.py
+++ b/tests/test_spec_review_iterations_from_receipts.py
@@ -60,6 +60,15 @@ def _write_approval_receipt(td: Path, filename: str) -> None:
     (receipts / filename).write_text(json.dumps(payload, indent=2))
 
 
+def _write_empty_planted_receipt(td: Path, filename: str) -> None:
+    """Write an EMPTY file (or JSON-invalid content) matching the glob —
+    simulating a SEC-005 attack where someone plants bare files to
+    inflate the counter without a real approval. Should NOT count."""
+    receipts = td / "receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    (receipts / filename).write_text("")
+
+
 def _iterations(td: Path) -> int:
     """Return the `spec_review_iterations` value computed by
     `compute_reward` for the given task dir."""
@@ -93,6 +102,31 @@ def test_counts_two_with_rotation_suffix(tmp_path: Path) -> None:
     _write_approval_receipt(td, "human-approval-SPEC_REVIEW.json")
     _write_approval_receipt(td, "human-approval-SPEC_REVIEW-002.json")
     assert _iterations(td) == 2
+
+
+def test_empty_planted_files_do_not_inflate_count(tmp_path: Path) -> None:
+    """SEC-005 regression: `touch human-approval-SPEC_REVIEW-fake.json`
+    (empty file, no JSON content) must NOT inflate the counter.
+    Receipts must parse as JSON objects carrying a matching
+    `step == "human-approval-SPEC_REVIEW*"` field AND non-empty
+    `artifact_sha256`."""
+    td = _make_task_dir(tmp_path, slug="SEC5")
+    # One legitimate receipt + three planted files of different shapes.
+    _write_approval_receipt(td, "human-approval-SPEC_REVIEW.json")
+    _write_empty_planted_receipt(td, "human-approval-SPEC_REVIEW-empty.json")
+    # Valid JSON but not a dict.
+    (td / "receipts" / "human-approval-SPEC_REVIEW-list.json").write_text("[]")
+    # Valid JSON object but wrong step field.
+    (td / "receipts" / "human-approval-SPEC_REVIEW-wrong.json").write_text(
+        json.dumps({"step": "something-else", "artifact_sha256": "a" * 64})
+    )
+    # Valid JSON object with empty artifact_sha256.
+    (td / "receipts" / "human-approval-SPEC_REVIEW-noart.json").write_text(
+        json.dumps({"step": "human-approval-SPEC_REVIEW", "artifact_sha256": ""})
+    )
+    assert _iterations(td) == 1, (
+        f"only the legitimate receipt should count; planted files must be rejected"
+    )
 
 
 def test_log_lines_no_longer_counted(tmp_path: Path) -> None:

--- a/tests/test_tdd_required_default.py
+++ b/tests/test_tdd_required_default.py
@@ -61,14 +61,7 @@ def _setup(tmp_path: Path, *, risk: str, tdd_required: bool | None = None) -> Pa
 
 def test_plan_audit_to_pre_exec_permitted_when_tdd_required_absent_critical(tmp_path: Path):
     td = _setup(tmp_path, risk="critical")  # no tdd_required field
-    receipt_plan_audit(
-        td,
-        tokens_used=100,
-        finding_count=0,
-        spec_sha256=hash_file(td / "spec.md"),
-        plan_sha256=hash_file(td / "plan.md"),
-        graph_sha256=hash_file(td / "execution-graph.json"),
-    )
+    receipt_plan_audit(td, tokens_used=100, finding_count=0)
     # Must succeed: tdd_required absent, plan-audit-check is present.
     transition_task(td, "PRE_EXECUTION_SNAPSHOT")
     manifest = json.loads((td / "manifest.json").read_text())

--- a/tests/test_transition_done_deferred_findings.py
+++ b/tests/test_transition_done_deferred_findings.py
@@ -1,0 +1,308 @@
+"""Tests for task-20260419-002 G4.c: ``transition_task`` DONE gate
+integration with ``check_deferred_findings``.
+
+Covers acceptance criterion 12 from the task spec:
+
+  - When a deferred finding is TTL-expired AND its ``files``
+    intersects this task's changed files, the DONE transition
+    refuses with a ValueError whose message contains the literal
+    ``deferred findings expired`` AND the expired-finding id(s).
+  - When the registry has entries but none are expired + intersecting,
+    the DONE transition proceeds.
+  - When the registry is missing (cold start), the DONE transition
+    proceeds.
+  - When entries exist but do not intersect the changed files, the
+    DONE transition proceeds regardless of TTL.
+
+Each test builds a full-DONE-ready task directory with every gate
+precondition satisfied (audit-routing, retrospective receipt,
+rules-check-passed receipt, postmortem-skipped receipt, task
+retrospective JSON, audit-reports/*.json). The test's variable is
+which deferred-findings registry we write + where ``execution-graph
+.json`` points its ``files_expected``.
+
+Changed-files discovery path (under test): the DONE gate walks
+``executor-routing`` → ``executor-{seg}`` receipts' ``files_expected``
+fields (empty in these fixtures since ``receipt_executor_done``
+doesn't store that field) AND falls back to
+``execution-graph.json::segments[].files_expected``. We rely on the
+execution-graph.json fallback to supply changed_files deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+from lib_core import transition_task  # noqa: E402
+from lib_receipts import (  # noqa: E402
+    receipt_audit_routing,
+    receipt_postmortem_skipped,
+    receipt_retrospective,
+    receipt_rules_check_passed,
+)
+
+
+def _setup_done_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a task dir whose manifest sits at CHECKPOINT_AUDIT and
+    has EVERY receipt + artifact the DONE gate demands. Returns the
+    task dir path. After this setup, ``transition_task(td, "DONE")``
+    would succeed if the deferred-findings gate is clean.
+
+    Pins DYNOS_HOME so any persistent-dir side effects land in the
+    test sandbox.
+    """
+    monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
+    project = tmp_path / "project"
+    td = project / ".dynos" / "task-20260419-DF"
+    td.mkdir(parents=True)
+    # Manifest at CHECKPOINT_AUDIT — the source stage for -> DONE.
+    (td / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260419-DF",
+        "stage": "CHECKPOINT_AUDIT",
+        "classification": {"risk_level": "medium"},
+    }))
+    # Retrospective JSON + per-receipt record.
+    (td / "task-retrospective.json").write_text(
+        json.dumps({"quality_score": 0.95})
+    )
+    # At least one audit-report file.
+    audit_dir = td / "audit-reports"
+    audit_dir.mkdir()
+    (audit_dir / "report.json").write_text(json.dumps({"findings": []}))
+    # receipt_retrospective (proves reward was computed).
+    receipt_retrospective(td, 0.95, 0.9, 0.9, 1000)
+    # receipt_rules_check_passed (error_violations=0 lets the gate pass).
+    receipt_rules_check_passed(td, rules_evaluated=0, violations_count=0,
+                                error_violations=0, mode="all")
+    # audit-routing with empty auditors → no per-auditor receipts required.
+    receipt_audit_routing(td, [])
+    # postmortem-skipped (cheap path — reason=no-findings so subsumed_by
+    # may be empty).
+    receipt_postmortem_skipped(
+        td, "no-findings", "d" * 64, subsumed_by=[]
+    )
+    return td
+
+
+def _write_execution_graph(td: Path, files_by_segment: dict[str, list[str]]) -> None:
+    """Write a minimal execution-graph.json with the given files_expected
+    per segment. The transition_task DONE gate uses this as a fallback
+    source for the changed-files list."""
+    segments = [
+        {"id": seg_id, "files_expected": files}
+        for seg_id, files in files_by_segment.items()
+    ]
+    (td / "execution-graph.json").write_text(
+        json.dumps({"segments": segments})
+    )
+
+
+def _write_registry(root: Path, entries: list[dict]) -> Path:
+    """Write ``.dynos/deferred-findings.json`` verbatim."""
+    reg = root / ".dynos" / "deferred-findings.json"
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text(json.dumps({"findings": entries}))
+    return reg
+
+
+def _deferred_entry(
+    *,
+    id: str,
+    files: list[str],
+    first_seen: int = 0,
+    ttl: int = 3,
+    task_id: str = "task-20260319-001",
+    category: str = "security",
+) -> dict:
+    return {
+        "id": id,
+        "category": category,
+        "task_id": task_id,
+        "files": files,
+        "first_seen_at": "2026-03-19T00:00:00Z",
+        "first_seen_at_task_count": first_seen,
+        "acknowledged_until_task_count": ttl,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) expired-and-intersecting → refuse
+# ---------------------------------------------------------------------------
+
+
+def test_done_transition_refuses_when_expired_finding_intersects_changed_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Full-DONE-ready task + deferred-findings registry with ONE
+    expired-and-intersecting entry. The transition must refuse with
+    a ValueError whose message contains the literal ``deferred
+    findings expired`` and the id of the offending entry."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    root = td.parent.parent
+
+    # execution-graph.json names hooks/lib_core.py as a changed file
+    # via its single segment's files_expected. (This is the fallback
+    # path the DONE gate uses since executor-done receipts don't
+    # store files_expected directly in this fixture.)
+    _write_execution_graph(td, {"seg-1": ["hooks/lib_core.py"]})
+
+    # Deferred finding: TTL=0 from task_count=0 → elapsed >= ttl
+    # immediately. `files` intersects the execution-graph entry.
+    _write_registry(root, [
+        _deferred_entry(
+            id="SEC-003",
+            files=["hooks/lib_core.py"],
+            first_seen=0,
+            ttl=0,
+        ),
+    ])
+
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "DONE")
+    msg = str(excinfo.value)
+    assert "deferred findings expired" in msg, (
+        f"expected 'deferred findings expired' in refusal message; "
+        f"got: {msg}"
+    )
+    assert "SEC-003" in msg, (
+        f"expected offending finding id 'SEC-003' in refusal message; "
+        f"got: {msg}"
+    )
+    # Stage did NOT advance.
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "CHECKPOINT_AUDIT"
+
+
+def test_done_transition_reports_all_expired_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Multiple expired-and-intersecting entries → refusal message
+    enumerates ALL of them. A single fail-first implementation would
+    miss later entries and hide deferred work."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    root = td.parent.parent
+    _write_execution_graph(td, {
+        "seg-1": ["hooks/lib_core.py"],
+        "seg-2": ["hooks/rules_engine.py"],
+    })
+    _write_registry(root, [
+        _deferred_entry(id="SEC-003", files=["hooks/lib_core.py"],
+                        first_seen=0, ttl=0),
+        _deferred_entry(id="PERF-002", files=["hooks/rules_engine.py"],
+                        first_seen=0, ttl=0),
+    ])
+    with pytest.raises(ValueError) as excinfo:
+        transition_task(td, "DONE")
+    msg = str(excinfo.value)
+    assert "SEC-003" in msg
+    assert "PERF-002" in msg
+    assert "deferred findings expired" in msg
+
+
+# ---------------------------------------------------------------------------
+# (b) finding exists but TTL not yet exceeded → proceed
+# ---------------------------------------------------------------------------
+
+
+def test_done_transition_proceeds_when_no_expired_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Registry has an intersecting finding but its TTL is set high
+    enough that elapsed < ttl. DONE transition succeeds."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    root = td.parent.parent
+    _write_execution_graph(td, {"seg-1": ["hooks/lib_core.py"]})
+    _write_registry(root, [
+        _deferred_entry(
+            id="SEC-003",
+            files=["hooks/lib_core.py"],
+            first_seen=0,
+            ttl=999,  # elapsed=0 << 999 → not expired
+        ),
+    ])
+    transition_task(td, "DONE")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "DONE"
+
+
+# ---------------------------------------------------------------------------
+# (c) registry missing → proceed (cold start)
+# ---------------------------------------------------------------------------
+
+
+def test_done_transition_proceeds_when_registry_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Cold start: no ``.dynos/deferred-findings.json`` file. The
+    DONE gate must treat this as "no signal" and proceed. Any
+    regression that raised on missing file would wedge every
+    fresh-project DONE transition."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    # Write an execution-graph to confirm the gate runs its
+    # changed-files path without crashing when the registry is absent.
+    _write_execution_graph(td, {"seg-1": ["hooks/lib_core.py"]})
+    # Deliberately do NOT write .dynos/deferred-findings.json.
+    assert not (td.parent.parent / ".dynos" / "deferred-findings.json").exists()
+
+    transition_task(td, "DONE")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "DONE"
+
+
+# ---------------------------------------------------------------------------
+# (d) registry has entries but they do not intersect → proceed
+# ---------------------------------------------------------------------------
+
+
+def test_done_transition_proceeds_when_intersection_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Registry has an entry that is past TTL, but the entry's
+    ``files`` do NOT overlap this task's changed files. No
+    intersection = nothing to report = transition proceeds."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    root = td.parent.parent
+    _write_execution_graph(td, {"seg-1": ["hooks/lib_core.py"]})
+    _write_registry(root, [
+        _deferred_entry(
+            id="SEC-003",
+            files=["unrelated/path/nowhere.py"],
+            first_seen=0,
+            ttl=0,  # TTL-expired but no file overlap
+        ),
+    ])
+    transition_task(td, "DONE")
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "DONE"
+
+
+# ---------------------------------------------------------------------------
+# Force bypass — deferred gate MUST be bypassable via --force
+# ---------------------------------------------------------------------------
+
+
+def test_done_transition_force_bypasses_deferred_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``force=True`` bypasses every gate including the new deferred-
+    findings one. An expired+intersecting entry is present, and the
+    transition still succeeds because force is the break-glass door.
+    Without this contract, an operator couldn't escape a wedged DONE
+    gate caused by a corrupt registry or stuck category."""
+    td = _setup_done_ready(tmp_path, monkeypatch)
+    root = td.parent.parent
+    _write_execution_graph(td, {"seg-1": ["hooks/lib_core.py"]})
+    _write_registry(root, [
+        _deferred_entry(id="SEC-003", files=["hooks/lib_core.py"],
+                        first_seen=0, ttl=0),
+    ])
+    transition_task(td, "DONE", force=True)
+    manifest = json.loads((td / "manifest.json").read_text())
+    assert manifest["stage"] == "DONE"


### PR DESCRIPTION
## Summary

Four structural guardrails that make the "skip-postmortem, rationalize-later" pattern mechanically impossible or mechanically visible. Trigger: my own pattern across PRs #126/#128/#129 — documenting findings as "non-blocking, deferred", rationalizing the skip under token pressure, reopening only after user prompting. This PR is the structural fix.

**Stacks on PR #128 (merged) + PR #129 (open).** Rebase target: `origin/main` after #129 lands.

One commit: `stop the postmortem-skip trust-me-bro pattern with 4 structural guardrails`.

## What this closes

| ID | Finding | Fix |
|---|---|---|
| **G1** | `quality-above-threshold` was the shortcut that let high-quality-but-finding-ful tasks skip the LLM postmortem | Deleted from `_POSTMORTEM_SKIP_REASONS`. Callers raising it now hit a clean `ValueError` |
| **G2** | Skip receipts had no mechanism requiring they cite specific prior work | `receipt_postmortem_skipped` requires `subsumed_by: list[str]` (required arg, no default). Four-rule validator: list-check → slug-regex → non-empty-when-reason → postmortem-file-exists |
| **G3** | Receipt writer / reader drift (task-006's investigator pattern) stayed invisible until the next audit | New `tests/test_receipt_writer_reader_parity.py` — AST-walks `hooks/lib_receipts.py` for writers, greps hooks/skills/memory/cli-templates for readers, extracts gate-citation step_names from `hooks/lib_core.py`. Any drift breaks CI. Allowlist `_INTENTIONALLY_WRITE_ONLY` is a dict (not set) so every entry carries a mandatory reason |
| **G4** | Non-blocking findings had no countdown; they could ride forever | Project-level `.dynos/deferred-findings.json` registry with TTL; `check_deferred_findings.py` CLI + importable function; `transition_task` DONE gate blocks if any TTL-expired finding intersects the task's changed files |

## Inline hardening from the 5-auditor pass (not deferred this time)

- **CQ-001** — `memory/postmortem.py` skip-reason discriminator was using `quality_score >= 0.8` instead of the spec's auditor-count rule. A task run by 3 auditors with zero findings but 0.5 quality would be mislabeled `no-findings`. Now correctly counts `audit-reports/*.json`.
- **SEC-002** — `seg_id` interpolated into `executor-{seg_id}` step_name is slug-validated before use.
- **SEC-003** — `append_deferred_findings(task_id=...)` slug-validated (same regex as PR #126 F10).

## Self-proof

This task itself passed through CHECKPOINT_AUDIT → DONE → CALIBRATED **under the new code path**. 5 auditors reported 9 total findings (all non-blocking). G1/G2 mechanically prevented the postmortem skip — `receipt_postmortem_skipped` would have refused given the non-zero findings. The LLM postmortem **ran** and derived 8 concrete prevention rules from this task's findings (including rules for the very patterns that failed in seg-1 authoring: "Skip/gate discriminators named in spec by cardinality must count the artifact they name, not substitute a heuristic proxy"). Persistent retrospective flushed to `~/.dynos/projects/Users-hassam-Documents-dynos-work/retrospectives/task-20260419-002.json`.

## Tests

- 5 new test files (45 new tests):
  - `test_postmortem_skip_reasons.py` (7 tests)
  - `test_receipt_writer_reader_parity.py` (4 tests)
  - `test_append_deferred_findings.py` (12 tests)
  - `test_check_deferred_findings.py` (8 tests)
  - `test_transition_done_deferred_findings.py` (6 tests)
- Migrated callers: `tests/test_receipt_postmortem.py`, `tests/test_gate_done.py`, `tests/test_gate_done_postmortem.py`, `tests/test_retrospective_flush.py`, `tests/test_receipt_contract_version.py`.
- Full suite: **1291 passed, 2 skipped (pre-existing), 0 failed**.

## Explicitly deferred (documented with reasons, not silently skipped)

- **SEC-001** — malformed deferred-findings.json fails open. Accepted per D5: fail-open on corruption prevents a wedging attack via registry corruption; tamper is visible via the surrounding gate behavior.
- **SEC-004** — TTL computation can be gamed by planting fake retrospectives. Same trust boundary as the persistent dir; FS-permission-dependent. Flagged for review above ~1k entries.
- **CQ-002** — cross-module private import `_atomic_write_text`. Acceptable given circular-import avoidance; documented.
- **CQ-003** — redundant local `import re`. Trivial but further churn avoided in this PR.
- **PERF-AUD-008** — registry pruning. Not a concern at current scale; addressed when volume warrants.

Each of these has a NEW enforcement mechanism on top of it (G4's check script flags aged findings), so they can't ride forever.

## Meta

The pattern that kicked off this task was my own — repeatedly documenting findings as "deferred" under token pressure across PRs #126/#128/#129, then reopening after your prompting. Procedural fixes ("I'll be more careful") ARE the anti-pattern. This PR replaces the procedural reliance with mechanical enforcement: G1 removes the shortcut reason; G2 makes skip-claims cite real prior work; G3 catches writer/reader drift at CI time; G4 puts non-blocking findings on a clock.

## Test plan

- [x] Full pytest suite green (1291/1291 relevant)
- [x] Self-proof: this task reached CALIBRATED without bypassing G1/G2
- [x] LLM postmortem ran and wrote 8 derived prevention rules
- [x] Persistent retrospective flushed (PR #126 F10)
- [ ] Reviewer spot-check: confirm G3 allowlist entries correspond to actual current write-only receipts (I grep-verified at authoring time; fresh scan at merge time)
- [ ] Reviewer spot-check: SEC-001/SEC-004 acceptance reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)