### PR TITLE
WIP: cloud-plane client scaffolding (dormant by default)

### DIFF
--- a/.github/workflows/cloud-client.yml
+++ b/.github/workflows/cloud-client.yml
@@ -1,0 +1,47 @@
+name: cloud-client
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "hooks/cloud/**"
+      - "tests/cloud/**"
+      - "bin/dynos"
+      - ".github/workflows/cloud-client.yml"
+  pull_request:
+    paths:
+      - "hooks/cloud/**"
+      - "tests/cloud/**"
+      - "bin/dynos"
+      - ".github/workflows/cloud-client.yml"
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        py: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cryptography websockets keyring pytest pytest-asyncio
+
+      - name: Run tests
+        env:
+          DYNOS_KEYCHAIN: file
+        run: python -m pytest tests/cloud/ -q --tb=short
+
+      - name: CLI smoke
+        env:
+          DYNOS_KEYCHAIN: file
+        run: ./bin/dynos status

--- a/hooks/cloud/README.md
+++ b/hooks/cloud/README.md
@@ -1,0 +1,82 @@
+# hooks/cloud/ — dynos-work cloud plane client
+
+This directory is the bridge between the open-source `dynos-work`
+plugin and the commercial `cloud-sibyl` foundry. It is **dormant by
+default** — every OSS install has this code but nothing in it runs
+unless the user enables it.
+
+## How the switch works
+
+The driver (`hooks/driver.py`) checks `~/.dynos/config.toml` and env
+vars. If `cloud.enabled = false`, the driver defers to the existing
+local-canonical pipeline (`hooks/ctl.py` and friends). The plugin
+behaves *identically* to how it did before this module existed.
+
+Flip the switch:
+
+```bash
+dynos config set cloud.enabled true
+dynos config set cloud.api_url https://cloud.yourcompany.com
+dynos login
+```
+
+Now `dynos-work:start` etc. route through the cloud coordinator.
+
+## Files
+
+| File | Role |
+|---|---|
+| `config.py` | Loads `~/.dynos/config.toml` + env overrides. Defines `Config` dataclass. |
+| `keychain.py` | OS keychain wrapper (macOS Keychain / Windows Credential Locker / libsecret). File fallback when `DYNOS_KEYCHAIN=file`. |
+| `crypto.py` | Canonical JSON + Ed25519 + repo Merkle hash. Matches cloud-sibyl and sibyl-runner byte-for-byte. |
+| `client.py` | WebSocket client. Reconnect with backoff + resume by `last_seen_seq`. Signs every receipt. |
+| `cas.py` | Content-addressed storage: local cache + presign/upload against `/v1/artifacts/presign`. |
+| `dispatch.py` | Instruction handlers: `collect_context`, `run_tests`, `apply_patch`, `gather_evidence`, `request_human_review`, `run_local_validator`, `commit_and_sign`, `fetch_artifact`, `apply_plan_segment`. |
+| `queue.py` | SQLite offline queue + per-task `last_seen_seq` cursor. |
+| `cli.py` | `dynos login` / `logout` / `status` / `config`. |
+
+## What a receipt looks like
+
+Every instruction the cloud issues produces one receipt. The receipt
+is canonical-JSON serialized, Ed25519-signed with the device's session
+key, and contains outcome hashes specific to the instruction type.
+
+```python
+from hooks.cloud import crypto, keychain
+from hooks.cloud.crypto import load_private_key_seed
+
+seed = keychain.get_secret_bytes(keychain.SESSION_PRIVATE_KEY)
+priv = load_private_key_seed(seed)
+
+receipt_body = {
+    "receipt_id": "rcpt_abc",
+    "instruction_id": "inst_xyz",
+    "task_id": "t_001",
+    "executed_at": "2026-04-19T00:00:00Z",
+    "executor_target": "plugin",
+    "session_key_fingerprint": keychain.get_secret(keychain.SESSION_KEY_FINGERPRINT),
+    "precondition_met": True,
+    "outcome": {"exit_code": 0, "stdout_hash": "sha256:..."},
+    "artifact_refs": [],
+}
+signed = crypto.sign_receipt(priv, receipt_body, receipt_body["session_key_fingerprint"])
+```
+
+## What never leaves the machine
+
+- The Ed25519 **private key seed** — in the OS keychain only.
+- Any file matching `.git/**`, `.dynos/**`, `node_modules/**` — hard-excluded.
+- Full source bytes **unless** Zero-Retention is off AND the cloud
+  requests them via CAS presign. ZR tenants set `storage_mode =
+  local_only` — the cloud records only the hash, never the bytes.
+
+## Tests
+
+```bash
+cd /Users/hassam/Documents/dynos-work
+python3 -m pytest tests/cloud/ -q
+```
+
+39 tests covering canonical JSON stability, Ed25519 sign/verify,
+tamper rejection, offline queue idempotency, dispatcher handlers, and
+config resolution precedence.

--- a/hooks/cloud/__init__.py
+++ b/hooks/cloud/__init__.py
@@ -1,0 +1,27 @@
+"""
+dynos-work cloud module.
+
+Dormant by default. Enables when `~/.dynos/config.toml` has
+`[cloud] enabled = true` (or env `DYNOS_CLOUD_ENABLED=1`). When active,
+the plugin becomes a thin executor for cloud-issued instructions and
+writes its local state through the `driver` router (see hooks/driver.py).
+
+Public API:
+    from hooks.cloud import is_enabled, config, open_session, client
+"""
+from __future__ import annotations
+
+from .config import Config, is_enabled, load as load_config
+from . import crypto, keychain, client, cas, dispatch, queue
+
+__all__ = [
+    "Config",
+    "is_enabled",
+    "load_config",
+    "crypto",
+    "keychain",
+    "client",
+    "cas",
+    "dispatch",
+    "queue",
+]

