### PR TITLE
close proactive meta-audit findings MA-005 and MA-007

### DIFF
--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -1036,17 +1036,34 @@ def receipt_audit_done(
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, auditor_name, model_used or "default", tokens_used)
 
+    # MA-005 hardening: when report_path is None we have no way to verify
+    # caller-supplied finding_count / blocking_count. Any non-zero count
+    # supplied without a corresponding report file is caller-attested and
+    # exactly the TOCTOU pattern SEC-004 closed for receipt_plan_audit.
+    # Rule: `report_path=None` demands both counts be zero. If the auditor
+    # found anything, they must materialise a report file and pass its
+    # path. Learned / ensemble callers already hit the AC 17 guard above
+    # (report_path REQUIRED). This rule catches the remaining generic
+    # case and legacy voting-harness callers that pass None+counts>0.
+    if not (isinstance(report_path, str) and report_path):
+        if finding_count != 0 or blocking_count != 0:
+            raise ValueError(
+                f"audit-{auditor_name}: report_path is None but "
+                f"finding_count={finding_count}, blocking_count={blocking_count}. "
+                "Caller-attested non-zero counts are forbidden — "
+                "materialise a report file and pass its path, or pass "
+                "(0, 0) and None together."
+            )
+
     # AC 2 — self-verify block. When ``report_path`` is a non-null string
     # referring to an existing JSON file, cross-check caller-supplied
     # finding_count / blocking_count against the actual contents of the
     # report and attach a sha256 of the file. Any mismatch aborts the
     # write with ValueError naming the mismatched field and both values.
     #
-    # When ``report_path`` is None OR the file does not exist, the
-    # self-verify block is skipped entirely. This preserves the pre-
-    # escalation ensemble-vote semantics (where the voting harness writes
-    # receipts before a report file has been materialised) AND the
-    # backward-compat path for callers that legitimately pass None.
+    # When ``report_path`` is None OR the file does not exist, the MA-005
+    # rule above already demands counts=(0, 0). The skip below is now
+    # semantically: "no report means literal zero findings."
     report_sha256: str | None = None
     if isinstance(report_path, str) and report_path:
         report_file = Path(report_path)

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -773,6 +773,14 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
     persistent.mkdir(parents=True, exist_ok=True)
     lock_path = rules_path.with_suffix(rules_path.suffix + ".lock")
     added = 0
+    # MA-007: emit one event per successful rule promotion. The drop-
+    # side already emits `postmortem_rule_dropped` (stage=normalize
+    # and stage=schema); parity demands the add-side be equally visible.
+    # A reviewer grepping events.jsonl for `postmortem_rule_promoted`
+    # sees exactly which rules landed, from which task, under what
+    # category — the same chain-of-custody PR #131 established for
+    # the drop path but cut off before the promote path.
+    promoted_records: list[dict] = []
     lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
     with os.fdopen(lock_fd, "w") as lock_fh:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
@@ -811,11 +819,35 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
                 current_rules.append(merged)
                 existing_rule_texts.add(text.lower())
                 added += 1
+                promoted_records.append({
+                    "category": merged["category"],
+                    "executor": merged["executor"],
+                    "template": merged["template"],
+                    "enforcement": merged["enforcement"],
+                    "source_finding": merged["source_finding"],
+                })
 
             if added:
                 write_json(rules_path, {"rules": current_rules, "updated_at": now_iso()})
         finally:
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+    # MA-007: emit promotion events AFTER lock release so a failed log
+    # write doesn't hold the rules-file lock. One event per promoted
+    # rule — no batch aggregation — so a reviewer can trace each rule's
+    # individual provenance without parsing a compound event.
+    for record in promoted_records:
+        log_event(
+            root,
+            "postmortem_rule_promoted",
+            task=task_id,
+            task_id=task_id,
+            category=record["category"],
+            executor=record["executor"],
+            template=record["template"],
+            enforcement=record["enforcement"],
+            source_finding=record["source_finding"],
+        )
 
     # Hash analysis + rules POST-merge so the receipt records the on-disk
     # state that downstream verifiers will see. If any hashing or receipt

--- a/tests/test_postmortem_rule_promotion_parity.py
+++ b/tests/test_postmortem_rule_promotion_parity.py
@@ -253,3 +253,93 @@ def test_successful_promotion_reports_parity_counts(tmp_path: Path):
     assert not any(
         e.get("event") == "postmortem_rule_promotion_dropped" for e in events
     )
+
+
+# ---------------------------------------------------------------------------
+# MA-007 — successful promotions emit events, one per rule
+# ---------------------------------------------------------------------------
+
+
+def test_successful_promotion_emits_event_per_rule(tmp_path: Path):
+    """MA-007 regression: `apply_analysis` was silent on successful
+    promotions. PR-131 added events for drops; parity demands the add
+    side be equally visible. One `postmortem_rule_promoted` event per
+    promoted rule, carrying category + executor + template +
+    enforcement + source_finding so a reviewer can trace each rule's
+    individual provenance without parsing a compound event."""
+    root = _project(tmp_path)
+    td = _task_dir(root)
+    analysis = {
+        "summary": "test",
+        "prevention_rules": [
+            _mk_rule("rule alpha", category="sec"),
+            _mk_rule("rule bravo", category="cq"),
+            _mk_rule("rule charlie", category="perf"),
+        ],
+    }
+    result = apply_analysis(td, analysis)
+    assert result["rules_added"] == 3
+
+    events = _read_events(root)
+    promoted = [e for e in events if e.get("event") == "postmortem_rule_promoted"]
+    assert len(promoted) == 3, f"expected 3 promotion events, got {promoted}"
+    categories = sorted(e.get("category") for e in promoted)
+    assert categories == ["cq", "perf", "sec"]
+    # Every event carries the full provenance schema.
+    for ev in promoted:
+        assert ev.get("executor") == "all"
+        assert ev.get("template") == "advisory"
+        # enforcement "advisory" is not in VALID_ENFORCEMENT on main;
+        # the normalizer rewrites to "prompt-constraint" as the
+        # fallback. The event carries the post-normalization value.
+        assert ev.get("enforcement") == "prompt-constraint"
+        assert ev.get("source_finding") == "TEST-001"
+        assert ev.get("task_id") == "task-20260419-TP"
+
+
+def test_no_promotion_event_when_rule_already_exists(tmp_path: Path):
+    """Dedup-by-existing-text path: a rule whose text already appears in
+    prevention-rules.json is NOT appended and therefore must NOT emit a
+    postmortem_rule_promoted event (the provenance was recorded on the
+    original add, not this one). Verifies `added` does not double-count
+    and parity events don't inflate on re-runs."""
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+    from lib_core import _persistent_project_dir  # noqa: E402
+
+    root = _project(tmp_path)
+    td = _task_dir(root)
+    # Pre-seed the rules file with an existing entry matching our rule text.
+    persistent = _persistent_project_dir(root)
+    persistent.mkdir(parents=True, exist_ok=True)
+    existing_rules_path = persistent / "prevention-rules.json"
+    existing_rules_path.write_text(json.dumps({
+        "rules": [{
+            "rule": "rule alpha",
+            "category": "sec",
+            "executor": "all",
+            "enforcement": "advisory",
+            "source_task": "task-prior",
+            "source_finding": "PRIOR-001",
+            "added_at": "2026-04-01T00:00:00Z",
+            "template": "advisory",
+            "params": {},
+        }],
+    }))
+
+    analysis = {
+        "summary": "test",
+        "prevention_rules": [
+            _mk_rule("rule alpha", category="sec"),  # dup → skip
+            _mk_rule("rule bravo", category="cq"),   # new → promote
+        ],
+    }
+    result = apply_analysis(td, analysis)
+    assert result["rules_added"] == 1
+
+    events = _read_events(root)
+    promoted = [e for e in events if e.get("event") == "postmortem_rule_promoted"]
+    assert len(promoted) == 1, (
+        f"expected 1 promotion event (only the new rule); got {promoted}"
+    )
+    assert promoted[0].get("category") == "cq"

--- a/tests/test_receipt_audit_done_selfverify.py
+++ b/tests/test_receipt_audit_done_selfverify.py
@@ -33,17 +33,37 @@ def _write_report(task_dir: Path, findings: list[dict]) -> Path:
     return report
 
 
-def test_report_path_none_skips_selfverify(tmp_path: Path):
-    """AC 2 (None path): report_path=None → self-verify is skipped."""
+def test_report_path_none_allows_zero_counts(tmp_path: Path):
+    """MA-005 hardening: report_path=None is legal ONLY when finding_count
+    and blocking_count are both zero. The legit case is an auditor that
+    ran and found nothing. No report file is required for zero findings."""
     td = _make_task(tmp_path)
     out = receipt_audit_done(
-        td, "sec", "haiku", 5, 2, None, 100,
+        td, "sec", "haiku", 0, 0, None, 100,
         route_mode="generic", agent_path=None, injected_agent_sha256=None,
     )
     payload = json.loads(out.read_text())
-    assert payload["finding_count"] == 5
-    assert payload["blocking_count"] == 2
+    assert payload["finding_count"] == 0
+    assert payload["blocking_count"] == 0
     assert payload["report_sha256"] is None