--- a/hooks/cloud/cas.py
+++ b/hooks/cloud/cas.py
@@ -1,0 +1,185 @@
+"""
+Content-addressed artifact upload / download against the cloud.
+
+The plugin scans the working tree, computes per-file SHA-256s, and
+sends a single `POST /v1/artifacts/presign` with the full index. The
+cloud replies with ONLY the hashes it's missing and a pre-signed PUT
+URL for each. The plugin uploads those blobs and caches them locally
+under `.dynos/cache/<first2>/<sha>` for future tasks.
+
+On Zero-Retention tenants, the plugin flips `storage=local_only` in
+the request (via config) — the cloud still registers the metadata but
+never accepts the bytes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import Config
+from . import keychain
+
+
+@dataclass(slots=True)
+class ArtifactRef:
+    hash: str  # sha256:<hex>
+    kind: str
+    size_bytes: int
+    local_path: Path  # absolute
+
+
+class LocalCAS:
+    """Local content-addressed cache. Deduplicates uploads across tasks."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._dir = cache_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, hash_: str) -> Path:
+        hex_ = hash_.split(":", 1)[-1]
+        return self._dir / hex_[:2] / hex_
+
+    def has(self, hash_: str) -> bool:
+        return self.path_for(hash_).exists()
+
+    def put(self, data: bytes, hash_: str) -> Path:
+        p = self.path_for(hash_)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if not p.exists():
+            tmp = p.with_suffix(".tmp")
+            tmp.write_bytes(data)
+            tmp.rename(p)
+        return p
+
+    def get(self, hash_: str) -> bytes | None:
+        p = self.path_for(hash_)
+        if not p.exists():
+            return None
+        return p.read_bytes()
+
+
+def compute_file_index(root: Path, entries: list[tuple[str, str]]) -> list[ArtifactRef]:
+    """Given the `(path, hash)` list from crypto.repo_hash, produce
+    ArtifactRefs with absolute paths + sizes, ready to presign."""
+    refs: list[ArtifactRef] = []
+    for rel, h in entries:
+        p = root / rel
+        if not p.exists():
+            continue
+        refs.append(
+            ArtifactRef(
+                hash=f"sha256:{h}",
+                kind="source_chunk",
+                size_bytes=p.stat().st_size,
+                local_path=p,
+            )
+        )
+    return refs
+
+
+def negotiate_and_upload(
+    cfg: Config,
+    refs: list[ArtifactRef],
+    *,
+    local_only: bool = False,
+) -> dict[str, str]:
+    """Do a CAS round-trip: presign → filter missing → upload each
+    missing blob. Returns a map `hash → storage ('r2' | 'local_only')`.
+
+    If `local_only=True`, no upload happens and `artifacts` rows are
+    still registered cloud-side as metadata-only.
+    """
+    jwt = keychain.get_secret(keychain.SESSION_JWT)
+    if not jwt:
+        raise RuntimeError("no JWT — run `dynos login` first")
+    api = cfg.api_url.rstrip("/")
+
+    # Split in chunks of 2000 — keeps request size reasonable.
+    storage: dict[str, str] = {}
+    for i in range(0, len(refs), 2000):
+        batch = refs[i : i + 2000]
+        req_body = {
+            "hashes": [
+                {"hash": r.hash, "kind": r.kind, "size_bytes": r.size_bytes}
+                for r in batch
+            ],
+        }
+        headers = {
+            "authorization": f"Bearer {jwt}",
+            "content-type": "application/json",
+        }
+        req = urllib.request.Request(
+            f"{api}/v1/artifacts/presign",
+            data=json.dumps(req_body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            presign = json.loads(resp.read().decode("utf-8"))
+
+        for h in presign.get("present", []):
+            storage[h] = "r2"
+        if local_only:
+            for m in presign.get("missing", []):
+                storage[m["hash"]] = "local_only"
+            continue
+        for m in presign.get("missing", []):
+            r = next((x for x in batch if x.hash == m["hash"]), None)
+            if r is None:
+                continue
+            body = r.local_path.read_bytes()
+            # Verify hash before upload to avoid wasted bytes.
+            computed = hashlib.sha256(body).hexdigest()
+            if f"sha256:{computed}" != r.hash:
+                # Files can race; silently skip — next task picks it up.
+                continue
+            _upload(cfg, jwt, m["put_url"], body)
+            storage[r.hash] = "r2"
+    return storage
+
+
+def _upload(cfg: Config, jwt: str, put_url: str, body: bytes) -> None:
+    full = put_url if put_url.startswith("http") else f"{cfg.api_url.rstrip('/')}{put_url}"
+    headers = {
+        "authorization": f"Bearer {jwt}",
+        "content-type": "application/octet-stream",
+    }
+    req = urllib.request.Request(full, data=body, headers=headers, method="PUT")
+    with urllib.request.urlopen(req, timeout=60):  # noqa: S310
+        pass
+
+
+def fetch_artifact(cfg: Config, hash_: str, cache: LocalCAS) -> bytes:
+    """Download an artifact. Checks local cache first."""
+    cached = cache.get(hash_)
+    if cached is not None:
+        return cached
+    jwt = keychain.get_secret(keychain.SESSION_JWT)
+    if not jwt:
+        raise RuntimeError("no JWT")
+    hex_ = hash_.split(":", 1)[-1]
+    api = cfg.api_url.rstrip("/")
+    req = urllib.request.Request(
+        f"{api}/v1/artifacts/{urllib.parse.quote(f'sha256:{hex_}', safe='')}",
+        headers={"authorization": f"Bearer {jwt}"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+        body = resp.read()
+    cache.put(body, hash_)
+    return body
+
+
+__all__ = [
+    "ArtifactRef",
+    "LocalCAS",
+    "compute_file_index",
+    "negotiate_and_upload",
+    "fetch_artifact",
+]
+
+_ = os.environ

--- a/hooks/cloud/cli.py
+++ b/hooks/cloud/cli.py
@@ -1,0 +1,281 @@
+"""
+`dynos` CLI.
+
+Subcommands:
+    dynos login              Register a session key with the cloud
+    dynos logout             Revoke the session key
+    dynos status             Show config + session state
+    dynos config             Read / write ~/.dynos/config.toml
+    dynos task create <msg>  Create a cloud task (mostly for testing)
+    dynos task watch <id>    Stream coordinator events for a task
+
+Reads the same config the driver uses. When cloud.enabled=false, every
+command that requires a session bails with a clear message.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import secrets
+import sys
+import urllib.request
+from pathlib import Path
+
+from .config import load as load_config, Config
+from .crypto import (
+    export_private_key_seed,
+    export_public_key_raw,
+    generate_keypair,
+    load_private_key_seed,
+    public_key_fingerprint,
+    sign_canonical,
+)
+from . import keychain
+
+
+def _request(
+    cfg: Config,
+    method: str,
+    path: str,
+    *,
+    body: dict | None = None,
+    auth: bool = True,
+) -> tuple[int, dict | None]:
+    url = cfg.api_url.rstrip("/") + path
+    headers = {"content-type": "application/json"}
+    if auth:
+        jwt = keychain.get_secret(keychain.SESSION_JWT)
+        if jwt:
+            headers["authorization"] = f"Bearer {jwt}"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8") if body is not None else None,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8") or "{}")
+    except urllib.request.HTTPError as e:
+        try:
+            payload = json.loads(e.read().decode("utf-8"))
+        except Exception:
+            payload = None
+        return e.code, payload
+    except Exception as e:
+        print(f"request failed: {e}", file=sys.stderr)
+        return 0, None
+
+
+# ─────────────────────── login ──
+
+
+def cmd_login(args: argparse.Namespace) -> int:
+    cfg = load_config()
+    if not cfg.enabled:
+        print(
+            "cloud.enabled is false — dynos will stay in local-only mode. "
+            "Run `dynos config set cloud.enabled true` to enable.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Reuse an existing keypair if present; generate otherwise.
+    seed_b64 = keychain.get_secret(keychain.SESSION_PRIVATE_KEY)
+    pub_b64 = keychain.get_secret(keychain.SESSION_PUBLIC_KEY)
+
+    if not seed_b64 or not pub_b64:
+        priv, pub = generate_keypair()
+        seed = export_private_key_seed(priv)
+        pub_raw = export_public_key_raw(pub)
+        keychain.set_secret(keychain.SESSION_PRIVATE_KEY, seed)
+        keychain.set_secret(keychain.SESSION_PUBLIC_KEY, pub_raw)
+        seed_b64 = base64.b64encode(seed).decode("ascii")
+        pub_b64 = base64.b64encode(pub_raw).decode("ascii")
+
+    priv = load_private_key_seed(base64.b64decode(seed_b64))
+    pub_bytes = base64.b64decode(pub_b64)
+    fingerprint = public_key_fingerprint(pub_bytes)
+
+    # Challenge round trip.
+    nonce = secrets.token_hex(16)
+    status, ch = _request(cfg, "POST", "/v1/sessions/challenge", body={"nonce": nonce}, auth=False)
+    if status != 200 or not ch or "challenge" not in ch:
+        print(f"challenge request failed: {status}", file=sys.stderr)
+        return 1
+    challenge = ch["challenge"]
+
+    # Sign the challenge.
+    sig = priv.sign(challenge.encode("utf-8"))
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+
+    body = {
+        "device_name": cfg.device_name,
+        "alg": "ed25519",
+        "public_key_b64": pub_b64,
+        "challenge": challenge,
+        "challenge_sig_b64": sig_b64,
+        "tenant_id": args.tenant,
+    }
+    status, reg = _request(cfg, "POST", "/v1/sessions/", body=body, auth=False)
+    if status not in (200, 201) or not reg:
+        print(f"registration failed: {status}: {reg}", file=sys.stderr)
+        return 1
+
+    keychain.set_secret(keychain.SESSION_JWT, reg["jwt"])
+    keychain.set_secret(keychain.SESSION_KEY_ID, reg["session_key_id"])
+    keychain.set_secret(keychain.SESSION_KEY_FINGERPRINT, reg["key_fingerprint"])
+
+    print(f"logged in · session_key_id={reg['session_key_id']} fingerprint={fingerprint[:16]}…")
+    # The server may have slightly different fingerprint computation;
+    # trust the server's reported value going forward.
+    if reg["key_fingerprint"] != fingerprint:
+        print(
+            f"warning: local fingerprint {fingerprint[:16]}… != server {reg['key_fingerprint'][:16]}…",
+            file=sys.stderr,
+        )
+    # Sign-over canonicalization self-check.
+    assert sign_canonical(priv, {"a": 1}) == sign_canonical(priv, {"a": 1})
+    return 0
+
+
+def cmd_logout(args: argparse.Namespace) -> int:
+    cfg = load_config()
+    session_key_id = keychain.get_secret(keychain.SESSION_KEY_ID)
+    if session_key_id:
+        _request(cfg, "DELETE", f"/v1/sessions/{session_key_id}")
+    for k in (
+        keychain.SESSION_JWT,
+        keychain.SESSION_KEY_ID,
+        keychain.SESSION_KEY_FINGERPRINT,
+    ):
+        keychain.delete_secret(k)
+    if args.keys:
+        keychain.delete_secret(keychain.SESSION_PRIVATE_KEY)
+        keychain.delete_secret(keychain.SESSION_PUBLIC_KEY)
+        print("logged out + forgot keypair")
+    else:
+        print("logged out · keypair retained for next `dynos login`")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    cfg = load_config()
+    jwt = keychain.get_secret(keychain.SESSION_JWT)
+    fingerprint = keychain.get_secret(keychain.SESSION_KEY_FINGERPRINT)
+    session_id = keychain.get_secret(keychain.SESSION_KEY_ID)
+    print(f"cloud.enabled      = {cfg.enabled}")
+    print(f"cloud.api_url      = {cfg.api_url}")
+    print(f"cloud.ws_url       = {cfg.derived_ws_url}")
+    print(f"cloud.device_name  = {cfg.device_name}")
+    print(f"cloud.cache_dir    = {cfg.cache_dir}")
+    print(f"session_jwt        = {'present' if jwt else 'none'}")
+    print(f"session_key_id     = {session_id or 'none'}")
+    print(f"session_fingerprint= {fingerprint or 'none'}")
+    return 0
+
+
+def cmd_config(args: argparse.Namespace) -> int:
+    path = Path.home() / ".dynos" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if args.op == "show":
+        if not path.exists():
+            print("# (empty)")
+            return 0
+        print(path.read_text())
+        return 0
+    if args.op == "set":
+        # Simple line-editor: we find the [cloud] section and upsert the key.
+        key = args.key or ""
+        value = args.value or ""
+        if "." not in key:
+            print(f"key must be section.name, got {key}", file=sys.stderr)
+            return 2
+        section, name = key.split(".", 1)
+        lines = path.read_text().splitlines() if path.exists() else []
+
+        # Find section start + end.
+        start_idx = end_idx = -1
+        for i, line in enumerate(lines):
+            if line.strip() == f"[{section}]":
+                start_idx = i
+            elif start_idx >= 0 and line.strip().startswith("[") and i > start_idx:
+                end_idx = i
+                break
+        if start_idx < 0:
+            # Append a new section.
+            if lines and lines[-1].strip() != "":
+                lines.append("")
+            lines.append(f"[{section}]")
+            start_idx = len(lines) - 1
+            end_idx = len(lines)
+        if end_idx < 0:
+            end_idx = len(lines)
+
+        # Upsert the key.
+        value_repr = _toml_literal(value)
+        replaced = False
+        for i in range(start_idx + 1, end_idx):
+            lstrip = lines[i].lstrip()
+            if lstrip.startswith(f"{name} ") or lstrip.startswith(f"{name}="):
+                lines[i] = f"{name} = {value_repr}"
+                replaced = True
+                break
+        if not replaced:
+            lines.insert(end_idx, f"{name} = {value_repr}")
+
+        path.write_text("\n".join(lines) + "\n")
+        print(f"set {key} = {value_repr}")
+        return 0
+    return 2
+
+
+def _toml_literal(s: str) -> str:
+    if s.lower() in ("true", "false"):
+        return s.lower()
+    try:
+        int(s)
+        return s
+    except ValueError:
+        pass
+    return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
+
+
+# ─────────────────────── argparse ──
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="dynos", description="dynos-work cloud client")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_login = sub.add_parser("login", help="register a session key with the cloud")
+    p_login.add_argument("--tenant", default=None, help="tenant id (required for dev/admin flows)")
+    p_login.set_defaults(func=cmd_login)
+
+    p_logout = sub.add_parser("logout", help="revoke the current session")
+    p_logout.add_argument("--keys", action="store_true", help="also forget the local keypair")
+    p_logout.set_defaults(func=cmd_logout)
+
+    p_status = sub.add_parser("status", help="show cloud config + session state")
+    p_status.set_defaults(func=cmd_status)
+
+    p_config = sub.add_parser("config", help="read / write ~/.dynos/config.toml")
+    cfg_sub = p_config.add_subparsers(dest="op", required=True)
+    cfg_sub.add_parser("show")
+    p_set = cfg_sub.add_parser("set")
+    p_set.add_argument("key", help="dotted key, e.g. cloud.enabled")
+    p_set.add_argument("value")
+    p_config.set_defaults(func=cmd_config)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/hooks/cloud/client.py
+++ b/hooks/cloud/client.py
@@ -1,0 +1,205 @@
+"""
+Cloud WebSocket client.
+
+Maintains a long-lived connection to the PluginCoordinator DO. On every
+connect:
+    1. Load session private key from keychain.
+    2. Send `hello` with `last_seen_seq` (persisted in the offline queue).
+    3. Receive `resume_ack` with any pending instructions.
+    4. Dispatch each instruction to `hooks.cloud.dispatch`.
+    5. Sign the resulting receipt and send it back.
+
+Failures reconnect with capped exponential backoff. All work is idempotent
+under `(task_id, instruction_id)`.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+
+from .config import Config
+from .crypto import load_private_key_seed, sign_receipt
+from . import keychain
+from . import queue as _queue
+
+logger = logging.getLogger("dynos.cloud.client")
+
+
+@dataclass(slots=True)
+class ClientState:
+    task_id: str
+    session_key_fingerprint: str
+    config: Config
+
+
+DispatchFn = Callable[[dict[str, Any], ClientState], Awaitable[dict[str, Any]]]
+
+
+def _msg_id() -> str:
+    return "m_" + uuid.uuid4().hex[:12]
+
+
+async def run_client(
+    state: ClientState,
+    dispatch_fn: DispatchFn,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run until stop_event is set. Reconnects on disconnect."""
+    import websockets
+
+    backoff = 1.0
+    stop_event = stop_event or asyncio.Event()
+
+    ws_base = state.config.derived_ws_url.rstrip("/")
+    url = f"{ws_base}/v1/tasks/{state.task_id}/ws"
+
+    jwt = keychain.get_secret(keychain.SESSION_JWT)
+    seed_b64 = keychain.get_secret(keychain.SESSION_PRIVATE_KEY)
+    pub_b64 = keychain.get_secret(keychain.SESSION_PUBLIC_KEY)
+    if not jwt or not seed_b64 or not pub_b64:
+        raise RuntimeError("session not provisioned — run `dynos login` first")
+    priv = load_private_key_seed(base64.b64decode(seed_b64))
+
+    queue = _queue.OfflineQueue(state.config.offline_queue_path)
+    last_seen_seq = queue.last_seen_seq(state.task_id)
+
+    while not stop_event.is_set():
+        try:
+            async with websockets.connect(  # type: ignore[attr-defined]
+                url,
+                additional_headers={"Authorization": f"Bearer {jwt}"},
+                open_timeout=15,
+                ping_interval=30,
+                ping_timeout=10,
+            ) as ws:
+                hello = {
+                    "v": 1,
+                    "type": "hello",
+                    "msg_id": _msg_id(),
+                    "task_id": state.task_id,
+                    "client_version": "0.1.0",
+                    "session_pubkey_b64": pub_b64,
+                    "last_seen_seq": last_seen_seq,
+                }
+                await ws.send(json.dumps(hello))
+                logger.info("sent hello last_seen_seq=%d", last_seen_seq)
+
+                backoff = 1.0  # reset on successful connect
+
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        raw = raw.decode("utf-8")
+                    try:
+                        frame = json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.warning("received non-JSON frame")
+                        continue
+
+                    ftype = frame.get("type")
+                    if ftype == "resume_ack":
+                        pending = frame.get("pending_instructions", [])
+                        logger.info("resume_ack next_seq=%s pending=%d", frame.get("next_seq"), len(pending))
+                        for inst in pending:
+                            await _handle_instruction(ws, inst, state, dispatch_fn, priv, queue)
+                    elif ftype == "instruction":
+                        inst = frame.get("instruction", {})
+                        await _handle_instruction(ws, inst, state, dispatch_fn, priv, queue)
+                    elif ftype == "pong":
+                        pass
+                    elif ftype == "abort":
+                        logger.info("abort received: %s", frame.get("reason"))
+                        await ws.close(code=1000)
+                        return
+                    elif ftype == "error":
+                        recoverable = frame.get("recoverable", True)
+                        logger.warning("error frame: %s", frame.get("message"))
+                        if not recoverable:
+                            await ws.close(code=1008)
+                            return
+        except Exception as e:
+            logger.warning("ws session ended: %s", e)
+
+        if stop_event.is_set():
+            return
+        await asyncio.sleep(backoff)
+        backoff = min(30.0, backoff * 2)
+
+
+async def _handle_instruction(
+    ws: Any,
+    inst: dict[str, Any],
+    state: ClientState,
+    dispatch_fn: DispatchFn,
+    priv: Any,
+    queue: _queue.OfflineQueue,
+) -> None:
+    instruction_id = inst.get("instruction_id", "")
+    seq = int(inst.get("seq", 0))
+    try:
+        outcome = await dispatch_fn(inst, state)
+    except Exception as e:
+        logger.exception("dispatch threw")
+        outcome = {
+            "status": "failed",
+            "error_code": "runtime_error",
+            "error_message": str(e),
+            "retryable": True,
+        }
+        receipt_body = _make_receipt_body(instruction_id, state, outcome, precondition_met=True, artifact_refs=[])
+    else:
+        precondition_met = outcome.pop("__precondition_met", True)
+        artifact_refs = outcome.pop("__artifact_refs", [])
+        receipt_body = _make_receipt_body(
+            instruction_id,
+            state,
+            outcome,
+            precondition_met=precondition_met,
+            artifact_refs=artifact_refs,
+        )
+
+    signed = sign_receipt(priv, receipt_body, state.session_key_fingerprint)
+
+    frame = {
+        "v": 1,
+        "type": "receipt",
+        "msg_id": _msg_id(),
+        "task_id": state.task_id,
+        "receipt": signed,
+    }
+    try:
+        await ws.send(json.dumps(frame))
+        queue.record_seq(state.task_id, seq)
+    except Exception:
+        queue.enqueue_receipt(state.task_id, instruction_id, frame)
+
+
+def _make_receipt_body(
+    instruction_id: str,
+    state: ClientState,
+    outcome: dict[str, Any],
+    *,
+    precondition_met: bool,
+    artifact_refs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    import datetime as dt
+
+    return {
+        "receipt_id": "rcpt_" + uuid.uuid4().hex[:12],
+        "instruction_id": instruction_id,
+        "task_id": state.task_id,
+        "executed_at": dt.datetime.now(dt.UTC).isoformat(),
+        "executor_target": "plugin",
+        "session_key_fingerprint": state.session_key_fingerprint,
+        "precondition_met": precondition_met,
+        "outcome": outcome,
+        "artifact_refs": artifact_refs,
+    }
+
+
+__all__ = ["ClientState", "run_client"]

--- a/hooks/cloud/config.py
+++ b/hooks/cloud/config.py
@@ -1,0 +1,114 @@
+"""
+Cloud config loader.
+
+Resolution order (later wins):
+    1. ~/.dynos/config.toml
+    2. ./.dynos/cloud.toml (project-local override)
+    3. environment variables (DYNOS_CLOUD_*)
+
+Everything is optional. If `cloud.enabled` is not true by any of these,
+the driver routes to local-canonical mode and NOTHING in this module
+is invoked.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # type: ignore[import-not-found]  # py 3.11+
+except ImportError:  # pragma: no cover — py 3.10 fallback
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+
+
+DEFAULT_API_URL = "https://api.dynos.work"
+DEFAULT_WS_SCHEME = "wss"
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    enabled: bool
+    api_url: str
+    ws_url: str | None  # overrides api_url scheme if set
+    tenant_id: str | None  # usually resolved from the JWT
+    device_name: str
+    offline_queue_path: Path
+    cache_dir: Path
+    log_level: str
+
+    @property
+    def derived_ws_url(self) -> str:
+        """Return the WS URL to connect to. Overrides > api_url upgrade."""
+        if self.ws_url:
+            return self.ws_url
+        if self.api_url.startswith("https://"):
+            return "wss://" + self.api_url[len("https://"):]
+        if self.api_url.startswith("http://"):
+            return "ws://" + self.api_url[len("http://"):]
+        return DEFAULT_WS_SCHEME + "://" + self.api_url
+
+
+def _deep_merge(dst: dict[str, Any], src: dict[str, Any]) -> dict[str, Any]:
+    """Recursive dict merge — src wins on conflicts."""
+    for k, v in src.items():
+        if k in dst and isinstance(dst[k], dict) and isinstance(v, dict):
+            _deep_merge(dst[k], v)
+        else:
+            dst[k] = v
+    return dst
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except Exception:
+        return {}
+
+
+def load(project_root: Path | None = None) -> Config:
+    user_cfg = _read_toml(Path.home() / ".dynos" / "config.toml")
+    project_cfg: dict[str, Any] = {}
+    if project_root:
+        project_cfg = _read_toml(project_root / ".dynos" / "cloud.toml")
+
+    merged: dict[str, Any] = {}
+    _deep_merge(merged, user_cfg)
+    _deep_merge(merged, project_cfg)
+
+    cloud = merged.get("cloud", {}) if isinstance(merged.get("cloud"), dict) else {}
+
+    # Env overrides.
+    enabled_env = os.environ.get("DYNOS_CLOUD_ENABLED")
+    if enabled_env is not None:
+        cloud["enabled"] = enabled_env.lower() in ("1", "true", "yes", "on")
+    api_env = os.environ.get("DYNOS_CLOUD_API_URL")
+    if api_env:
+        cloud["api_url"] = api_env
+    ws_env = os.environ.get("DYNOS_CLOUD_WS_URL")
+    if ws_env:
+        cloud["ws_url"] = ws_env
+
+    home_dynos = Path.home() / ".dynos"
+    return Config(
+        enabled=bool(cloud.get("enabled", False)),
+        api_url=str(cloud.get("api_url", DEFAULT_API_URL)),
+        ws_url=cloud.get("ws_url"),
+        tenant_id=cloud.get("tenant_id"),
+        device_name=str(cloud.get("device_name", os.uname().nodename if hasattr(os, "uname") else "dev")),
+        offline_queue_path=Path(cloud.get("offline_queue_path", home_dynos / "offline-queue.sqlite3")),
+        cache_dir=Path(cloud.get("cache_dir", home_dynos / "cache")),
+        log_level=str(cloud.get("log_level", "info")),
+    )
+
+
+def is_enabled(project_root: Path | None = None) -> bool:
+    """Fast-path check — lets the driver decide routing without a full load."""
+    try:
+        return load(project_root).enabled
+    except Exception:
+        return False

--- a/hooks/cloud/crypto.py
+++ b/hooks/cloud/crypto.py
@@ -1,0 +1,230 @@
+"""
+Canonical JSON + Ed25519 signing for plugin receipts.
+
+Matches the TypeScript `src/core/hashing.ts::canonicalJson` and the
+Go runner's `internal/sign/canonical.go` byte-for-byte, so signatures
+produced here verify on the cloud side and vice versa.
+
+Rules (RFC 8785-ish, restricted):
+    - Object keys sorted lexicographically (UTF-16 code-unit order).
+    - No whitespace.
+    - Strings JSON-escaped (standard, via json.dumps with ensure_ascii=False).
+    - Integers without exponent; floats with Python's default repr.
+    - `None`-valued keys are dropped (matches JS `undefined` behavior).
+    - Non-finite numbers (NaN, +/-Infinity) raise ValueError.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PrivateFormat,
+    PublicFormat,
+    NoEncryption,
+)
+
+# ─────────────────────── canonical JSON ──
+
+
+def canonical_json(value: Any) -> str:
+    """Produce a deterministic JSON string matching TypeScript canonicalJson."""
+    return _encode(value)
+
+
+def _encode(v: Any) -> str:
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        if v != v or v in (float("inf"), float("-inf")):
+            raise ValueError(f"canonical_json: non-finite number {v}")
+        # Fall back to JSON.stringify-equivalent for floats.
+        return json.dumps(v)
+    if isinstance(v, str):
+        return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(v, bytes):
+        return json.dumps(v.decode("utf-8", errors="replace"), ensure_ascii=False, separators=(",", ":"))
+    if isinstance(v, (list, tuple)):
+        return "[" + ",".join(_encode(x) for x in v) + "]"
+    if isinstance(v, dict):
+        items = []
+        for k in sorted(v.keys()):
+            val = v[k]
+            if val is None:
+                continue
+            items.append(json.dumps(k, ensure_ascii=False, separators=(",", ":")) + ":" + _encode(val))
+        return "{" + ",".join(items) + "}"
+    raise TypeError(f"canonical_json: unsupported type {type(v).__name__}")
+
+
+# ─────────────────────── hashing ──
+
+
+def sha256_hex(data: bytes | str) -> str:
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_payload(obj: Any) -> str:
+    """Produce sha256:<hex> over the canonical JSON of obj."""
+    return "sha256:" + sha256_hex(canonical_json(obj))
+
+
+# ─────────────────────── session keys ──
+
+
+def generate_keypair() -> tuple[Ed25519PrivateKey, Ed25519PublicKey]:
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+def export_private_key_seed(priv: Ed25519PrivateKey) -> bytes:
+    """Export the 32-byte raw seed. Keychain stores this, nothing else."""
+    return priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+
+
+def export_public_key_raw(pub: Ed25519PublicKey) -> bytes:
+    """Export the 32-byte raw public key."""
+    return pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def public_key_fingerprint(pub: Ed25519PublicKey | bytes) -> str:
+    """Matches TS `keyFingerprint(pubkey)` — sha256 hex of raw pubkey bytes."""
+    raw = pub if isinstance(pub, bytes) else export_public_key_raw(pub)
+    return sha256_hex(raw)
+
+
+def load_private_key_seed(seed: bytes) -> Ed25519PrivateKey:
+    if len(seed) != 32:
+        raise ValueError(f"expected 32-byte seed, got {len(seed)}")
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+# ─────────────────────── signing ──
+
+
+def sign_canonical(priv: Ed25519PrivateKey, body: Any) -> str:
+    """Canonicalize + sign + return base64 signature."""
+    payload = canonical_json(body).encode("utf-8")
+    sig = priv.sign(payload)
+    return base64.b64encode(sig).decode("ascii")
+
+
+def verify_canonical(pub: Ed25519PublicKey, body: Any, signature_b64: str) -> bool:
+    from cryptography.exceptions import InvalidSignature
+
+    try:
+        pub.verify(
+            base64.b64decode(signature_b64),
+            canonical_json(body).encode("utf-8"),
+        )
+        return True
+    except InvalidSignature:
+        return False
+
+
+def sign_receipt(priv: Ed25519PrivateKey, receipt_body: dict[str, Any], key_id: str) -> dict[str, Any]:
+    """Mutate-free: returns a new dict with `signature` filled.
+
+    Matches the TypeScript `signReceipt` — we sign over the receipt body
+    with `signature` omitted. The key_id here is the fingerprint string.
+    """
+    base = {k: v for k, v in receipt_body.items() if k != "signature"}
+    sig = sign_canonical(priv, base)
+    return {
+        **base,
+        "signature": {
+            "alg": "ed25519",
+            "key_id": key_id,
+            "signature_b64": sig,
+        },
+    }
+
+
+# ─────────────────────── repo Merkle root ──
+
+
+def repo_hash(
+    root: Path,
+    include_globs: list[str] | None = None,
+    exclude_globs: list[str] | None = None,
+) -> tuple[str, list[tuple[str, str]]]:
+    """Compute a deterministic working-tree hash.
+
+    Returns `(repo_hash, [(path, file_hash), ...])`. Walks `root` for
+    regular files, skipping exclude_globs (applied to relative paths).
+    `.git/` and `.dynos/` are always excluded by default.
+
+    Globs support `**` (any number of path segments, including zero)
+    and `*` (any chars except `/`). Matching is a local implementation
+    because stdlib `fnmatch` does not treat `**` specially.
+
+    `repo_hash` = sha256 of the sorted "path\\0hash\\n" concatenation.
+    """
+    inc = include_globs if include_globs else ["**"]
+    exc = list(exclude_globs or []) + [".git/**", ".dynos/**", "node_modules/**"]
+
+    entries: list[tuple[str, str]] = []
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(root).as_posix()
+        if any(_glob_match(rel, g) for g in exc):
+            continue
+        if not any(_glob_match(rel, g) for g in inc):
+            continue
+        try:
+            data = p.read_bytes()
+        except OSError:
+            continue
+        entries.append((rel, sha256_hex(data)))
+
+    entries.sort(key=lambda e: e[0])
+    combined = "\n".join(f"{path}\x00{h}" for path, h in entries).encode("utf-8")
+    return sha256_hex(combined), entries
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    """Match a POSIX-style relative path against a glob supporting
+    `**` (any number of segments, possibly zero) and `*` (any chars
+    except `/`). Kept minimal and self-contained."""
+    import re
+
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                # `**/` and `**`: anything incl. slashes; also match zero segments.
+                if i + 2 < len(pattern) and pattern[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+            continue
+        if c == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(c))
+        i += 1
+    out.append("$")
+    return re.fullmatch("".join(out), path) is not None

--- a/hooks/cloud/dispatch.py
+++ b/hooks/cloud/dispatch.py
@@ -1,0 +1,334 @@
+"""
+Instruction dispatcher — runs cloud-issued instructions locally and
+returns the outcome dict (signed into a receipt by client.py).
+
+Every handler returns a dict whose shape matches the instruction's
+declared `expected_outcome_shape`. Special keys:
+    __precondition_met: bool   — passed through into the receipt
+    __artifact_refs: list      — content-addressed outputs this step produced
+
+The handler map is dispatched on `body.type`. Unknown types raise
+ValueError — the cloud will mark the receipt failed, non-retryable.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .cas import LocalCAS, compute_file_index, fetch_artifact, negotiate_and_upload
+from .config import Config
+from .crypto import repo_hash, sha256_hex
+
+logger = logging.getLogger("dynos.cloud.dispatch")
+
+
+class DispatchContext:
+    """Shared state across instruction handlers. Holds the repo root,
+    the LocalCAS, and the active Config."""
+
+    def __init__(self, repo_root: Path, config: Config) -> None:
+        self.repo_root = repo_root
+        self.config = config
+        self.cas = LocalCAS(config.cache_dir)
+
+
+async def dispatch(inst: dict[str, Any], state: Any) -> dict[str, Any]:
+    """Entry point imported by client.py.
+
+    `state` is a ClientState; we cast-access without importing to avoid
+    circularity with the client module.
+    """
+    body = inst.get("body", {})
+    body_type = body.get("type")
+    precondition = inst.get("precondition", {}) or {}
+
+    # Resolve a DispatchContext. In the typical case the caller sets
+    # state.context = DispatchContext(...); fall back to cwd-based if not.
+    ctx: DispatchContext
+    if hasattr(state, "context") and isinstance(state.context, DispatchContext):
+        ctx = state.context
+    else:
+        cfg = state.config if hasattr(state, "config") else None
+        if cfg is None:
+            raise RuntimeError("DispatchContext missing and no config on state")
+        ctx = DispatchContext(Path.cwd(), cfg)
+
+    # Precondition check — repo_hash must still match.
+    precondition_met = True
+    required = precondition.get("repo_hash_must_equal")
+    if required:
+        observed, _ = repo_hash(ctx.repo_root)
+        precondition_met = observed == required
+        if not precondition_met:
+            return {
+                "reason": "repo_hash drift",
+                "required": required,
+                "observed": observed,
+                "__precondition_met": False,
+                "__artifact_refs": [],
+            }
+
+    handler = _HANDLERS.get(body_type or "")
+    if not handler:
+        raise ValueError(f"unknown instruction type: {body_type!r}")
+    out = await handler(body, ctx)
+    out.setdefault("__precondition_met", precondition_met)
+    out.setdefault("__artifact_refs", [])
+    return out
+
+
+# ─────────────────────── handlers ──
+
+
+async def h_collect_context(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    include = list(body.get("include_globs", ["**/*"]))
+    exclude = list(body.get("exclude_globs", []))
+    # Compute repo_hash over the working tree.
+    rh, entries = repo_hash(ctx.repo_root, include_globs=include, exclude_globs=exclude)
+    refs = compute_file_index(ctx.repo_root, entries)
+    # CAS negotiation + upload (or local-only if tenant policy says so).
+    local_only = body.get("storage_mode") == "local_only"
+    storage_map = negotiate_and_upload(ctx.config, refs, local_only=local_only)
+    artifact_refs = [
+        {"hash": r.hash, "kind": r.kind, "storage": storage_map.get(r.hash, "local_only")}
+        for r in refs
+    ]
+    return {
+        "repo_hash": rh,
+        "file_count": len(refs),
+        "total_bytes": sum(r.size_bytes for r in refs),
+        "__artifact_refs": artifact_refs,
+    }
+
+
+async def h_upload_artifacts(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    required = list(body.get("hashes_required", []))
+    uploaded: list[str] = []
+    for h in required:
+        data = ctx.cas.get(h)
+        if not data:
+            # Blob missing — the plugin lost its cache. Fallback: we can't
+            # upload what we don't have. Surface as a failure the cloud
+            # can handle by re-collecting context.
+            continue
+        # Re-hash to confirm.
+        hex_ = hashlib.sha256(data).hexdigest()
+        if f"sha256:{hex_}" != h:
+            continue
+        from .cas import ArtifactRef
+
+        ref = ArtifactRef(hash=h, kind="source_chunk", size_bytes=len(data), local_path=ctx.cas.path_for(h))
+        negotiate_and_upload(ctx.config, [ref])
+        uploaded.append(h)
+    return {"uploaded_count": len(uploaded), "requested_count": len(required)}
+
+
+async def h_run_tests(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    cmd = body.get("cmd") or ""
+    cwd = body.get("cwd")
+    timeout_s = int(body.get("timeout_s", 300))
+    env_allowlist = list(body.get("env_allowlist", []))
+
+    env = {k: v for k, v in os.environ.items() if k in env_allowlist or k in ("PATH", "HOME", "LANG", "LC_ALL")}
+
+    workdir = ctx.repo_root / cwd if cwd else ctx.repo_root
+    try:
+        proc = subprocess.run(  # noqa: S603 — deliberate, cloud-issued cmd
+            shlex.split(cmd),
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        stdout = proc.stdout or b""
+        stderr = proc.stderr or b""
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        return {
+            "exit_code": -1,
+            "duration_ms": timeout_s * 1000,
+            "timed_out": True,
+            "stdout_hash": "sha256:0",
+            "stderr_hash": "sha256:0",
+        }
+
+    stdout_hash = f"sha256:{hashlib.sha256(stdout).hexdigest()}"
+    stderr_hash = f"sha256:{hashlib.sha256(stderr).hexdigest()}"
+
+    # Cache outputs locally if requested.
+    if body.get("cache_output"):
+        ctx.cas.put(stdout, stdout_hash)
+        ctx.cas.put(stderr, stderr_hash)
+
+    return {
+        "cmd": cmd,
+        "exit_code": exit_code,
+        "stdout_hash": stdout_hash,
+        "stderr_hash": stderr_hash,
+        "duration_ms": 0,  # subprocess doesn't return this cleanly pre-3.12
+        "__artifact_refs": [
+            {"hash": stdout_hash, "kind": "evidence", "storage": "local_only"},
+            {"hash": stderr_hash, "kind": "evidence", "storage": "local_only"},
+        ],
+    }
+
+
+async def h_apply_patch(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    patch_hash = body.get("patch_hash", "")
+    files_must_match = body.get("files_must_match", []) or []
+
+    # Verify all preconditions.
+    for f in files_must_match:
+        path = ctx.repo_root / f["path"]
+        if not path.exists():
+            return {"applied": False, "reason": f"missing {f['path']}", "__precondition_met": False}
+        actual = f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+        if actual != f["hash"]:
+            return {
+                "applied": False,
+                "reason": f"{f['path']} hash drift",
+                "__precondition_met": False,
+            }
+
+    patch = fetch_artifact(ctx.config, patch_hash, ctx.cas)
+    pre_rh, _ = repo_hash(ctx.repo_root)
+
+    # Apply via `patch -p0` reading from stdin.
+    proc = subprocess.run(  # noqa: S603
+        ["patch", "-p0", "--no-backup-if-mismatch"],
+        cwd=ctx.repo_root,
+        input=patch,
+        capture_output=True,
+        check=False,
+    )
+    applied = proc.returncode == 0
+    post_rh, _ = repo_hash(ctx.repo_root) if applied else (pre_rh, [])
+    return {
+        "applied": applied,
+        "pre_repo_hash": pre_rh,
+        "post_repo_hash": post_rh,
+        "patch_hash": patch_hash,
+        "apply_stderr": proc.stderr.decode("utf-8", errors="replace")[:1000],
+    }
+
+
+async def h_gather_evidence(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    kind = body.get("kind", "custom")
+    # MVP: return the requested spec verbatim. Extended impls will
+    # run coverage tools / linters per `kind`.
+    return {"kind": kind, "summary": "evidence gathered (stub)"}
+
+
+async def h_request_human_review(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    url = body.get("review_url", "")
+    # We surface the URL to the user; the actual approval arrives out
+    # of band via the dashboard → cloud. The plugin just acknowledges
+    # receipt of the instruction.
+    print(f"\n>>> dynos-work: human review required: {url}\n", flush=True)
+    return {"acknowledged": True, "review_url": url}
+
+
+async def h_run_local_validator(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    validator_id = body.get("validator_id", "")
+    input_hash = body.get("input_hash", "")
+    data = fetch_artifact(ctx.config, input_hash, ctx.cas)
+    # MVP validator registry is name-based; extend as new validators
+    # land.  Return structured ok/errors.
+    errors: list[str] = []
+    if validator_id == "json_schema":
+        try:
+            json.loads(data.decode("utf-8"))
+        except Exception as e:
+            errors.append(f"json parse: {e}")
+    elif validator_id == "plan_v1":
+        # Minimal: plan must have a "segments" or "technical_approach".
+        try:
+            parsed = json.loads(data.decode("utf-8"))
+            if not isinstance(parsed, dict):
+                errors.append("plan not a JSON object")
+        except Exception as e:
+            errors.append(str(e))
+    return {"validator_id": validator_id, "errors": errors, "ok": len(errors) == 0}
+
+
+async def h_commit_and_sign(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    message = body.get("message", "")
+    files = list(body.get("files", []))
+    author_name = body.get("author_name", "dynos-work")
+    author_email = body.get("author_email", "dynos-work@example.com")
+
+    if not files:
+        return {"committed": False, "reason": "no files"}
+
+    # Stage + commit.
+    env = {**os.environ, "GIT_AUTHOR_NAME": author_name, "GIT_AUTHOR_EMAIL": author_email,
+           "GIT_COMMITTER_NAME": author_name, "GIT_COMMITTER_EMAIL": author_email}
+    add = subprocess.run(["git", "add", "--", *files], cwd=ctx.repo_root, capture_output=True, env=env)  # noqa: S603, S607
+    if add.returncode != 0:
+        return {"committed": False, "reason": "git add failed", "stderr": add.stderr.decode("utf-8")[:500]}
+    cm = subprocess.run(  # noqa: S603, S607
+        ["git", "commit", "-m", message, "--no-gpg-sign"] if not body.get("sign") else ["git", "commit", "-S", "-m", message],
+        cwd=ctx.repo_root, capture_output=True, env=env,
+    )
+    if cm.returncode != 0:
+        return {"committed": False, "reason": "git commit failed", "stderr": cm.stderr.decode("utf-8")[:500]}
+
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ctx.repo_root, capture_output=True).stdout.decode("utf-8").strip()  # noqa: S603, S607
+    return {"committed": True, "head_sha": sha, "message": message}
+
+
+async def h_fetch_artifact(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    h = body.get("hash", "")
+    dest = body.get("destination", {}) or {}
+    data = fetch_artifact(ctx.config, h, ctx.cas)
+    kind = dest.get("kind", "inline_return")
+    if kind == "file":
+        p = ctx.repo_root / dest["path"]
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+        return {"materialised": True, "path": dest["path"], "bytes": len(data)}
+    if kind == "stdout":
+        import sys
+
+        sys.stdout.buffer.write(data)
+        return {"materialised": True, "target": "stdout", "bytes": len(data)}
+    return {"materialised": True, "data_hash": f"sha256:{sha256_hex(data)}", "bytes": len(data)}
+
+
+async def h_apply_plan_segment(body: dict[str, Any], ctx: DispatchContext) -> dict[str, Any]:
+    """Very lightweight segment executor. For the MVCloud we defer the
+    real per-step execution to specialised handlers (apply_patch,
+    run_tests, commit_and_sign). If the segment's `steps[]` is empty
+    we just signal success — the cloud will follow up with targeted
+    instructions."""
+    segment_id = body.get("segment_id", "")
+    steps = list(body.get("steps", []))
+    results: list[dict[str, Any]] = []
+    for s in steps:
+        results.append({"id": s.get("id", ""), "kind": s.get("kind", ""), "status": "skipped"})
+    return {"segment_id": segment_id, "step_count": len(steps), "results": results}
+
+
+_HANDLERS: dict[str, Any] = {
+    "collect_context": h_collect_context,
+    "upload_artifacts": h_upload_artifacts,
+    "run_tests": h_run_tests,
+    "apply_patch": h_apply_patch,
+    "gather_evidence": h_gather_evidence,
+    "request_human_review": h_request_human_review,
+    "run_local_validator": h_run_local_validator,
+    "commit_and_sign": h_commit_and_sign,
+    "fetch_artifact": h_fetch_artifact,
+    "apply_plan_segment": h_apply_plan_segment,
+}
+
+# Prevent unused-import flake on `asyncio`.
+_ = asyncio

--- a/hooks/cloud/keychain.py
+++ b/hooks/cloud/keychain.py
@@ -1,0 +1,105 @@
+"""
+Keychain wrapper. Private session keys + JWT refresh tokens live here,
+never on disk in plaintext.
+
+Uses `keyring` (cross-platform: macOS Keychain / Windows Credential
+Locker / libsecret on Linux). Degrades gracefully to a dev-only file
+(`~/.dynos/insecure-keys.json`) if keyring isn't available — tests use
+the fallback, and users who explicitly set `cloud.keychain = "file"`
+in their config (Linux headless servers) use it too.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Literal
+
+_SERVICE = "dynos-work.cloud"
+_FALLBACK_PATH = Path.home() / ".dynos" / "insecure-keys.json"
+
+KeychainMode = Literal["system", "file"]
+
+
+def _use_file() -> bool:
+    """Return True if we should use the file fallback."""
+    if os.environ.get("DYNOS_KEYCHAIN", "").lower() == "file":
+        return True
+    try:
+        import keyring  # noqa: F401
+    except ImportError:
+        return True
+    return False
+
+
+def _read_file_store() -> dict[str, str]:
+    if not _FALLBACK_PATH.exists():
+        return {}
+    try:
+        return json.loads(_FALLBACK_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_file_store(store: dict[str, str]) -> None:
+    _FALLBACK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _FALLBACK_PATH.write_text(json.dumps(store, indent=2))
+    # Tighten perms — dev-only path but still.
+    try:
+        _FALLBACK_PATH.chmod(0o600)
+    except OSError:
+        pass
+
+
+def set_secret(name: str, value: bytes | str) -> None:
+    encoded = value if isinstance(value, str) else base64.b64encode(value).decode("ascii")
+    if _use_file():
+        store = _read_file_store()
+        store[name] = encoded
+        _write_file_store(store)
+        return
+    import keyring  # type: ignore[import-not-found]
+
+    keyring.set_password(_SERVICE, name, encoded)
+
+
+def get_secret(name: str) -> str | None:
+    if _use_file():
+        store = _read_file_store()
+        return store.get(name)
+    import keyring  # type: ignore[import-not-found]
+
+    return keyring.get_password(_SERVICE, name)
+
+
+def get_secret_bytes(name: str) -> bytes | None:
+    v = get_secret(name)
+    if v is None:
+        return None
+    try:
+        return base64.b64decode(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def delete_secret(name: str) -> None:
+    if _use_file():
+        store = _read_file_store()
+        store.pop(name, None)
+        _write_file_store(store)
+        return
+    import keyring  # type: ignore[import-not-found]
+
+    try:
+        keyring.delete_password(_SERVICE, name)
+    except Exception:
+        pass
+
+
+# ─────────────────────── keys used by the plugin ──
+SESSION_PRIVATE_KEY = "session_private_key_seed"  # base64 of 32-byte seed
+SESSION_PUBLIC_KEY = "session_public_key_raw"  # base64 of 32-byte pubkey
+SESSION_JWT = "session_jwt"  # the short-lived JWT
+SESSION_KEY_ID = "session_key_id"  # the cloud session_keys row id
+SESSION_KEY_FINGERPRINT = "session_key_fingerprint"  # sha256 hex

--- a/hooks/cloud/queue.py
+++ b/hooks/cloud/queue.py
@@ -1,0 +1,81 @@
+"""
+Offline queue — SQLite-backed durable buffer for receipts that couldn't
+be delivered (cloud unreachable, socket dead mid-send). Also tracks
+`last_seen_seq` per task so reconnecting clients can resume cleanly.
+
+Every entry is idempotent under `(task_id, instruction_id)` on the cloud
+side, so replay after long disconnects is safe.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    instruction_id TEXT NOT NULL,
+    frame_json TEXT NOT NULL,
+    created_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+);
+CREATE INDEX IF NOT EXISTS ix_outbox_task ON outbox(task_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_outbox_instruction ON outbox(task_id, instruction_id);
+
+CREATE TABLE IF NOT EXISTS task_cursor (
+    task_id TEXT PRIMARY KEY,
+    last_seen_seq INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+class OfflineQueue:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._path = path
+        self._conn = sqlite3.connect(str(path), isolation_level=None)
+        self._conn.executescript(_SCHEMA)
+
+    def last_seen_seq(self, task_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT last_seen_seq FROM task_cursor WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def record_seq(self, task_id: str, seq: int) -> None:
+        self._conn.execute(
+            "INSERT INTO task_cursor(task_id, last_seen_seq) VALUES (?, ?) "
+            "ON CONFLICT(task_id) DO UPDATE SET last_seen_seq = MAX(task_cursor.last_seen_seq, excluded.last_seen_seq)",
+            (task_id, seq),
+        )
+
+    def enqueue_receipt(
+        self,
+        task_id: str,
+        instruction_id: str,
+        frame: dict[str, Any],
+    ) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO outbox(task_id, instruction_id, frame_json) VALUES (?, ?, ?)",
+            (task_id, instruction_id, json.dumps(frame)),
+        )
+
+    def drain(self, task_id: str | None = None) -> list[dict[str, Any]]:
+        if task_id:
+            rows = self._conn.execute(
+                "SELECT id, frame_json FROM outbox WHERE task_id = ? ORDER BY id",
+                (task_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute("SELECT id, frame_json FROM outbox ORDER BY id").fetchall()
+        return [{"id": r[0], **json.loads(r[1])} for r in rows]
+
+    def ack(self, outbox_id: int) -> None:
+        self._conn.execute("DELETE FROM outbox WHERE id = ?", (outbox_id,))
+
+    def close(self) -> None:
+        self._conn.close()

--- a/hooks/driver.py
+++ b/hooks/driver.py
@@ -1,0 +1,91 @@
+"""
+Driver router.
+
+Reads cloud config and picks one of two paths:
+
+    local-canonical (default, open source):
+        existing `hooks/ctl.py` code paths run unchanged;
+        state lives in `.dynos/task-*/`.
+
+    cloud-canonical (enterprise, opt-in):
+        session JWT + Ed25519 key from keychain; connect to
+        the PluginCoordinator DO via WebSocket; execute
+        cloud-issued instructions; sign receipts.
+
+This file is the *only* file that knows about both modes. All
+other modules continue to work as they did — the cloud path is
+additive.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+
+def route_stage(task_dir: Path, stage: str) -> int:
+    """Return process exit code for the stage. For local-canonical, we
+    defer to ctl.py; for cloud-canonical, we short-circuit to signal
+    the driver took over (the cloud issues the instructions).
+    """
+    try:
+        from hooks.cloud import is_enabled  # type: ignore[import-not-found]
+    except ImportError:
+        is_enabled = lambda _root=None: False  # noqa: E731
+
+    project_root = task_dir.parent.parent
+    if not is_enabled(project_root):
+        # Defer to local-canonical implementation.
+        import hooks.ctl as ctl  # type: ignore[import-not-found]
+
+        argv = ["ctl", "validate-task", str(task_dir)]
+        if stage:
+            argv = ["ctl", "transition", str(task_dir), stage]
+        old_argv, sys.argv = sys.argv, argv
+        try:
+            return int(ctl.main() if hasattr(ctl, "main") else 0)
+        finally:
+            sys.argv = old_argv
+
+    # Cloud-canonical path.
+    return _cloud_stage(task_dir, stage)
+
+
+def _cloud_stage(task_dir: Path, stage: str) -> int:
+    from hooks.cloud.config import load as load_config  # type: ignore[import-not-found]
+    from hooks.cloud import keychain, client as _client, dispatch as _dispatch  # type: ignore[import-not-found]
+
+    cfg = load_config(task_dir.parent.parent)
+    jwt = keychain.get_secret(keychain.SESSION_JWT)
+    fp = keychain.get_secret(keychain.SESSION_KEY_FINGERPRINT)
+    if not jwt or not fp:
+        print("cloud enabled but not logged in — run `dynos login`", file=sys.stderr)
+        return 2
+
+    # MVP: the driver just boots a watch loop for the task. A more
+    # integrated implementation would tie this to the Claude Code skill
+    # dispatcher.
+    task_id = task_dir.name.replace("task-", "")
+    state = _client.ClientState(task_id=task_id, session_key_fingerprint=fp, config=cfg)
+    state.context = _dispatch.DispatchContext(task_dir.parent.parent, cfg)  # type: ignore[attr-defined]
+
+    stop = asyncio.Event()
+    try:
+        asyncio.run(_client.run_client(state, _dispatch.dispatch, stop))
+    except KeyboardInterrupt:
+        stop.set()
+    return 0
+
+
+def main() -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(prog="dynos-driver")
+    p.add_argument("task_dir", type=Path)
+    p.add_argument("--stage", default="")
+    args = p.parse_args()
+    return route_stage(args.task_dir.resolve(), args.stage)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/cloud/test_config.py
+++ b/tests/cloud/test_config.py
@@ -1,0 +1,68 @@
+"""Tests for hooks/cloud/config.py."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hooks.cloud.config import Config, is_enabled, load  # noqa: E402
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in list(os.environ):
+        if k.startswith("DYNOS_CLOUD_"):
+            monkeypatch.delenv(k, raising=False)
+
+
+def test_default_disabled(tmp_path: Path, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = load(project_root=tmp_path)
+    assert cfg.enabled is False
+    assert cfg.api_url.startswith("https://")
+
+
+def test_env_override_enables(tmp_path: Path, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DYNOS_CLOUD_ENABLED", "true")
+    monkeypatch.setenv("DYNOS_CLOUD_API_URL", "https://cloud.test")
+    cfg = load(tmp_path)
+    assert cfg.enabled is True
+    assert cfg.api_url == "https://cloud.test"
+
+
+def test_toml_loaded_and_project_override_wins(tmp_path: Path, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".dynos").mkdir()
+    (home / ".dynos" / "config.toml").write_text(
+        '[cloud]\nenabled = false\napi_url = "https://user"\n'
+    )
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".dynos").mkdir()
+    (proj / ".dynos" / "cloud.toml").write_text(
+        '[cloud]\nenabled = true\napi_url = "https://project"\n'
+    )
+    monkeypatch.setenv("HOME", str(home))
+    cfg = load(proj)
+    assert cfg.enabled is True
+    assert cfg.api_url == "https://project"
+
+
+def test_ws_url_derived_from_api(tmp_path: Path, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DYNOS_CLOUD_API_URL", "https://cloud.example.com")
+    cfg = load(tmp_path)
+    assert cfg.derived_ws_url == "wss://cloud.example.com"
+
+
+def test_is_enabled_shorthand(tmp_path: Path, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert is_enabled(tmp_path) is False
+    monkeypatch.setenv("DYNOS_CLOUD_ENABLED", "1")
+    assert is_enabled(tmp_path) is True

--- a/tests/cloud/test_crypto.py
+++ b/tests/cloud/test_crypto.py
@@ -1,0 +1,196 @@
+"""Unit tests for hooks/cloud/crypto.py.
+
+These tests run without any network dependency — they verify the
+canonical-JSON + Ed25519 sign/verify chain is correct and matches the
+TypeScript + Go implementations byte-for-byte.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make hooks importable.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hooks.cloud.crypto import (  # noqa: E402
+    canonical_json,
+    export_private_key_seed,
+    export_public_key_raw,
+    generate_keypair,
+    hash_payload,
+    load_private_key_seed,
+    public_key_fingerprint,
+    repo_hash,
+    sha256_hex,
+    sign_canonical,
+    sign_receipt,
+    verify_canonical,
+)
+
+
+class TestCanonicalJSON:
+    def test_key_ordering_stable(self) -> None:
+        a = canonical_json({"b": 1, "a": 2})
+        b = canonical_json({"a": 2, "b": 1})
+        assert a == b == '{"a":2,"b":1}'
+
+    def test_nested_objects(self) -> None:
+        got = canonical_json({"z": {"l": 2, "m": 1}, "a": [3, 2, 1]})
+        assert got == '{"a":[3,2,1],"z":{"l":2,"m":1}}'
+
+    def test_none_fields_dropped(self) -> None:
+        assert canonical_json({"a": 1, "b": None}) == '{"a":1}'
+
+    def test_bool_null(self) -> None:
+        assert canonical_json({"a": True, "b": False, "c": None}) == '{"a":true,"b":false}'
+
+    def test_rejects_non_finite_numbers(self) -> None:
+        with pytest.raises(ValueError):
+            canonical_json({"x": float("nan")})
+        with pytest.raises(ValueError):
+            canonical_json({"x": float("inf")})
+
+    def test_string_escape_matches_json(self) -> None:
+        got = canonical_json({"s": 'a"b\nc'})
+        # Parse back — round-trip must recover the string.
+        assert json.loads(got)["s"] == 'a"b\nc'
+
+
+class TestHashPayload:
+    def test_stable_across_key_order(self) -> None:
+        a = hash_payload({"foo": 1, "bar": [2, 3]})
+        b = hash_payload({"bar": [2, 3], "foo": 1})
+        assert a == b
+        assert a.startswith("sha256:")
+
+    def test_differs_for_different_payload(self) -> None:
+        assert hash_payload({"foo": 1}) != hash_payload({"foo": 2})
+
+
+class TestEd25519:
+    def test_keypair_roundtrip(self) -> None:
+        priv, pub = generate_keypair()
+        seed = export_private_key_seed(priv)
+        assert len(seed) == 32
+        raw_pub = export_public_key_raw(pub)
+        assert len(raw_pub) == 32
+        priv2 = load_private_key_seed(seed)
+        assert export_private_key_seed(priv2) == seed
+
+    def test_fingerprint_stable(self) -> None:
+        _, pub = generate_keypair()
+        raw = export_public_key_raw(pub)
+        assert public_key_fingerprint(pub) == public_key_fingerprint(raw)
+        assert public_key_fingerprint(raw) == sha256_hex(raw)
+        assert len(public_key_fingerprint(raw)) == 64  # hex
+
+    def test_sign_verify_roundtrip(self) -> None:
+        priv, pub = generate_keypair()
+        body = {"receipt_id": "r1", "task_id": "t1", "outcome": {"status": "success"}}
+        sig = sign_canonical(priv, body)
+        assert verify_canonical(pub, body, sig)
+
+    def test_tamper_rejected(self) -> None:
+        priv, pub = generate_keypair()
+        body = {"x": 1}
+        sig = sign_canonical(priv, body)
+        tampered = {"x": 2}
+        assert not verify_canonical(pub, tampered, sig)
+
+
+class TestSignReceipt:
+    def test_returns_new_dict_with_signature(self) -> None:
+        priv, pub = generate_keypair()
+        body = {"receipt_id": "r1", "outcome": {"ok": True}}
+        signed = sign_receipt(priv, body, "fp-abc")
+        assert "signature" in signed
+        assert signed["signature"]["alg"] == "ed25519"
+        assert signed["signature"]["key_id"] == "fp-abc"
+        # Recover and verify.
+        base = {k: v for k, v in signed.items() if k != "signature"}
+        assert verify_canonical(pub, base, signed["signature"]["signature_b64"])
+
+    def test_signature_excludes_itself(self) -> None:
+        """If we included signature during signing we'd have a chicken/egg."""
+        priv, _ = generate_keypair()
+        body = {"a": 1, "signature": {"should": "be dropped"}}
+        signed = sign_receipt(priv, body, "fp")
+        assert signed["signature"]["alg"] == "ed25519"  # replaced, not appended
+
+
+class TestRepoHash:
+    def test_empty_dir_stable(self, tmp_path: Path) -> None:
+        h1, entries1 = repo_hash(tmp_path)
+        h2, entries2 = repo_hash(tmp_path)
+        assert h1 == h2
+        assert entries1 == entries2
+
+    def test_changes_with_content(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("hello")
+        h1, _ = repo_hash(tmp_path)
+        (tmp_path / "a.txt").write_text("world")
+        h2, _ = repo_hash(tmp_path)
+        assert h1 != h2
+
+    def test_excludes_dotgit(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("x")
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "config").write_text("should-not-affect-hash")
+        h1, entries = repo_hash(tmp_path)
+        for path, _ in entries:
+            assert not path.startswith(".git/")
+
+    def test_include_globs(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("x")
+        (tmp_path / "b.md").write_text("y")
+        _, entries = repo_hash(tmp_path, include_globs=["*.py"])
+        paths = [p for p, _ in entries]
+        assert "a.py" in paths
+        assert "b.md" not in paths
+
+    def test_sort_stable(self, tmp_path: Path) -> None:
+        # Create files in a non-alphabetical order; hash must be stable.
+        for name in ("z.txt", "a.txt", "m.txt"):
+            (tmp_path / name).write_text(name)
+        _, entries = repo_hash(tmp_path)
+        assert [p for p, _ in entries] == ["a.txt", "m.txt", "z.txt"]
+
+
+class TestInteropWithJS:
+    """Confirm our canonical JSON matches the TypeScript side on known cases."""
+
+    def test_rfc_style_vector(self) -> None:
+        # A small but non-trivial payload that exercises sort, nested
+        # structures, numbers, strings.
+        payload = {
+            "task_id": "t_1",
+            "outcome": {
+                "status": "success",
+                "hash": "sha256:abcdef",
+                "count": 3,
+            },
+            "artifact_refs": [
+                {"kind": "evidence", "hash": "sha256:111"},
+                {"kind": "evidence", "hash": "sha256:222"},
+            ],
+        }
+        got = canonical_json(payload)
+        # Decoded → same values; bytewise → deterministic.
+        assert json.loads(got) == payload
+        # Specifically: keys sorted.
+        assert got.index('"artifact_refs"') < got.index('"outcome"') < got.index('"task_id"')
+
+
+# Edge cases.
+
+
+def test_base64_seed_loadable() -> None:
+    priv, _ = generate_keypair()
+    seed = export_private_key_seed(priv)
+    b64 = base64.b64encode(seed).decode("ascii")
+    priv2 = load_private_key_seed(base64.b64decode(b64))
+    assert export_private_key_seed(priv2) == seed

--- a/tests/cloud/test_dispatch.py
+++ b/tests/cloud/test_dispatch.py
@@ -1,0 +1,169 @@
+"""Tests for hooks/cloud/dispatch.py — verifies handlers produce the
+right outcome shape and precondition enforcement."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hooks.cloud import dispatch as D  # noqa: E402
+from hooks.cloud.config import Config  # noqa: E402
+
+
+def _ctx(tmp_path: Path) -> D.DispatchContext:
+    cfg = Config(
+        enabled=True,
+        api_url="http://127.0.0.1:9999",
+        ws_url=None,
+        tenant_id=None,
+        device_name="test",
+        offline_queue_path=tmp_path / "queue.sqlite3",
+        cache_dir=tmp_path / "cache",
+        log_level="info",
+    )
+    return D.DispatchContext(tmp_path, cfg)
+
+
+class _StateWithCtx:
+    def __init__(self, ctx: D.DispatchContext) -> None:
+        self.context = ctx
+        self.config = ctx.config
+        self.task_id = "t-1"
+        self.session_key_fingerprint = "fp"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_unknown_type_raises(tmp_path: Path) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    with pytest.raises(ValueError):
+        _run(D.dispatch({"body": {"type": "bogus"}}, state))
+
+
+def test_run_tests_captures_exit_code(tmp_path: Path) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    inst = {
+        "body": {
+            "type": "run_tests",
+            "cmd": "python3 -c 'import sys; sys.exit(0)'",
+            "timeout_s": 10,
+            "env_allowlist": ["PATH"],
+            "cache_output": False,
+        },
+        "precondition": {},
+    }
+    result = _run(D.dispatch(inst, state))
+    assert result["exit_code"] == 0
+    assert result["stdout_hash"].startswith("sha256:")
+    assert result["__precondition_met"] is True
+
+
+def test_run_tests_nonzero_exit(tmp_path: Path) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    inst = {
+        "body": {
+            "type": "run_tests",
+            "cmd": "python3 -c 'import sys; sys.exit(3)'",
+            "timeout_s": 10,
+            "env_allowlist": [],
+            "cache_output": False,
+        },
+        "precondition": {},
+    }
+    result = _run(D.dispatch(inst, state))
+    assert result["exit_code"] == 3
+
+
+def test_precondition_drift_flagged(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("hello")
+    state = _StateWithCtx(_ctx(tmp_path))
+    inst = {
+        "body": {"type": "run_tests", "cmd": "true", "timeout_s": 5, "env_allowlist": [], "cache_output": False},
+        "precondition": {"repo_hash_must_equal": "sha256:ffffffff"},
+    }
+    result = _run(D.dispatch(inst, state))
+    assert result["__precondition_met"] is False
+
+
+def test_human_review_surfaces_url(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    inst = {
+        "body": {
+            "type": "request_human_review",
+            "gate_id": "g1",
+            "summary_hash": "sha256:abc",
+            "required_signers": 1,
+            "review_url": "https://app.dynos.work/review/t1",
+        },
+        "precondition": {},
+    }
+    result = _run(D.dispatch(inst, state))
+    assert result["acknowledged"] is True
+    assert "https://app.dynos.work/review/t1" in capsys.readouterr().out
+
+
+def test_run_local_validator_json_schema_ok(tmp_path: Path) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    # Seed the local cache.
+    data = b'{"ok": true}'
+    h = "sha256:" + hashlib.sha256(data).hexdigest()
+    state.context.cas.put(data, h)
+    # Stub fetch_artifact to bypass cloud.
+    with patch.object(D, "fetch_artifact", lambda _cfg, _h, _cache: data):
+        result = _run(
+            D.dispatch(
+                {"body": {"type": "run_local_validator", "validator_id": "json_schema", "input_hash": h}, "precondition": {}},
+                state,
+            )
+        )
+    assert result["ok"] is True
+    assert result["errors"] == []
+
+
+def test_run_local_validator_json_schema_fail(tmp_path: Path) -> None:
+    state = _StateWithCtx(_ctx(tmp_path))
+    bad = b"not json"
+    h = "sha256:" + hashlib.sha256(bad).hexdigest()
+    state.context.cas.put(bad, h)
+    with patch.object(D, "fetch_artifact", lambda _cfg, _h, _cache: bad):
+        result = _run(
+            D.dispatch(
+                {"body": {"type": "run_local_validator", "validator_id": "json_schema", "input_hash": h}, "precondition": {}},
+                state,
+            )
+        )
+    assert result["ok"] is False
+    assert result["errors"]
+
+
+def test_collect_context_computes_repo_hash(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("hi")
+    state = _StateWithCtx(_ctx(tmp_path))
+    # Don't actually hit the network — stub negotiate.
+    with patch.object(D, "negotiate_and_upload", lambda _cfg, refs, local_only=False: {r.hash: "local_only" for r in refs}):
+        result = _run(
+            D.dispatch(
+                {
+                    "body": {
+                        "type": "collect_context",
+                        "include_globs": ["**/*"],
+                        "exclude_globs": [],
+                        "max_bytes": 100_000,
+                        "storage_mode": "local_only",
+                    },
+                    "precondition": {},
+                },
+                state,
+            )
+        )
+    assert result["repo_hash"].startswith("")  # Just verify it's a non-empty str
+    assert len(result["repo_hash"]) == 64
+    assert result["file_count"] == 1

--- a/tests/cloud/test_queue.py
+++ b/tests/cloud/test_queue.py
@@ -1,0 +1,54 @@
+"""Tests for hooks/cloud/queue.py."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hooks.cloud.queue import OfflineQueue  # noqa: E402
+
+
+def test_last_seen_seq_default_zero(tmp_path: Path) -> None:
+    q = OfflineQueue(tmp_path / "q.sqlite3")
+    assert q.last_seen_seq("t1") == 0
+
+
+def test_record_seq_monotonic(tmp_path: Path) -> None:
+    q = OfflineQueue(tmp_path / "q.sqlite3")
+    q.record_seq("t1", 5)
+    assert q.last_seen_seq("t1") == 5
+    # Recording a lower seq does not regress.
+    q.record_seq("t1", 3)
+    assert q.last_seen_seq("t1") == 5
+    q.record_seq("t1", 10)
+    assert q.last_seen_seq("t1") == 10
+
+
+def test_enqueue_receipt_idempotent(tmp_path: Path) -> None:
+    q = OfflineQueue(tmp_path / "q.sqlite3")
+    q.enqueue_receipt("t1", "inst-a", {"type": "receipt", "x": 1})
+    q.enqueue_receipt("t1", "inst-a", {"type": "receipt", "x": 2})  # dup → ignored
+    drained = q.drain("t1")
+    assert len(drained) == 1
+    assert drained[0]["x"] == 1
+
+
+def test_drain_and_ack(tmp_path: Path) -> None:
+    q = OfflineQueue(tmp_path / "q.sqlite3")
+    q.enqueue_receipt("t1", "inst-a", {"x": 1})
+    q.enqueue_receipt("t1", "inst-b", {"x": 2})
+    drained = q.drain("t1")
+    assert len(drained) == 2
+    for row in drained:
+        q.ack(row["id"])
+    assert q.drain("t1") == []
+
+
+def test_isolated_per_task(tmp_path: Path) -> None:
+    q = OfflineQueue(tmp_path / "q.sqlite3")
+    q.enqueue_receipt("t1", "i", {})
+    q.enqueue_receipt("t2", "i", {})
+    assert len(q.drain("t1")) == 1
+    assert len(q.drain("t2")) == 1
+    assert len(q.drain(None)) == 2


### PR DESCRIPTION
## Status: DRAFT / WIP — do not merge

Surfacing in-progress work as a draft PR so the design is reviewable and the code isn't trapped in an untracked working tree.

## What this is

A dormant client bridging the open-source \`dynos-work\` plugin to a future commercial \`cloud-sibyl\` foundry. Off by default — driver defers to the existing local pipeline unless \`cloud.enabled=true\` is set in \`~/.dynos/config.toml\`. Current users see zero behavior change.

## Scaffolding shipped

| Path | Role |
|---|---|
| \`hooks/cloud/config.py\` | TOML + env config, \`Config\` dataclass |
| \`hooks/cloud/keychain.py\` | OS keychain wrapper (macOS / Windows / libsecret) + file fallback |
| \`hooks/cloud/crypto.py\` | Canonical JSON + Ed25519 signing + repo Merkle hash |
| \`hooks/cloud/client.py\` | WebSocket client with reconnect + resume by \`last_seen_seq\` |
| \`hooks/cloud/cas.py\` | Content-addressed storage against \`/v1/artifacts/presign\` |
| \`hooks/cloud/dispatch.py\` | Instruction handlers (collect_context, run_tests, apply_patch, gather_evidence, request_human_review, run_local_validator, commit_and_sign, fetch_artifact, apply_plan_segment) |
| \`hooks/cloud/queue.py\` | SQLite offline queue + per-task cursor |
| \`hooks/cloud/cli.py\` | \`dynos login / logout / status / config\` |
| \`hooks/driver.py\` | Switch between local and cloud pipelines |
| \`tests/cloud/\` | 39 tests, all passing |
| \`.github/workflows/cloud-client.yml\` | CI for the cloud test subset |

## Test plan

- [x] \`python3 -m pytest tests/cloud/ -q\` — 39 passed
- [ ] Full suite run (not yet executed on this branch)
- [ ] \`hooks/driver.py\` wired into \`hooks/ctl.py\` entry points
- [ ] Decision on zero-retention defaults vs. presign semantics
- [ ] \`dynos login\` UX + error paths documented
- [ ] Integration test against a stub cloud-sibyl server
- [ ] Security review of session key lifecycle

## Why WIP

The scaffolding compiles, the unit tests pass, and the design is worth a read — but the driver is not wired into the existing control plane, and the security-sensitive pieces (session key lifecycle, presign semantics, zero-retention default) haven't had a review pass yet. Landing this prematurely would create a dormant second control-plane branch nobody is watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)