+
+
+def test_report_path_none_with_nonzero_counts_rejected(tmp_path: Path):
+    """MA-005 regression: caller-attested non-zero counts without a
+    report file are forbidden. This closes the TOCTOU where a malicious
+    or careless caller could pass finding_count=5, blocking_count=0 and
+    skip writing a report that would contradict the claim."""
+    td = _make_task(tmp_path)
+    with pytest.raises(ValueError, match="Caller-attested non-zero counts are forbidden"):
+        receipt_audit_done(
+            td, "sec", "haiku", 5, 2, None, 100,
+            route_mode="generic", agent_path=None, injected_agent_sha256=None,
+        )
+    with pytest.raises(ValueError, match="Caller-attested non-zero counts are forbidden"):
+        receipt_audit_done(
+            td, "sec", "haiku", 0, 1, None, 100,
+            route_mode="generic", agent_path=None, injected_agent_sha256=None,
+        )
 
 
 def test_report_path_matching_counts_verifies(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes the two genuinely-actionable findings from the `/dynos-work:calibration` proactive meta-audit run on 2026-04-19. Five of the seven original findings were false positives or closed by already-merged stacked PRs; this PR does the two that remained.

One commit: `close proactive meta-audit findings MA-005 and MA-007`.

## What's fixed

### MA-005 — `receipt_audit_done` TOCTOU via `report_path=None` + caller-supplied counts

**Before:** `receipt_audit_done(..., finding_count, blocking_count, report_path=None, ...)` skipped the self-verify block when `report_path is None` and took the caller's counts at face value. Same TOCTOU pattern PR #129 SEC-004 closed for `receipt_plan_audit`.

**After:** when `report_path is None`, `finding_count` and `blocking_count` MUST both be zero. The legit case is an auditor that ran and found nothing; no report file needed for zero findings. Any non-zero count without a report is a `ValueError: Caller-attested non-zero counts are forbidden`. Auditors with real findings must materialize a report file, at which point the existing AC 2 self-verify re-reads and cross-checks.

### MA-007 — `apply_analysis` silent on successful rule promotions

**Before:** PR #131 closed the drop-side silence (`postmortem_rule_dropped` per drop, `postmortem_rule_promotion_dropped` when all inputs silently drop). The add-side was still silent — a successful `rules_added: N` return value but zero events. Asymmetric chain of custody: reviewers could grep drops but not adds.

**After:** one `postmortem_rule_promoted` event per rule actually appended to `prevention-rules.json`. Each event carries `category`, `executor`, `template`, `enforcement`, `source_finding`, and `task_id`. Deduplicated rules (text already in registry) do NOT emit — they weren't added this run. Events fire AFTER lock release so a log-write failure can't hold the rules-file lock.

## Meta-audit findings NOT fixed here (with reason)

| ID | Finding | Why skipped |
|----|---------|-------------|
| MA-001 | `quality-above-threshold` still a postmortem-skip reason | Closed by open PR #130 G1; auditor scanned pre-#130 main |
| MA-002 | `--force` writes no `force_override` receipt | False positive; `hooks/lib_core.py:1765-1824` on current main already writes it |
| MA-003 | `receipt_postmortem_skipped` has no `subsumed_by` | Closed by open PR #130 G2 |
| MA-004 | Deferred-findings TTL unimplemented | Closed by open PR #130 G4 |
| MA-006 | Parity test allowlist missing some receipts | False positive; `test_receipt_writer_reader_parity.py` passes on current main |

Three of those close when PR #130 lands (G1/G2/G4 all live on that branch). The two "false positive" rows are auditor mis-reads against main HEAD.

## Tests

- 4 new regression tests:
  - `test_report_path_none_allows_zero_counts` — the legit zero-findings case still writes cleanly.
  - `test_report_path_none_with_nonzero_counts_rejected` — both `finding_count>0` and `blocking_count>0` shapes raise.
  - `test_successful_promotion_emits_event_per_rule` — 3 input rules → 3 events with full provenance.
  - `test_no_promotion_event_when_rule_already_exists` — dedup'd rules don't emit; only newly-added rules do.

**Full suite: 1476 passed, 3 skipped (pre-existing), 0 failed.**

## Test plan

- [x] `python3 -m pytest tests/` exits 0
- [x] Every new `ValueError` has an adversarial test (the CI coverage linter passes)
- [x] Every new `log_event` call has a regression test asserting the event fires
- [ ] Reviewer spot-check: is there a legacy test fixture anywhere that calls `receipt_audit_done(..., 5, 0, None, ...)` and would now break? I grep'd and didn't find one outside the ones already migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)