### PR TITLE
release 7.1.0 — receipt-driven state machine + trust-me-bro elimination

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,75 @@ and this project adheres to **Semantic Versioning**.
 
 ## [Unreleased]
 
+---
+
+## [7.1.0] - 2026-04-19
+### "Close the Anti-Pattern": Receipt-Driven State Machine, Trust-Me-Bro Elimination, Modular Runtime
+
+The theme of 7.1.0 is moving the state machine from pull-based (LLM decides when to advance) toward receipt-driven (scheduler advances when proofs are on disk), and closing the trust-me-bro anti-pattern across every control-plane surface. Receipt writers self-compute machine-derivable fields — callers can no longer supply counts, hashes, or scores. The contract version is bumped from 2 → 4 in two waves.
+
+### Added
+- **Receipt-driven scheduler POC**: new `hooks/scheduler.py` exports a pure `compute_next_stage(task_dir) -> (next_stage | None, list[missing_proofs])` and an I/O-capable `handle_receipt_written(...)` dispatcher. `write_receipt` in `lib_receipts.py` now synchronously invokes the scheduler after the atomic write, so writing the `human-approval-SPEC_REVIEW` receipt advances the task to `PLANNING` without any caller running `ctl.py transition`. Scope ceiling is explicit: `compute_next_stage` returns `(None, [])` for every non-SPEC_REVIEW stage. `<!-- scheduler-owned: X -> Y -->` marker in skill prose opts a transition out of the LLM-must-mention-the-ctl-command linter. New `receipt_scheduler_refused` writer + `scheduler_transition_refused` / `scheduler_transition_race` diagnostic events.
+- **Deterministic rules engine** (#125): 6 prevention-rule templates (`pattern_must_not_appear`, `co_modification_required`, `signature_lock`, `caller_count_required`, `import_constant_only`, `every_name_in_X_satisfies_Y`, `advisory`) with structured params. Rules from postmortem analysis are normalized to these templates and enforced by `run_checks` at `REPAIR_EXECUTION → TEST_EXECUTION` / pre-DONE gates via `receipt_rules_check_passed`.
+- **`rules-check-passed` receipt + transition gate**: error-severity violations refuse to write the pass receipt, blocking DONE transition. Prevention-rules file hash is pinned to the receipt; drift after the check forces a re-run.
+- **LLM-powered postmortem analysis**: `postmortem_analysis.py build-prompt` / `apply` pipeline. `opus` analyst reads deterministic postmortem + findings and returns structured JSON with root_causes, prevention_rules, repair_failures. Rules merge into `prevention-rules.json` via the template normalizer. `postmortem_rule_promoted`, `postmortem_rule_dropped`, `postmortem_rule_promotion_dropped` events.
+- **Hierarchical Q-learning**: per-category action spaces (3 Q-tables) replace the flat executor×model table. `ctl.py repair-plan` surfaces Q-derived assignments; `repair-update` writes outcomes back. No-op when learning is disabled.
+- **Auditor ensemble voting**: router-plan entries can set `ensemble: true` with `ensemble_voting_models` (haiku + sonnet) and `ensemble_escalation_model` (opus). Both voters zero → pass; either voter non-zero → escalate to opus (binding). Per-model injected-prompt sidecars disambiguate ensemble call paths.
+- **CI linters** (+5): `test_ci_event_emit_consume` (every `log_event` name must be consumed or in `DIAGNOSTIC_ONLY_EVENTS`), `test_ci_value_error_coverage` (every `raise ValueError` in production has an adversarial `pytest.raises(match=…)`), `test_ci_receipt_selfverify_parity` (every receipt writer self-verifies or is allowlisted), `test_skill_stage_references::test_no_skill_prose_advises_manual_stage_edit` (scans for `manually set` within 80 bytes of `"stage"` — catches DONE-escape-hatch regressions), `test_skill_stage_references::test_scheduler_owned_transitions_are_exempt_from_transition_prose_requirement` (caps scheduler-owned markers at `SPEC_REVIEW -> PLANNING`).
+- **Plug-and-play modularity**: auditor registry, executor discovery, action spaces, ensemble wiring, handler discovery — all opt-in via registry lookups rather than hardcoded lists.
+- **`bus` CLI subcommands** on `ctl.py`: `emit`, `drain`, `status`, `handlers`.
+- **`router-cache-status`**: reports freshness of the per-task executor-plan cache (see Performance).
+- **External-solution gate in start skill**: structured JSON artifact at `.dynos/task-{id}/external-solution-gate.json` captures when the planner consulted external docs and which candidate was chosen. Includes untrusted-content contract (paraphrase-not-quote, URL allowlist, instruction-shaped-content rejection, body caps).
+- **Global dashboard live updates** (#121): regen-on-fetch + JS polling. Dashboard reflects current task state without manual refresh.
+- **Stage-aware artifact validation**: `validate_task_artifacts` no longer false-fails on early stages (pre-spec, pre-plan) by conditioning required artifacts on current stage.
+- **Contract version 4** (#127, #132): receipts embed `contract_version: 4`. `MIN_VERSION_PER_STEP` enforces per-receipt minimums. Writers refuse to emit below-floor; readers refuse to consume below-floor.
+
+### Changed
+- **Receipt writers self-compute machine-derivable fields** (#123, #127, #130, #131, #132, #133): `receipt_retrospective`, `receipt_plan_validated`, `receipt_plan_audit`, `receipt_audit_done`, `receipt_postmortem_generated` no longer accept caller-supplied `quality_score`, `cost_score`, `efficiency_score`, `total_tokens`, `segment_count`, `criteria_coverage`, `validation_passed`, or `finding_count`. The writers re-read the artifacts themselves and raise `TypeError` on any legacy kwarg. Closes the trust-me-bro input-trust hole.
+- **`receipt_audit_done` TOCTOU fixed** (#133 / MA-005): when `report_path is None`, `finding_count` and `blocking_count` MUST both be zero. Auditors with real findings materialize a report file, and the writer re-reads and cross-checks.
+- **`receipt_planner_spawn` enforces sidecar**: `injected_prompt_sha256` is required (no-sidecar legacy path removed). The sidecar file at `receipts/_injected-planner-prompts/{phase}.{sha256,txt}` pins the exact prompt bytes.
+- **`receipt_executor_done` enforces sidecar**: per-segment injected prompt sidecar must exist and match the supplied digest.
+- **`write_receipt` chokepoint dispatch**: every receipt write triggers `scheduler.handle_receipt_written` after the atomic write + existing `log_event("receipt_written", ...)`. Exception in the scheduler dispatch is swallowed to stderr — never rolls back the durable receipt.
+- **`cmd_approve_stage` stops calling `transition_task`**: exits 0 after the receipt is durably on disk; the scheduler drives the resulting stage advance asynchronously in-process. Docstring updated to match.
+- **Post-completion drain is async** (#117): `task-completed` handler no longer blocks the execute skill's return. Improve / policy_engine / dashboard / registry refresh run after the skill completes.
+- **`evolve.py` → `calibrate.py`**: rename. The shell alias `dynos calibration` routes to `memory/agent_generator.py auto`. Old `hooks/calibrate.py` / `hooks/generate.py` wrappers removed; functionality lives in `agent_generator.py init-registry` / `register-agent` / `auto` subcommands.
+- **`patterns.py` → `policy_engine.py`**: rename. `patterns.md` table data split into JSON (`project_rules.json`) so the LLM-facing prose (`project_rules.md`) no longer drifts against the structured data.
+- **Eventbus flattened**: 4 handlers, 1 event (`task-completed`), 1 drain loop. `receipt_written` and `stage_transition` remain as orthogonal JSONL-only observability events.
+- **`agent_generator` refreshes existing learned agents** (#115): every run regenerates agent `.md` files from the latest retrospective patterns, not just new ones. Bias / format / rule-filtering fixes.
+- **Benchmark scheduler wired as auto-discovered eventbus handler**.
+- **Daemon stripped to trajectory-only**: removed duplicate seeding; calibration CLI added; dormant modules cleared.
+- **Test migration** (#108): 7 unittest files → pytest; 3 dyno-prefixed tests renamed.
+
 ### Performance / Determinism
-- **Router executor-plan cache**: `executor-plan` now writes a fingerprinted plan to `.dynos/task-{id}/router-cache/executor-plan.json`. Per-segment `inject-prompt` calls reuse the cached plan instead of rebuilding it from scratch, eliminating N redundant `RouterContext` rebuilds per task. Critically, this also eliminates re-rolled epsilon-greedy exploration dice between executor-plan and inject-prompt, guaranteeing the model the executor was spawned under matches the model the prompt was injected for. Cache fingerprint covers graph, policy, effectiveness scores, retrospectives, learned registry, benchmark history, and prevention rules — any drift forces a live rebuild. New `router-cache-status` subcommand reports cache freshness. New `router_cache_lookup` / `router_cache_write` events make cache hits/misses observable.
-- **`_benchmark_model_for_agent` honors `RouterContext`**: previously this helper always re-read the learned registry and benchmark history JSON files, even when called from inside a `resolve_model` path that already had both cached on its `RouterContext`. Now it accepts and uses the shared context.
+- **Router executor-plan cache** (#113, #114): `executor-plan` writes a fingerprinted plan to `.dynos/task-{id}/router-cache/executor-plan.json`. Per-segment `inject-prompt` calls reuse the cached plan instead of rebuilding it. Critically, this eliminates re-rolled epsilon-greedy exploration dice between executor-plan and inject-prompt, so the model the executor was spawned under matches the model the prompt was injected for. Cache fingerprint covers graph, policy, effectiveness scores, retrospectives, learned registry, benchmark history, and prevention rules — any drift forces a live rebuild. New `router-cache-status` subcommand. New `router_cache_lookup` / `router_cache_write` events.
+- **`_benchmark_model_for_agent` honors `RouterContext`**: helper no longer re-reads learned registry and benchmark history when called from a path that already has both on its context.
+- **Gap analysis cached + decoupled** (#119): `plan_gap_analysis` no longer runs inside `validate_task_artifacts`; callers invoke it explicitly. Handler work deduplicated.
+- **Worktree slug normalization** (#122): `~/.dynos/projects/{slug}/` derived from the main-repo path, not the worktree path — retrospectives, benchmarks, and learned agents now flow back to the same persistent dir regardless of which worktree executed the task. Safe `migrate` CLI consolidates legacy duplicate slugs.
+
+### Fixed
+- **27 silently-vacuous gates** (#132): receipt/transition gates that checked the wrong field or returned True on empty input. Contract v4 adds explicit non-empty constraints.
+- **10 remaining trust-me-bro LLM surfaces** (#127): contract v3 closes caller-supplied counts on auditor receipts and plan receipts.
+- **8 initial trust-me-bro control-plane gates** (#123): sha256-bound sidecars, hash-drift refusal, explicit kwarg requirements.
+- **6 framework enforcement gaps** (#126) + 4 non-blocking followups (#128): stage-transition + receipt-parity + auditor-registry cross-checks.
+- **G1–G4 postmortem-skip structural guardrails** (#130): `.dynos/deferred-findings.json` TTL registry + `check_deferred_findings` CLI. Removed `quality-above-threshold` from `_POSTMORTEM_SKIP_REASONS`.
+- **Postmortem rule-promotion parity** (#131): `postmortem_rule_promoted` event fires per rule added; `postmortem_rule_dropped` fires per rule dropped. Closes the PR-#130 silent-drop pattern.
+- **MA-005 / MA-007 meta-audit** (#133): `receipt_audit_done` rejects `report_path=None` with non-zero counts; `apply_analysis` emits `postmortem_rule_promoted` per rule on successful promotion (was silent).
+- **Three pipeline regressions** (#116): registry data loss, fast-track stage walk, post-completion receipt gap.
+- **`performance_check`** (#111, #112): stopped flagging `dict.get()` as N+1 queries; indent-stack-based quadratic-loop detection.
+- **Execute skill stage transitions** (#117): post-completion drain dispatched async so `/dynos-work:execute` returns promptly.
+- **Dead code removal** (#109): `cli/assets/hooks`, `cli/assets/memory`, `cli/assets/bin`, `cli/assets/telemetry` subtrees; dormant sandbox modules (`sweeper`, `dream`, `state`, `founder-skill`, stale copies).
+
+### Removed
+- **`no-sidecar legacy path` in `receipt_planner_spawn`**: the pre-#124 `injected_prompt_sha256=None` branch is gone.
+- **Caller-supplied score / count fields** on `receipt_retrospective` / `receipt_plan_validated` / `receipt_plan_audit` / `receipt_audit_done` (also listed under Changed for breaking-change discoverability — legacy kwargs raise `TypeError`).
+- **`quality-above-threshold`** as a valid value in `_POSTMORTEM_SKIP_REASONS` (#130).
+- **`hooks/calibrate.py`** / **`hooks/generate.py`** shell wrappers: functionality lives in `memory/agent_generator.py`.
+- **MCTS / dreamer modules**: extracted to `sandbox/` — out of the main pipeline.
+- **Optional learning modules**: sandboxed; `memory/` is now 1,318 lines. Q-learning / postmortem_improve / agent_generator restored from sandbox when needed.
+
+### Plugin / Distribution
+- Bump `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` to `7.1.0`.
+- Reinstall via `/plugin update dynos-work` to pick up updated skills. Cached-v7.0.0 installations will continue to serve stale skill prompts (notably a stale 5-arg `receipt_retrospective` signature from an intermediate commit) until the update runs.
 
 ---
 

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -107,12 +107,17 @@ def cmd_transition(args: argparse.Namespace) -> int:
 
 
 def cmd_approve_stage(args: argparse.Namespace) -> int:
-    """Record a human approval receipt for a review stage and advance the task.
+    """Record a human approval receipt for a review stage.
 
     stage must be one of SPEC_REVIEW / PLAN_REVIEW / TDD_REVIEW. Exits 1 on any
-    failure (unknown stage, missing artifact, receipt-write or transition
-    refusal); exits 0 only after the state machine has accepted the advance.
-    stderr carries the ValueError text; stdout is reserved for a success line.
+    failure that prevents the receipt write (unknown stage, missing artifact,
+    receipt-write refusal); exits 0 after the receipt is durably on disk.
+    The scheduler (hooks/scheduler.py) observes the receipt write via the
+    write_receipt chokepoint and drives any resulting stage advance
+    asynchronously in-process. Exit 0 therefore signals "receipt written";
+    it does NOT signal "stage advanced" — callers that need the latter must
+    re-read manifest.json after the call returns. stderr carries the
+    ValueError text; stdout is reserved for a success line.
     """
     stage = args.stage
     mapping = _APPROVE_STAGE_MAP.get(stage)
@@ -123,7 +128,7 @@ def cmd_approve_stage(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    artifact_rel, next_stage = mapping
+    artifact_rel, _ = mapping
 
     task_dir = Path(args.task_dir).resolve()
     artifact_path = task_dir / artifact_rel
@@ -146,16 +151,7 @@ def cmd_approve_stage(args: argparse.Namespace) -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
-    try:
-        previous, manifest = transition_task(task_dir, next_stage)
-    except Exception as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-
-    print(
-        f"{manifest['task_id']}: approved {stage} ({sha256_hex[:12]}) "
-        f"and transitioned {previous} -> {manifest['stage']}"
-    )
+    print(f"{task_dir.name}: approved {stage} ({sha256_hex[:12]}) — receipt written, scheduler will advance")
     return 0
 
 

--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -59,6 +59,8 @@ DIAGNOSTIC_ONLY_EVENTS: frozenset[str] = frozenset({
     "stage_transition",
     "eventbus_handler",
     "maintenance_cycle",
+    "scheduler_transition_refused",
+    "scheduler_transition_race",
 })
 
 

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -376,6 +376,34 @@ def write_receipt(task_dir: Path, step_name: str, **payload: Any) -> Path:
             f"[FORCE] {from_stage} → {to_stage} — bypassed {n_bypassed} gate(s)",
         )
 
+    # Synchronous in-process scheduler dispatch. Fires AFTER the atomic
+    # receipt write (durable on disk) AND AFTER the log_event observability
+    # record (captured in events.jsonl). Ordering is load-bearing: moving
+    # this call before _atomic_write_text would expose a window where the
+    # scheduler sees a non-existent receipt; moving it before log_event
+    # would let a scheduler-dispatch side effect (e.g. a refusal-receipt
+    # write) race the observability record.
+    #
+    # The dispatch is wrapped in a try/except Exception so a scheduler
+    # failure can NEVER roll back the already-committed atomic receipt
+    # write. All failures are printed to stderr and swallowed. Catch
+    # Exception (NOT BaseException) to let KeyboardInterrupt / SystemExit
+    # propagate normally.
+    #
+    # Lazy import (function-local) avoids the circular-import cycle
+    # scheduler → lib_receipts → scheduler that would fire at module load
+    # if the import sat at the top of this file.
+    try:
+        from scheduler import handle_receipt_written
+        receipt_sha256 = hash_file(receipt_path)
+        handle_receipt_written(task_dir, step_name, receipt_sha256)
+    except Exception as exc:
+        import sys as _sys
+        print(
+            f"[lib_receipts] scheduler dispatch failed: {exc}",
+            file=_sys.stderr,
+        )
+
     return receipt_path
 
 
@@ -1963,6 +1991,72 @@ def receipt_force_override(
         bypassed_gates=list(bypassed_gates),
         bypassed_count=len(bypassed_gates),
         forced_at=now_iso(),
+    )
+
+
+def receipt_scheduler_refused(
+    task_dir: Path,
+    current_stage: str,
+    proposed_stage: str,
+    missing_proofs: list[str],
+) -> Path:
+    """Write receipt proving the scheduler refused to transition.
+
+    Emitted by ``scheduler.handle_receipt_written`` when
+    ``compute_next_stage(task_dir)`` returns a non-None ``next_stage``
+    with a non-empty ``missing_proofs`` list. The receipt is purely
+    observational — no gate reads it; it parallels the
+    ``scheduler_transition_refused`` event and lets the audit trail
+    record refusal reasons on disk rather than only in events.jsonl.
+
+    Writes ``receipts/scheduler-refused.json``. Subsequent refusals
+    overwrite via the atomic write path — the most recent refusal wins.
+
+    Validation:
+      - ``current_stage`` and ``proposed_stage`` MUST be non-empty
+        strings matching ``^[A-Z][A-Z0-9_]*$``. The regex shape mirrors
+        ``receipt_force_override``'s ``_STAGE_RE`` hardening
+        (SEC-002): stage names become part of event payloads and log
+        lines, so crafted manifest values like ``"../../etc/x"`` must
+        be rejected at the writer boundary. Empty or non-matching
+        values raise ``ValueError`` naming the arg.
+      - ``missing_proofs`` MUST be a list (possibly empty). Every
+        entry MUST be a string. Any other container type or non-string
+        entry raises ``ValueError``.
+    """
+    if not isinstance(current_stage, str) or not current_stage:
+        raise ValueError("current_stage must be a non-empty string")
+    if not isinstance(proposed_stage, str) or not proposed_stage:
+        raise ValueError("proposed_stage must be a non-empty string")
+    # SEC-002 hardening: stage names MUST be strict uppercase identifier
+    # slugs. Prevents path traversal / event-payload injection via crafted
+    # manifest stage values reaching the receipt/event surface.
+    import re as _re_stage
+    _STAGE_RE = r"^[A-Z][A-Z0-9_]*$"
+    if not _re_stage.match(_STAGE_RE, current_stage):
+        raise ValueError(
+            f"current_stage must match {_STAGE_RE} (got {current_stage!r})"
+        )
+    if not _re_stage.match(_STAGE_RE, proposed_stage):
+        raise ValueError(
+            f"proposed_stage must match {_STAGE_RE} (got {proposed_stage!r})"
+        )
+    if not isinstance(missing_proofs, list):
+        raise ValueError("missing_proofs must be a list of strings")
+    for idx, entry in enumerate(missing_proofs):
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"missing_proofs[{idx}] must be a string "
+                f"(got {type(entry).__name__})"
+            )
+
+    return write_receipt(
+        task_dir,
+        "scheduler-refused",
+        current_stage=current_stage,
+        proposed_stage=proposed_stage,
+        missing_proofs=list(missing_proofs),
+        refused_at=now_iso(),
     )
 
 

--- a/hooks/scheduler.py
+++ b/hooks/scheduler.py
@@ -1,0 +1,346 @@
+"""Receipt-driven stage-transition scheduler for dynos-work.
+
+The scheduler inverts control for a narrow slice of the state machine:
+instead of a caller (prose in a skill, a CLI command, an executor) deciding
+when to advance a task, the scheduler observes receipt writes via the
+``write_receipt`` chokepoint in ``hooks/lib_receipts.py`` and — when every
+required proof is present — drives ``transition_task`` itself.
+
+This module exports two symbols:
+
+* ``compute_next_stage(task_dir)`` — a PURE predicate. Reads the manifest
+  and receipts/artifacts, returns a tuple describing either the next
+  stage to advance to or the missing proofs blocking advancement.
+  Never writes, never emits events, never calls ``transition_task``.
+
+* ``handle_receipt_written(task_dir, receipt_step, receipt_sha256)`` —
+  the I/O-capable dispatcher invoked from ``write_receipt`` after each
+  receipt is durably on disk. Calls ``compute_next_stage``, routes the
+  result to ``transition_task`` on clean advance, emits observability
+  events on refusal or race, and NEVER raises — a scheduler failure
+  cannot roll back the receipt write that triggered it.
+
+Scope ceiling (task-20260419-008 POC): ``compute_next_stage`` handles
+only ``SPEC_REVIEW -> PLANNING``. Every other ``current_stage`` value
+returns ``(None, [])`` via an explicit early-return so that future
+migrations are adds-only (one more ``elif`` arm) and cannot be
+introduced by accident (see AC 8, D6).
+
+Design notes (pinned by plan.md):
+* D1 — synchronous in-process dispatch via the ``write_receipt``
+  chokepoint; no async queue, no fs watcher, no separate process.
+* D5 — purity of ``compute_next_stage`` is load-bearing. It is the
+  property that makes the dispatch race-free.
+* Circular-import avoidance — ``scheduler.py`` is imported lazily from
+  inside ``write_receipt``. Conversely, ``receipt_scheduler_refused``
+  is imported lazily from inside ``handle_receipt_written`` so this
+  module can load before segment-4 lands the new writer.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from lib_core import transition_task
+from lib_log import log_event
+from lib_receipts import _receipts_dir, hash_file, read_receipt
+
+
+# Receipt step name used for the refusal receipt written when
+# ``compute_next_stage`` returns missing proofs. Short-circuits the
+# recursion that would otherwise fire when that receipt's own
+# ``write_receipt`` re-enters ``handle_receipt_written`` via the
+# chokepoint hook (plan.md Open Question 1).
+_SCHEDULER_REFUSED_STEP = "scheduler-refused"
+
+
+def compute_next_stage(task_dir: Path) -> tuple[str | None, list[str]]:
+    """Pure predicate: decide whether the task at ``task_dir`` should advance.
+
+    Returns a 2-tuple ``(next_stage, missing_proofs)`` where:
+
+    * ``(None, [])`` — no advance is due (current stage is outside the
+      POC scope ceiling).
+    * ``("PLANNING", [])`` — current stage is ``SPEC_REVIEW`` AND every
+      predicate required for ``SPEC_REVIEW -> PLANNING`` passes.
+    * ``("PLANNING", [reason])`` — current stage is ``SPEC_REVIEW`` but
+      at least one predicate fails. The reason string format mirrors
+      ``_human_approval_err`` in ``hooks/lib_core.py`` so callers and
+      operators see identical wording regardless of whether the
+      advancement was gated by ``transition_task`` itself or the
+      scheduler.
+
+    Purity contract (AC 6 / D5): this function MUST NOT write any file,
+    call ``transition_task``, call ``log_event``, call ``emit_event``,
+    issue network requests, mutate the manifest, or invoke any
+    subprocess. Its only permitted filesystem operations are READ
+    operations on ``task_dir / "manifest.json"``,
+    ``task_dir / "receipts" / *.json``, ``task_dir / "spec.md"``,
+    ``task_dir / "plan.md"``, and ``task_dir / "execution-graph.json"``.
+
+    Exceptions encountered while reading (missing manifest, malformed
+    JSON, hash of a vanished artifact) propagate to the caller —
+    ``handle_receipt_written`` classifies them in its outer wrapper.
+    """
+    # ---- Read current stage from manifest (read-only).
+    import json  # Local import keeps the module's top-level import
+                 # surface minimal and emphasizes purity — nothing
+                 # imported here has any side effect on load.
+
+    manifest_path = task_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    current_stage = manifest.get("stage") if isinstance(manifest, dict) else None
+
+    # ---- AC 8: scope ceiling. Explicit early-return for every stage
+    # except SPEC_REVIEW, regardless of what receipts exist on disk.
+    # Do NOT replace this with a dict dispatch or a set membership check
+    # — the inequality is the contract that future migrations must
+    # deliberately extend with a new ``elif`` arm.
+    if current_stage != "SPEC_REVIEW":
+        return (None, [])
+
+    # ---- AC 7: mirror _check_human_approval("SPEC_REVIEW", spec.md).
+    # The wording of each reason string mirrors _human_approval_err in
+    # hooks/lib_core.py (lines 728-756) so operators see the same
+    # diagnostic surface whether the block was raised by transition_task
+    # or reported by the scheduler. Sequential short-circuit: the FIRST
+    # predicate failure returns with a single reason, matching
+    # _human_approval_err's early-return shape.
+    receipt_step = "human-approval-SPEC_REVIEW"
+    receipt_path = _receipts_dir(task_dir) / f"{receipt_step}.json"
+    artifact_path = task_dir / "spec.md"
+    next_stage = "PLANNING"
+
+    # (a) Receipt exists and read_receipt returns non-None (i.e. valid
+    # with contract_version >= MIN_VERSION_PER_STEP["human-approval-*"]).
+    receipt = read_receipt(task_dir, receipt_step)
+    if receipt is None:
+        return (
+            next_stage,
+            [f"missing {receipt_step} at {receipt_path}"],
+        )
+
+    # (b) spec.md exists on disk. Use a distinct reason string so callers
+    # can tell this apart from (a) receipt-missing — mirrors the three-way
+    # split in _human_approval_err (hooks/lib_core.py:728-756).
+    if not artifact_path.exists():
+        return (
+            next_stage,
+            [
+                f"receipt {receipt_step} present at {receipt_path} but "
+                f"artifact missing at {artifact_path}"
+            ],
+        )
+
+    # (c) Receipt's artifact_sha256 matches the live hash of spec.md.
+    expected = receipt.get("artifact_sha256") or ""
+    actual = hash_file(artifact_path)
+    if not isinstance(expected, str) or expected != actual:
+        return (
+            next_stage,
+            [
+                f"hash mismatch for {receipt_step}: "
+                f"expected={(expected or '')[:12]} actual={actual[:12]}"
+            ],
+        )
+
+    # Every predicate passed — clean advance.
+    return (next_stage, [])
+
+
+def handle_receipt_written(
+    task_dir: Path,
+    receipt_step: str,
+    receipt_sha256: str,
+) -> None:
+    """Scheduler dispatcher invoked by ``write_receipt`` after each receipt.
+
+    Behavior per AC 9:
+
+    * Short-circuits (returns) when ``receipt_step`` is the
+      scheduler-owned refusal receipt. This breaks the recursion that
+      would otherwise fire when the refusal-receipt's own
+      ``write_receipt`` re-enters this function via the chokepoint
+      hook (plan.md Open Question 1, resolution approved).
+    * Calls ``compute_next_stage(task_dir)`` exactly once.
+    * On ``(next_stage, [])`` with ``next_stage is not None``: calls
+      ``transition_task(task_dir, next_stage)`` without ``force``. The
+      ``stage_transition`` log-line written by ``transition_task`` is
+      the observability surface — no additional writes here.
+    * On ``ValueError`` from ``transition_task`` (illegal transition —
+      e.g. another caller already advanced the stage): swallow the
+      exception, emit a ``scheduler_transition_race`` event via
+      ``log_event``, and return. The scheduler is the loser of the
+      race, not a failure.
+    * On ``(next_stage, [missing_proofs])`` with non-empty
+      ``missing_proofs``: does NOT call ``transition_task``. Emits a
+      ``scheduler_transition_refused`` event via ``log_event`` AND
+      writes ``receipts/scheduler-refused.json`` via the
+      ``receipt_scheduler_refused`` writer (segment-4).
+    * On ``(None, [])``: no-op (no event, no receipt).
+
+    Never raises. Any exception other than the expected ``ValueError``
+    from ``transition_task`` is caught by the outer wrapper, logged to
+    stderr as ``[scheduler] WARNING: {exc}``, and swallowed. This
+    protects the receipt-write caller from ripple-failures: the
+    receipt is already durable on disk by the time the scheduler runs
+    (AC 10 / Implicit Requirement "Receipt write durability").
+
+    ``receipt_sha256`` is currently unused by this POC — it is captured
+    on the calling side to keep the chokepoint signature forward-
+    compatible with downstream consumers that may want to audit the
+    exact bytes that fired the scheduler (future work).
+    """
+    # ---- Recursion guard (plan.md OQ 1): swallow the refusal-receipt's
+    # own re-entry before any other work. Placed OUTSIDE the try/except
+    # so it is the cheapest possible early-return path; also means a
+    # broken logging path during a refusal cannot trigger an infinite
+    # loop.
+    if receipt_step == _SCHEDULER_REFUSED_STEP:
+        return
+
+    # Reserved for future audit consumers — see docstring.
+    del receipt_sha256  # noqa: F841
+
+    # ---- Inner classification: ValueError from transition_task is the
+    # "lost the race" signal (see ALLOWED_STAGE_TRANSITIONS re-entry
+    # rejection at hooks/lib_core.py:1165). Any OTHER exception from
+    # ANY call path (compute_next_stage, transition_task, log_event,
+    # the receipt writer) is caught by the outer except and logged to
+    # stderr. Two layers are needed because the inner ValueError
+    # handler itself may call log_event, which could raise on disk
+    # failure — the outer wrapper absorbs that ripple.
+    try:
+        result = compute_next_stage(task_dir)
+        next_stage, missing_proofs = result
+
+        if next_stage is None:
+            # (None, []) path — compute_next_stage said "no advance
+            # due"; by contract missing_proofs is empty here.
+            return
+
+        # Derive current_stage from the manifest AFTER compute_next_stage
+        # has run. This is a read, not a mutation — used only for event
+        # payload context. If the manifest is unreadable, fall back to
+        # None; the outer wrapper still logs a warning.
+        current_stage = _read_current_stage(task_dir)
+        task_id = _read_task_id(task_dir)
+        root = task_dir.parent.parent
+
+        if not missing_proofs:
+            # Clean advance: the scheduler is the caller of
+            # transition_task. A ValueError here means
+            # ALLOWED_STAGE_TRANSITIONS rejected the edge — treat as a
+            # lost race (some other caller already advanced).
+            try:
+                transition_task(task_dir, next_stage)
+            except ValueError as race_exc:
+                try:
+                    log_event(
+                        root,
+                        "scheduler_transition_race",
+                        task=task_id,
+                        task_id=task_id,
+                        current_stage=current_stage,
+                        proposed_stage=next_stage,
+                        error_message=str(race_exc),
+                    )
+                except Exception as log_exc:  # pragma: no cover — defensive
+                    print(
+                        f"[scheduler] WARNING: {log_exc}",
+                        file=sys.stderr,
+                    )
+            return
+
+        # Refusal path: missing proofs. Emit event THEN write
+        # refusal-receipt. The event is independently durable
+        # regardless of whether the receipt write succeeds, so
+        # operators always see the reason even if disk is full.
+        try:
+            log_event(
+                root,
+                "scheduler_transition_refused",
+                task=task_id,
+                task_id=task_id,
+                current_stage=current_stage,
+                proposed_stage=next_stage,
+                missing_proofs=list(missing_proofs),
+            )
+        except Exception as log_exc:  # pragma: no cover — defensive
+            print(f"[scheduler] WARNING: {log_exc}", file=sys.stderr)
+
+        # Lazy import of receipt_scheduler_refused (segment-4 owns the
+        # writer in lib_receipts.py). Doing this inside the function
+        # means module load succeeds even before segment-4 lands; the
+        # import resolves at call-time.
+        try:
+            from lib_receipts import receipt_scheduler_refused  # type: ignore
+        except ImportError as imp_exc:
+            print(
+                f"[scheduler] WARNING: {imp_exc}",
+                file=sys.stderr,
+            )
+            return
+
+        try:
+            receipt_scheduler_refused(
+                task_dir,
+                current_stage or "",
+                next_stage,
+                list(missing_proofs),
+            )
+        except Exception as rec_exc:
+            # Refusal-receipt write failure is non-fatal: the event
+            # above already captured the refusal for observability.
+            print(
+                f"[scheduler] WARNING: {rec_exc}",
+                file=sys.stderr,
+            )
+
+    except Exception as exc:
+        # AC 9: MUST NOT raise. Any uncaught exception (malformed
+        # manifest, missing files, I/O error inside compute_next_stage,
+        # unexpected transition_task exception, etc.) is swallowed with
+        # a stderr warning. The receipt that triggered the scheduler
+        # remains durable on disk.
+        print(f"[scheduler] WARNING: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Internal read helpers
+# ---------------------------------------------------------------------------
+#
+# These helpers exist only to make handle_receipt_written's event-payload
+# construction robust against a missing/malformed manifest. They do NOT
+# participate in compute_next_stage's predicate evaluation and are kept
+# at module scope so test doubles can observe them if needed. Both
+# return None on any read error rather than propagating — the outer
+# wrapper's job is to keep the scheduler from raising.
+
+def _read_current_stage(task_dir: Path) -> str | None:
+    import json
+
+    try:
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        if isinstance(manifest, dict):
+            stage = manifest.get("stage")
+            if isinstance(stage, str):
+                return stage
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _read_task_id(task_dir: Path) -> str:
+    import json
+
+    try:
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        if isinstance(manifest, dict):
+            tid = manifest.get("task_id")
+            if isinstance(tid, str) and tid:
+                return tid
+    except (OSError, ValueError):
+        pass
+    return task_dir.name

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -405,7 +405,7 @@ If `has_findings` is false, skip this step and append:
 
 **Post-completion processing:** Improve, policy engine, dashboard, and registry refresh are handled automatically by the `task-completed` hook via the event bus. Do not run them inline. The hook fires after this skill completes and the task reaches DONE.
 
-Write `completion.json`. Transition the task to `DONE` by calling `transition_task(task_dir, "DONE")` from `lib.py` (this sets both `stage` and `completion_at`). If calling the function directly is not possible, manually set both `"stage": "DONE"` and `"completion_at": "{ISO timestamp}"` in `manifest.json`. Append to log:
+Write `completion.json`. Transition the task to `DONE` by calling `transition_task(task_dir, "DONE")` from `lib.py` (this sets both `stage` and `completion_at`). Append to log:
 ```
 {timestamp} [ADVANCE] CHECKPOINT_AUDIT → DONE
 ```

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -430,11 +430,13 @@ python3 hooks/ctl.py transition .dynos/task-{id} SPEC_REVIEW
 
 ## Step 4 — Spec Review
 
+<!-- scheduler-owned: SPEC_REVIEW -> PLANNING -->
+
 **Fast-track skip:** If `manifest.json` has `"fast_track": true`, skip this step. Spec is reviewed together with the plan in Step 6 (combined approval gate). Log: `{timestamp} [SKIP] spec-review — fast_track combined gate`.
 
 **Normal path:** Present `spec.md` to the user and ask for approval.
 
-- If approved: run the `approve-stage` ctl command below. It hashes the current `spec.md`, writes the `human-approval-SPEC_REVIEW` receipt with that hash, then transitions SPEC_REVIEW → PLANNING in one atomic step. Do NOT write a manual `[HUMAN]` log line — `approve-stage` is the only path that satisfies the receipt-gate in `transition_task` (which compares the receipt's `artifact_sha256` against the live `spec.md` at transition time and refuses with `human-approval-SPEC_REVIEW` / `hash mismatch` substrings on drift).
+- If approved: run the `approve-stage` ctl command below. It hashes the current `spec.md`, writes the `human-approval-SPEC_REVIEW` receipt with that hash, the scheduler then observes the receipt write and advances the task to PLANNING asynchronously. Do NOT write a manual `[HUMAN]` log line — `approve-stage` is the only path that satisfies the receipt-gate in `transition_task` (which compares the receipt's `artifact_sha256` against the live `spec.md` at transition time and refuses with `human-approval-SPEC_REVIEW` / `hash mismatch` substrings on drift).
 - If changes are requested: append the feedback, respawn the Planner in Spec Normalization mode, re-run deterministic spec validation, write a new `receipt_spec_validated`, and present the updated spec again. Do NOT call `approve-stage` until the user re-approves the regenerated spec.
 - If rejected outright: set `manifest.json` stage to `FAILED`, append `[FAILED] Spec rejected by user`, and stop.
 
@@ -444,7 +446,7 @@ When approved:
 python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW
 ```
 
-Exit code 0 means the receipt was written and the stage advanced to PLANNING. Exit code 1 means the gate refused — the stderr text identifies the cause (missing artifact, hash drift, illegal transition). Do not retry without addressing the reported cause; in particular, do not call `python3 hooks/ctl.py transition ... --force` to bypass — that would advance the stage without a receipt and break the audit chain.
+Exit code 0 means the receipt was written and the scheduler queued the advance to PLANNING (verify via manifest.stage after the in-process event dispatch completes). Exit code 1 means the gate refused — the stderr text identifies the cause (missing artifact, hash drift, illegal transition). Do not retry without addressing the reported cause; in particular, do not call `python3 hooks/ctl.py transition ... --force` to bypass — that would advance the stage without a receipt and break the audit chain.
 
 ---
 

--- a/tests/test_ci_receipt_selfverify_parity.py
+++ b/tests/test_ci_receipt_selfverify_parity.py
@@ -58,6 +58,7 @@ _SELF_VERIFY_EXEMPT = {
     "receipt_planner_spawn",        # payload: phase + tokens_used; tokens_used fundamentally unverifiable (B-005 acknowledges this)
     "receipt_rules_check_passed",   # payload: error_violations + rules_file_sha256; self-verify against rules_engine at gate time (B-008)
     "receipt_force_override",       # payload: bypassed_gates observability snapshot supplied by caller; no authoritative on-disk artifact to self-verify against
+    "receipt_scheduler_refused",    # payload: missing_proofs observability snapshot from compute_next_stage; no authoritative on-disk artifact to self-verify against (parallel to receipt_force_override)
 }
 
 

--- a/tests/test_gate_spec_review.py
+++ b/tests/test_gate_spec_review.py
@@ -26,6 +26,27 @@ def _setup(tmp_path: Path, *, spec_text: str = "spec content\n") -> Path:
     return td
 
 
+def _write_approval_direct(td: Path, artifact_sha256: str) -> None:
+    """Write a human-approval-SPEC_REVIEW receipt JSON directly.
+
+    Bypasses ``receipt_human_approval`` — which fires the synchronous
+    scheduler dispatch through ``write_receipt`` and auto-advances the
+    manifest to PLANNING. These tests exercise ``transition_task``'s own
+    gate logic in isolation; they must NOT let the scheduler race them.
+    """
+    receipts = td / "receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    (receipts / "human-approval-SPEC_REVIEW.json").write_text(json.dumps({
+        "step": "human-approval-SPEC_REVIEW",
+        "ts": "2026-04-19T00:00:00Z",
+        "valid": True,
+        "contract_version": 4,
+        "stage": "SPEC_REVIEW",
+        "artifact_sha256": artifact_sha256,
+        "approver": "human",
+    }, indent=2))
+
+
 def test_missing_receipt_refuses(tmp_path: Path):
     td = _setup(tmp_path)
     with pytest.raises(ValueError, match="human-approval-SPEC_REVIEW"):
@@ -35,7 +56,7 @@ def test_missing_receipt_refuses(tmp_path: Path):
 def test_hash_drift_refuses(tmp_path: Path):
     td = _setup(tmp_path)
     sha = hash_file(td / "spec.md")
-    receipt_human_approval(td, "SPEC_REVIEW", sha)
+    _write_approval_direct(td, sha)
     # Drift the spec after approval
     (td / "spec.md").write_text("modified content\n")
     with pytest.raises(ValueError, match="hash mismatch"):
@@ -53,7 +74,7 @@ def test_force_bypass_succeeds(tmp_path: Path):
 def test_matching_hash_passes(tmp_path: Path):
     td = _setup(tmp_path)
     sha = hash_file(td / "spec.md")
-    receipt_human_approval(td, "SPEC_REVIEW", sha)
+    _write_approval_direct(td, sha)
     transition_task(td, "PLANNING")
     manifest = json.loads((td / "manifest.json").read_text())
     assert manifest["stage"] == "PLANNING"

--- a/tests/test_receipt_scheduler_refused.py
+++ b/tests/test_receipt_scheduler_refused.py
@@ -1,0 +1,61 @@
+"""Adversarial tests for receipt_scheduler_refused validation.
+
+task-20260419-008 / AC 12: the writer rejects malformed input. Each
+``raise ValueError(...)`` in the validation block requires a matching
+``pytest.raises(ValueError, match=...)`` so the CI coverage linter
+(``tests/test_ci_value_error_coverage.py``) is satisfied.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import receipt_scheduler_refused  # noqa: E402
+
+
+def _task_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "project"
+    td = root / ".dynos" / "task-TEST"
+    td.mkdir(parents=True)
+    (td / "manifest.json").write_text('{"task_id": "task-TEST"}')
+    return td
+
+
+def test_current_stage_with_invalid_chars_rejected(tmp_path: Path) -> None:
+    """Lowercase / punctuation in current_stage triggers _STAGE_RE rejection."""
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError, match="current_stage must match"):
+        receipt_scheduler_refused(
+            task_dir=td,
+            current_stage="spec-review",
+            proposed_stage="PLANNING",
+            missing_proofs=[],
+        )
+
+
+def test_proposed_stage_with_invalid_chars_rejected(tmp_path: Path) -> None:
+    """Path-traversal-like proposed_stage triggers _STAGE_RE rejection."""
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError, match="proposed_stage must match"):
+        receipt_scheduler_refused(
+            task_dir=td,
+            current_stage="SPEC_REVIEW",
+            proposed_stage="../../etc/passwd",
+            missing_proofs=[],
+        )
+
+
+def test_missing_proofs_non_list_rejected(tmp_path: Path) -> None:
+    """tuple/None/str containers for missing_proofs are rejected."""
+    td = _task_dir(tmp_path)
+    with pytest.raises(ValueError, match="missing_proofs must be a list of strings"):
+        receipt_scheduler_refused(
+            task_dir=td,
+            current_stage="SPEC_REVIEW",
+            proposed_stage="PLANNING",
+            missing_proofs=("missing receipt",),  # tuple, not list
+        )

--- a/tests/test_receipt_writer_reader_parity.py
+++ b/tests/test_receipt_writer_reader_parity.py
@@ -104,6 +104,17 @@ _INTENTIONALLY_WRITE_ONLY: dict[str, str] = {
         "usage and evidence path, but TDD_REVIEW exit gate reads "
         "human-approval-TDD_REVIEW not tdd-tests — no reader exists"
     ),
+    # Written by receipt_scheduler_refused (hooks/lib_receipts.py:
+    # receipt_scheduler_refused). Emitted from
+    # scheduler.handle_receipt_written when compute_next_stage returns a
+    # non-None next_stage with non-empty missing_proofs. Parallel to the
+    # scheduler_transition_refused event: pure observability with no
+    # runtime gate reading it. The stage transition is gated by
+    # transition_task + receipt_force_override, not by this receipt.
+    "scheduler-refused": (
+        "observability-only; no gate reads it; parallel to "
+        "scheduler_transition_refused event"
+    ),
 }
 
 

--- a/tests/test_scheduler_compute_next_stage.py
+++ b/tests/test_scheduler_compute_next_stage.py
@@ -1,0 +1,374 @@
+"""Unit tests for ``hooks/scheduler.py::compute_next_stage``.
+
+Covers AC 16 of task-20260419-008 (and indirectly exercises the
+signatures/behaviors required by AC 5, 6, 7, 8):
+
+- (a) ``test_returns_none_for_every_non_spec_review_stage`` — parametrized
+       over ``STAGE_ORDER \\ {"SPEC_REVIEW"}``.
+- (b) ``test_spec_review_missing_receipt_returns_missing_proof``.
+- (c) ``test_spec_review_hash_mismatch_returns_missing_proof``.
+- (d) ``test_spec_review_valid_receipt_returns_clean_advance``.
+- (e) ``test_compute_next_stage_is_pure`` — patches ``transition_task``,
+       ``log_event``, ``emit_event``; asserts zero calls; snapshots
+       directory byte-for-byte before/after.
+
+The tests deliberately import from ``hooks.scheduler`` which does not yet
+exist — the suite is expected to FAIL at collection (ImportError) in TDD
+pre-implementation state. Once segment-3 (hooks/scheduler.py) lands the
+tests must pass unchanged.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Match the project-wide convention (see existing test files like
+# tests/test_receipt_human_approval.py, tests/test_eventbus_drain.py, etc.)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_core import STAGE_ORDER  # noqa: E402
+from lib_receipts import hash_file, receipt_human_approval  # noqa: E402
+
+# Import under test. This import will fail in TDD pre-implementation
+# state (no hooks/scheduler.py exists yet) — that is CORRECT for
+# red-phase TDD; once segment-3 lands the import resolves and all
+# tests here run.
+from scheduler import compute_next_stage  # noqa: E402
+
+
+SPEC_MD_CONTENTS = (
+    "# Normalized Spec\n\n"
+    "## Task Summary\nTesting scheduler.\n\n"
+    "## User Context\nCI.\n\n"
+    "## Acceptance Criteria\n1. one\n2. two\n\n"
+    "## Implicit Requirements Surfaced\nNone.\n\n"
+    "## Out of Scope\nNone.\n\n"
+    "## Assumptions\nsafe assumption: none\n\n"
+    "## Risk Notes\nNone.\n"
+)
+
+
+def _make_manifest(task_dir: Path, stage: str, task_id: str = "task-TEST") -> None:
+    """Write a minimal but schema-valid manifest.json at the given stage."""
+    task_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "task_id": task_id,
+        "created_at": "2026-04-19T00:00:00Z",
+        "title": "Scheduler POC test",
+        "raw_input": "x",
+        "stage": stage,
+        "classification": {
+            "type": "feature",
+            "domains": ["backend"],
+            "risk_level": "medium",
+            "notes": "n",
+        },
+        "retry_counts": {},
+        "blocked_reason": None,
+        "completion_at": None,
+    }
+    (task_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+
+def _make_spec(task_dir: Path, contents: str = SPEC_MD_CONTENTS) -> str:
+    """Write a spec.md and return its sha256."""
+    spec_path = task_dir / "spec.md"
+    spec_path.write_text(contents)
+    return hash_file(spec_path)
+
+
+def _build_task(tmp_path: Path, stage: str, *, with_spec: bool = True) -> Path:
+    """Build a minimal <repo>/.dynos/task-TEST/ tree at the given stage."""
+    root = tmp_path / "project"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".dynos").mkdir(parents=True, exist_ok=True)
+    task_dir = root / ".dynos" / "task-TEST"
+    _make_manifest(task_dir, stage)
+    if with_spec:
+        _make_spec(task_dir)
+    return task_dir
+
+
+def _write_approval_receipt_direct(task_dir: Path, artifact_sha256: str) -> None:
+    """Write a valid human-approval-SPEC_REVIEW receipt JSON directly.
+
+    Bypasses ``receipt_human_approval`` — which would fire the
+    synchronous scheduler dispatch inside ``write_receipt`` and
+    auto-advance the manifest to PLANNING, contaminating the fixture
+    state these unit tests measure. Writing the receipt file by hand
+    keeps ``manifest.stage`` at ``SPEC_REVIEW`` so
+    ``compute_next_stage`` exercises the happy-path branch under test.
+
+    Schema mirrors ``write_receipt``'s output for step
+    ``human-approval-SPEC_REVIEW`` (see .dynos/task-*/receipts/ for a
+    live example).
+    """
+    receipts_dir = task_dir / "receipts"
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    receipt = {
+        "step": "human-approval-SPEC_REVIEW",
+        "ts": "2026-04-19T00:00:00Z",
+        "valid": True,
+        "contract_version": 4,
+        "stage": "SPEC_REVIEW",
+        "artifact_sha256": artifact_sha256,
+        "approver": "human",
+    }
+    (receipts_dir / "human-approval-SPEC_REVIEW.json").write_text(
+        json.dumps(receipt, indent=2)
+    )
+
+
+def _snapshot_tree(task_dir: Path) -> dict[str, tuple[int, int, str]]:
+    """Return {relative_path: (size, mtime_ns, sha256)} for every file under task_dir.
+
+    Used to prove purity: a pure function MUST leave every file byte-for-byte
+    identical. Comparing sha256 defends against identical-timestamp edits and
+    size-preserving edits (both of which mtime alone could miss).
+    """
+    snap: dict[str, tuple[int, int, str]] = {}
+    for base, _dirs, files in os.walk(task_dir):
+        for name in sorted(files):
+            abs_path = Path(base) / name
+            rel = str(abs_path.relative_to(task_dir))
+            st = abs_path.stat()
+            data = abs_path.read_bytes()
+            snap[rel] = (st.st_size, st.st_mtime_ns, hashlib.sha256(data).hexdigest())
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# (a) Scope ceiling: every non-SPEC_REVIEW stage returns (None, [])
+# ---------------------------------------------------------------------------
+
+NON_SPEC_REVIEW_STAGES = [s for s in STAGE_ORDER if s != "SPEC_REVIEW"]
+
+
+@pytest.mark.parametrize("stage", NON_SPEC_REVIEW_STAGES)
+def test_returns_none_for_every_non_spec_review_stage(
+    tmp_path: Path, stage: str
+) -> None:
+    """AC 8 / AC 16 (a): scope ceiling is in code, not by omission.
+
+    For EVERY stage in STAGE_ORDER except SPEC_REVIEW, compute_next_stage
+    MUST return exactly ``(None, [])`` without evaluating any predicate.
+    This is the test that prevents an executor from "helpfully" adding a
+    second ``elif`` arm beyond the POC scope (D6).
+    """
+    task_dir = _build_task(tmp_path, stage)
+    # Also write a valid-looking human-approval-SPEC_REVIEW receipt to
+    # prove that even with proof material sitting on disk, a non-SPEC_REVIEW
+    # manifest still short-circuits to (None, []).
+    spec_sha = hash_file(task_dir / "spec.md")
+    receipt_human_approval(task_dir, "SPEC_REVIEW", spec_sha, approver="human")
+
+    result = compute_next_stage(task_dir)
+
+    assert result == (None, []), (
+        f"compute_next_stage must return (None, []) for stage={stage!r}; "
+        f"got {result!r}. Scope ceiling (D6/AC 8) violated."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) SPEC_REVIEW, missing receipt → ("PLANNING", [<missing reason>])
+# ---------------------------------------------------------------------------
+
+def test_spec_review_missing_receipt_returns_missing_proof(tmp_path: Path) -> None:
+    """AC 7 / AC 16 (b): missing human-approval receipt is reported.
+
+    Reason wording must mirror ``_human_approval_err`` in lib_core.py:
+    contains the literal substrings "missing" AND
+    "human-approval-SPEC_REVIEW".
+    """
+    task_dir = _build_task(tmp_path, "SPEC_REVIEW")
+    (task_dir / "receipts").mkdir(parents=True, exist_ok=True)
+    # NO human-approval-SPEC_REVIEW.json is written.
+
+    next_stage, reasons = compute_next_stage(task_dir)
+
+    assert next_stage == "PLANNING", (
+        f"On SPEC_REVIEW, proposed next_stage must be 'PLANNING' even when "
+        f"predicates fail; got {next_stage!r}"
+    )
+    assert isinstance(reasons, list), f"reasons must be list[str]; got {type(reasons)}"
+    assert len(reasons) >= 1, (
+        f"Missing receipt must yield at least one reason string; got {reasons!r}"
+    )
+    joined = " || ".join(reasons).lower()
+    assert "missing" in joined, (
+        f"At least one reason must contain 'missing'; got {reasons!r}"
+    )
+    assert "human-approval-spec_review" in joined, (
+        f"At least one reason must name 'human-approval-SPEC_REVIEW'; "
+        f"got {reasons!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) SPEC_REVIEW, hash mismatch → ("PLANNING", [<hash mismatch reason>])
+# ---------------------------------------------------------------------------
+
+def test_spec_review_hash_mismatch_returns_missing_proof(tmp_path: Path) -> None:
+    """AC 7 / AC 16 (c): receipt present but artifact_sha256 drift.
+
+    Reason wording must mirror ``_human_approval_err``'s hash-mismatch
+    branch: contains the literal substrings "hash mismatch" AND
+    "human-approval-SPEC_REVIEW".
+    """
+    task_dir = _build_task(tmp_path, "SPEC_REVIEW")
+    # Write a receipt pinned to a BOGUS hash (stale approval vs. the live spec).
+    receipt_human_approval(
+        task_dir, "SPEC_REVIEW", "a" * 64, approver="human"
+    )
+    # Sanity: the live spec's hash is NOT "a" * 64.
+    live_sha = hash_file(task_dir / "spec.md")
+    assert live_sha != "a" * 64
+
+    next_stage, reasons = compute_next_stage(task_dir)
+
+    assert next_stage == "PLANNING", (
+        f"next_stage must be 'PLANNING' on hash-mismatch refusal; got {next_stage!r}"
+    )
+    assert isinstance(reasons, list), f"reasons must be list[str]; got {type(reasons)}"
+    assert len(reasons) >= 1, f"Hash mismatch must yield a reason; got {reasons!r}"
+    joined = " || ".join(reasons).lower()
+    assert "hash mismatch" in joined, (
+        f"At least one reason must contain 'hash mismatch'; got {reasons!r}"
+    )
+    assert "human-approval-spec_review" in joined, (
+        f"At least one reason must name 'human-approval-SPEC_REVIEW'; "
+        f"got {reasons!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) SPEC_REVIEW, valid receipt → ("PLANNING", []) EXACTLY
+# ---------------------------------------------------------------------------
+
+def test_spec_review_valid_receipt_returns_clean_advance(tmp_path: Path) -> None:
+    """AC 7 / AC 16 (d): happy path returns (PLANNING, []) EXACTLY.
+
+    Every predicate passes:
+      - receipt exists with valid=true and contract_version >= 2
+        (``write_receipt`` always writes RECEIPT_CONTRACT_VERSION which
+        satisfies ``MIN_VERSION_PER_STEP["human-approval-*"] = 2``).
+      - spec.md exists.
+      - receipt.artifact_sha256 == hash_file(spec.md).
+    """
+    task_dir = _build_task(tmp_path, "SPEC_REVIEW")
+    live_sha = hash_file(task_dir / "spec.md")
+    _write_approval_receipt_direct(task_dir, live_sha)
+
+    result = compute_next_stage(task_dir)
+
+    assert result == ("PLANNING", []), (
+        f"Valid-proofs happy path must return ('PLANNING', []) EXACTLY; "
+        f"got {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) Purity: no writes, no log_event, no emit_event, no transition_task
+# ---------------------------------------------------------------------------
+
+def test_compute_next_stage_is_pure(tmp_path: Path) -> None:
+    """AC 6 / AC 16 (e): compute_next_stage is load-bearing pure.
+
+    Two axes of verification:
+
+    1. MOCKS on the three "I/O escape hatches" the scheduler module might
+       import — ``transition_task``, ``log_event``, ``emit_event``. After
+       the call, each mock's ``call_count`` MUST be zero. We patch both
+       the definition-site attribute AND the import-site attribute on
+       ``scheduler`` (if that attribute exists) because Python resolves
+       names at the call site, not the definition site.
+    2. BYTE-FOR-BYTE directory snapshot before vs. after. Any write,
+       rename, or touch within ``task_dir`` violates purity. Comparing
+       (size, mtime_ns, sha256) catches even identical-size content
+       rewrites that would slip past an mtime-only check.
+    """
+    task_dir = _build_task(tmp_path, "SPEC_REVIEW")
+    live_sha = hash_file(task_dir / "spec.md")
+    _write_approval_receipt_direct(task_dir, live_sha)
+
+    before = _snapshot_tree(task_dir)
+
+    # Patch at the DEFINITION sites. Patching at scheduler.<name> would
+    # only cover names that scheduler imports directly; patching at
+    # the owning modules covers BOTH direct and re-exported call chains.
+    with patch("lib_core.transition_task") as m_transition, \
+         patch("lib_log.log_event") as m_log, \
+         patch("lib_events.emit_event") as m_emit:
+
+        # Additionally, if scheduler imports these names with
+        # ``from lib_core import transition_task`` (etc.), the name is
+        # bound on the scheduler module at import time and must be
+        # patched THERE too. Use ``create=True`` so the patch works even
+        # if the attribute does not yet exist on scheduler.
+        with patch("scheduler.transition_task", create=True) as m_s_transition, \
+             patch("scheduler.log_event", create=True) as m_s_log, \
+             patch("scheduler.emit_event", create=True) as m_s_emit:
+
+            result = compute_next_stage(task_dir)
+
+            # Sanity: the happy-path call produces the expected tuple
+            # shape regardless of which names are patched — this asserts
+            # we actually exercised a SPEC_REVIEW code path with proof
+            # present, not a degenerate early-return.
+            assert result == ("PLANNING", []), (
+                f"Purity test fixture must hit the happy-path branch; "
+                f"got {result!r}"
+            )
+
+            # 1. No writer/event/transition call anywhere.
+            assert m_transition.call_count == 0, (
+                f"compute_next_stage called transition_task "
+                f"{m_transition.call_count} times; must be 0. Purity broken."
+            )
+            assert m_log.call_count == 0, (
+                f"compute_next_stage called log_event "
+                f"{m_log.call_count} times; must be 0. Purity broken."
+            )
+            assert m_emit.call_count == 0, (
+                f"compute_next_stage called emit_event "
+                f"{m_emit.call_count} times; must be 0. Purity broken."
+            )
+            assert m_s_transition.call_count == 0, (
+                f"compute_next_stage called scheduler.transition_task "
+                f"{m_s_transition.call_count} times; must be 0."
+            )
+            assert m_s_log.call_count == 0, (
+                f"compute_next_stage called scheduler.log_event "
+                f"{m_s_log.call_count} times; must be 0."
+            )
+            assert m_s_emit.call_count == 0, (
+                f"compute_next_stage called scheduler.emit_event "
+                f"{m_s_emit.call_count} times; must be 0."
+            )
+
+    # 2. Byte-for-byte equality of the directory tree.
+    after = _snapshot_tree(task_dir)
+    assert set(before.keys()) == set(after.keys()), (
+        f"compute_next_stage added or removed files. "
+        f"before_only={set(before) - set(after)!r}; "
+        f"after_only={set(after) - set(before)!r}"
+    )
+    for rel in before:
+        b_size, b_mtime, b_sha = before[rel]
+        a_size, a_mtime, a_sha = after[rel]
+        assert b_size == a_size, f"Size changed for {rel}: {b_size} -> {a_size}"
+        assert b_sha == a_sha, (
+            f"SHA256 changed for {rel}: {b_sha} -> {a_sha} "
+            f"(compute_next_stage mutated file contents)"
+        )
+        assert b_mtime == a_mtime, (
+            f"mtime changed for {rel}: {b_mtime} -> {a_mtime} "
+            f"(compute_next_stage rewrote or touched the file)"
+        )

--- a/tests/test_scheduler_spec_review_to_planning.py
+++ b/tests/test_scheduler_spec_review_to_planning.py
@@ -1,0 +1,253 @@
+"""Integration test for approve-stage -> receipt -> scheduler -> PLANNING.
+
+Covers AC 15 of task-20260419-008. This is the SINGLE merge-gate test
+per the User Context section of the spec:
+
+    "The integration test in AC 15 is the single gate that blocks merge;
+     reviewers cannot 'spot-check' a state-machine diff visually."
+
+The test exercises the full in-process dispatch chain:
+
+    cmd_approve_stage
+        -> receipt_human_approval
+            -> write_receipt
+                -> _atomic_write_text (receipt now durable)
+                -> log_event("receipt_written", ...)
+                -> scheduler.handle_receipt_written(task_dir, step, sha)
+                    -> compute_next_stage -> ("PLANNING", [])
+                    -> transition_task(task_dir, "PLANNING")
+                        -> manifest["stage"] = "PLANNING"
+                        -> log_event("stage_transition", ...)
+
+After ``cmd_approve_stage`` returns, the manifest MUST be at PLANNING
+(proves synchronous in-process dispatch — an async queued path would
+leave the manifest at SPEC_REVIEW at this assertion point).
+
+Pre-implementation (TDD red phase): the test FAILS because
+``cmd_approve_stage`` still calls ``transition_task`` directly
+(legacy path) AND the ``hooks/scheduler.py`` module does not exist, so
+the import-chain fires ImportError inside ``write_receipt``'s lazy
+import. Post-implementation (AC 5-12): the test passes cleanly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Match the project-wide sys.path convention (see
+# tests/test_receipt_human_approval.py, tests/test_eventbus_drain.py, etc.)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import hash_file  # noqa: E402
+import ctl as ctl_module  # noqa: E402
+
+
+SPEC_MD_CONTENTS = (
+    "# Normalized Spec\n\n"
+    "## Task Summary\nIntegration test.\n\n"
+    "## User Context\nCI.\n\n"
+    "## Acceptance Criteria\n1. first\n2. second\n\n"
+    "## Implicit Requirements Surfaced\nNone.\n\n"
+    "## Out of Scope\nNone.\n\n"
+    "## Assumptions\nsafe assumption: none\n\n"
+    "## Risk Notes\nNone.\n"
+)
+
+
+def _build_task(tmp_path: Path) -> Path:
+    """Build a minimal <repo>/.dynos/task-TEST/ tree at SPEC_REVIEW.
+
+    Mirrors the minimal-manifest shape used by tests/test_ctl_approve_stage.py
+    so that downstream gates (classification schema, task_id format) accept
+    it without complaint.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".dynos").mkdir()
+    task_dir = root / ".dynos" / "task-TEST"
+    task_dir.mkdir(parents=True)
+
+    (task_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "task_id": "task-TEST",
+                "created_at": "2026-04-19T00:00:00Z",
+                "title": "Scheduler integration test",
+                "raw_input": "x",
+                "stage": "SPEC_REVIEW",
+                "classification": {
+                    "type": "feature",
+                    "domains": ["backend"],
+                    "risk_level": "medium",
+                    "notes": "n",
+                },
+                "retry_counts": {},
+                "blocked_reason": None,
+                "completion_at": None,
+            },
+            indent=2,
+        )
+    )
+    (task_dir / "spec.md").write_text(SPEC_MD_CONTENTS)
+    (task_dir / "receipts").mkdir()
+    return task_dir
+
+
+def _read_events(task_dir: Path) -> list[dict]:
+    """Return all JSONL records from the task-scoped events.jsonl.
+
+    log_event writes to ``<task_dir>/events.jsonl`` when the task dir
+    exists (see hooks/lib_log.py:104-109). We also union in the global
+    ``.dynos/events.jsonl`` as a fallback in case a rare code path
+    writes there instead.
+    """
+    records: list[dict] = []
+    task_events = task_dir / "events.jsonl"
+    if task_events.exists():
+        for line in task_events.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    global_events = task_dir.parent / "events.jsonl"
+    if global_events.exists():
+        for line in global_events.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def test_approve_stage_spec_review_advances_to_planning_via_scheduler(
+    tmp_path: Path,
+) -> None:
+    """AC 15: full end-to-end scheduler dispatch chain.
+
+    Invokes ``hooks.ctl.cmd_approve_stage`` in-process via an
+    ``argparse.Namespace`` (matching the established harness pattern
+    used by ``tests/test_ctl_approve_stage.py`` and
+    ``tests/test_ctl.py`` for in-process ctl invocations), then asserts:
+
+    (c) return value == 0
+    (d) human-approval-SPEC_REVIEW.json exists and artifact_sha256
+        matches hash_file(spec.md)
+    (e) manifest.json["stage"] == "PLANNING" EXACTLY (proves
+        synchronous in-process dispatch)
+    (f) events.jsonl contains a stage_transition SPEC_REVIEW -> PLANNING
+    (g) NO scheduler-refused.json was written
+    """
+    task_dir = _build_task(tmp_path)
+
+    # (b) Invoke cmd_approve_stage in-process with argparse.Namespace.
+    # AC 15 (b) + plan OQ4 direct us to use the same shape as existing
+    # ctl tests. The existing tests/test_ctl_approve_stage.py drives
+    # ctl via subprocess, but AC 15 explicitly says "using
+    # argparse.Namespace or the equivalent helper already used by other
+    # ctl tests." argparse.Namespace matches the cmd_* function
+    # signature expected by ctl.py (see e.g. cmd_approve_stage(args)
+    # -> int at hooks/ctl.py:109), so we use it directly.
+    #
+    # RUTHLESSNESS: we wrap ctl.transition_task in a spy-raise so that
+    # if cmd_approve_stage still calls transition_task directly (the
+    # legacy path deleted by AC 11), this test fails loudly. Without
+    # this spy, the test would spuriously pass in partial-implementation
+    # states where segments 3-4 land but segment-5 (ctl.py trim) does
+    # not — the legacy transition_task call would advance the manifest
+    # and the test would green unjustifiedly. The spy makes AC 11's
+    # "ctl.py no longer drives the transition" contract verifiable.
+    ns = argparse.Namespace(task_dir=str(task_dir), stage="SPEC_REVIEW")
+    with patch.object(
+        ctl_module,
+        "transition_task",
+        side_effect=AssertionError(
+            "ctl.cmd_approve_stage MUST NOT call transition_task after "
+            "AC 11 — the scheduler owns the SPEC_REVIEW -> PLANNING "
+            "transition. Found a direct call from ctl.py."
+        ),
+    ):
+        rc = ctl_module.cmd_approve_stage(ns)
+
+    # (c) return 0.
+    assert rc == 0, (
+        f"cmd_approve_stage must return 0 on happy path; got {rc}. "
+        f"Either the receipt write failed or the scheduler dispatch "
+        f"refused the advance."
+    )
+
+    # (d) Receipt exists and artifact_sha256 matches live spec hash.
+    receipt_path = task_dir / "receipts" / "human-approval-SPEC_REVIEW.json"
+    assert receipt_path.exists(), (
+        f"human-approval-SPEC_REVIEW receipt MUST exist at {receipt_path}; "
+        f"cmd_approve_stage never wrote it."
+    )
+    receipt = json.loads(receipt_path.read_text())
+    live_sha = hash_file(task_dir / "spec.md")
+    assert receipt.get("artifact_sha256") == live_sha, (
+        f"Receipt artifact_sha256 drift: "
+        f"receipt={receipt.get('artifact_sha256')!r}, "
+        f"live={live_sha!r}"
+    )
+    assert receipt.get("valid") is True, (
+        f"Receipt must have valid=true; got {receipt!r}"
+    )
+    # Contract version floor per MIN_VERSION_PER_STEP["human-approval-*"] = 2
+    assert int(receipt.get("contract_version", 0)) >= 2, (
+        f"Receipt contract_version must be >= 2 to be accepted by "
+        f"read_receipt; got {receipt.get('contract_version')!r}"
+    )
+
+    # (e) Manifest at PLANNING — THE critical assertion.
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest.get("stage") == "PLANNING", (
+        f"manifest.stage must be EXACTLY 'PLANNING' after cmd_approve_stage "
+        f"returns (synchronous scheduler dispatch contract). "
+        f"Got {manifest.get('stage')!r}. If this is 'SPEC_REVIEW', the "
+        f"scheduler was not wired into write_receipt. If this is anything "
+        f"else, something advanced past PLANNING unexpectedly."
+    )
+
+    # (f) stage_transition event with from=SPEC_REVIEW, to=PLANNING.
+    # transition_task's _auto_log emits log_event with fields
+    # ``from_stage`` / ``to_stage`` (see hooks/lib_core.py:1877-1884).
+    # We accept either naming convention to be robust:
+    # - from_stage/to_stage (actual emission from transition_task)
+    # - stage_from/stage_to (naming used elsewhere, e.g. gate_refused)
+    events = _read_events(task_dir)
+    transitions = [e for e in events if e.get("event") == "stage_transition"]
+    assert transitions, (
+        f"events.jsonl must contain at least one stage_transition event; "
+        f"got events={[e.get('event') for e in events]!r}"
+    )
+
+    def _matches(e: dict) -> bool:
+        frm = e.get("from_stage") or e.get("stage_from")
+        to = e.get("to_stage") or e.get("stage_to")
+        return frm == "SPEC_REVIEW" and to == "PLANNING"
+
+    matching = [e for e in transitions if _matches(e)]
+    assert matching, (
+        f"events.jsonl must contain a stage_transition with "
+        f"from=SPEC_REVIEW and to=PLANNING; got transitions={transitions!r}"
+    )
+
+    # (g) NO scheduler-refused receipt — the happy path MUST NOT write
+    # receipt_scheduler_refused because compute_next_stage returns
+    # (PLANNING, []) with no missing proofs.
+    refused_path = task_dir / "receipts" / "scheduler-refused.json"
+    assert not refused_path.exists(), (
+        f"scheduler-refused.json MUST NOT be written on the happy path; "
+        f"found receipt at {refused_path}. Scheduler wrongly refused a "
+        f"valid advance (check compute_next_stage predicates)."
+    )

--- a/tests/test_skill_stage_references.py
+++ b/tests/test_skill_stage_references.py
@@ -36,6 +36,19 @@ _NOT_A_STAGE = {"STAGE", "STAGES", "TODO", "FIXME", "HACK", "NOTE", "PLUGIN_HOOK
                 "PYTHONPATH", "EOF", "AGENT_JSON_OUTPUT", "EXECUTOR_PLAN_JSON"}
 
 
+# Marker that delegates a stage transition to the scheduler event bus.
+# Example: `<!-- scheduler-owned: SPEC_REVIEW -> PLANNING -->`
+_SCHEDULER_OWNED_RE = re.compile(r"<!--\s*scheduler-owned:\s*([A-Z_][A-Z0-9_]*)\s*->\s*([A-Z_][A-Z0-9_]*)\s*-->")
+
+
+# Substrings that together form the "manually set stage" anti-pattern. The
+# detector flags any co-occurrence of these two substrings within a small
+# byte window, mirroring how a human would notice the phrase at a glance.
+_MANUAL_NEEDLE = b"manually set"
+_STAGE_NEEDLE = b'"stage"'
+_MANUAL_STAGE_WINDOW_BYTES = 80
+
+
 def _extract_stage_references(text: str) -> set[str]:
     """Return the set of stage-like tokens referenced via transition patterns."""
     found: set[str] = set()
@@ -46,6 +59,73 @@ def _extract_stage_references(text: str) -> set[str]:
                 continue
             found.add(token)
     return found
+
+
+def _all_byte_offsets(haystack: bytes, needle: bytes) -> list[int]:
+    """Return every starting byte offset where needle occurs in haystack.
+
+    Pure literal substring search — no regex, no normalization. Overlaps
+    are permitted because the detector cares about any co-occurrence.
+    """
+    offsets: list[int] = []
+    start = 0
+    while True:
+        idx = haystack.find(needle, start)
+        if idx == -1:
+            return offsets
+        offsets.append(idx)
+        start = idx + 1
+
+
+def find_manual_stage_advice(data: bytes | str) -> tuple[int, int] | None:
+    """Locate the `manually set` / `"stage"` anti-pattern within a window.
+
+    Scans the raw byte payload for every occurrence of the case-sensitive
+    literal substring `manually set` and every occurrence of the literal
+    substring `"stage"` (with the double-quote characters). Returns the
+    (manual_offset, stage_offset) pair whose nearest edges fall within
+    `_MANUAL_STAGE_WINDOW_BYTES` of each other, or `None` if no such pair
+    exists. The window is measured edge-to-edge: if `manually set` ends
+    before `"stage"` begins, the gap is `stage_start - manual_end`; if
+    `"stage"` ends before `manually set` begins, the gap is
+    `manual_start - stage_end`; overlapping spans yield a gap of 0.
+
+    Accepts either `bytes` or `str`; strings are encoded as UTF-8 so the
+    raw-byte contract holds regardless of caller convenience.
+    """
+    if isinstance(data, str):
+        buf = data.encode("utf-8")
+    else:
+        buf = data
+
+    manual_offsets = _all_byte_offsets(buf, _MANUAL_NEEDLE)
+    if not manual_offsets:
+        return None
+    stage_offsets = _all_byte_offsets(buf, _STAGE_NEEDLE)
+    if not stage_offsets:
+        return None
+
+    manual_len = len(_MANUAL_NEEDLE)
+    stage_len = len(_STAGE_NEEDLE)
+
+    for m in manual_offsets:
+        m_end = m + manual_len
+        for s in stage_offsets:
+            s_end = s + stage_len
+            if m_end <= s:
+                gap = s - m_end
+            elif s_end <= m:
+                gap = m - s_end
+            else:
+                gap = 0
+            if gap <= _MANUAL_STAGE_WINDOW_BYTES:
+                return (m, s)
+    return None
+
+
+def is_manual_stage_advice(data: bytes | str) -> bool:
+    """Boolean form of `find_manual_stage_advice` for ergonomic assertions."""
+    return find_manual_stage_advice(data) is not None
 
 
 def test_all_skill_stage_references_are_valid():
@@ -173,3 +253,85 @@ More prose with `[STAGE] → DONE` inline (descriptive).
     assert stages == ["CHECKPOINT_AUDIT"], (
         f"only the in-fence stage should be reported, got {stages}"
     )
+
+
+def test_no_skill_prose_advises_manual_stage_edit():
+    """Prose must never tell the orchestrator to hand-edit `manifest.json`
+    around the `stage` key. The canonical path is `transition_task(...)`;
+    any literal "manually set ... \"stage\"" sentence is an escape hatch
+    that leaves `stage` and companion fields (e.g., `completion_at`) out
+    of sync and bypasses the receipt-gate that `transition_task` enforces.
+
+    Flags any `manually set` occurrence within 80 raw bytes of a literal
+    `"stage"` occurrence (edges measured edge-to-edge; see
+    `find_manual_stage_advice`). Reports both byte offsets so the
+    offending phrase can be pinpointed without re-reading the file.
+    """
+    failures: list[str] = []
+    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        raw = skill_md.read_bytes()
+        hit = find_manual_stage_advice(raw)
+        if hit is not None:
+            manual_off, stage_off = hit
+            relpath = skill_md.relative_to(REPO_ROOT)
+            failures.append(
+                f"{relpath}: 'manually set' at byte {manual_off} is within "
+                f"{_MANUAL_STAGE_WINDOW_BYTES} bytes of '\"stage\"' at byte "
+                f"{stage_off} (manual-stage-edit anti-pattern)"
+            )
+
+    assert not failures, (
+        "Skill prose advises manually hand-editing the 'stage' key — use "
+        "transition_task(...) instead:\n"
+        + "\n".join(f"  - {f}" for f in failures)
+    )
+
+
+def test_manual_stage_advice_detector_flags_bad_fragment():
+    """Regression test for the detector helper itself.
+
+    A synthetic fragment with the two substrings within 80 bytes must
+    return True; a fragment with the substrings >80 bytes apart must
+    return False. Both assertions guard against future "fix" attempts
+    that silently widen or collapse the detection window.
+    """
+    # Substrings sit a few bytes apart — well inside the 80-byte window.
+    bad = 'If calling directly fails, manually set both "stage": "DONE" and ...'
+    assert is_manual_stage_advice(bad) is True, (
+        "detector failed to flag an obviously-bad fragment; "
+        f"offset lookup returned {find_manual_stage_advice(bad)!r}"
+    )
+
+    # Substrings separated by well over 80 bytes of filler must NOT trip.
+    filler = "x" * 200
+    good = f"manually set a reminder {filler} then later tweak the config for \"stage\" builds"
+    assert len(good.encode("utf-8")) > 200
+    assert is_manual_stage_advice(good) is False, (
+        "detector flagged a fragment whose substrings are >80 bytes apart; "
+        f"offset lookup returned {find_manual_stage_advice(good)!r}"
+    )
+
+
+def test_scheduler_owned_transitions_are_exempt_from_transition_prose_requirement():
+    """Any `<!-- scheduler-owned: FROM -> TO -->` marker present in skill
+    prose must name a transition that is currently approved as
+    scheduler-driven. For the POC scope, only `SPEC_REVIEW -> PLANNING`
+    is delegated to the scheduler; every other pair is a premature
+    handoff that would bypass `compute_next_stage` until the migration
+    tasks extend it.
+    """
+    failures: list[str] = []
+    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        text = skill_md.read_text()
+        for match in _SCHEDULER_OWNED_RE.finditer(text):
+            from_stage, to_stage = match.group(1), match.group(2)
+            path = skill_md.relative_to(REPO_ROOT)
+            if (from_stage, to_stage) != ("SPEC_REVIEW", "PLANNING"):
+                failures.append(
+                    f"scheduler-owned marker for {from_stage} -> {to_stage} in "
+                    f"{path} is beyond POC scope; only SPEC_REVIEW -> PLANNING "
+                    f"is permitted until follow-up migration tasks extend "
+                    f"compute_next_stage"
+                )
+
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary

Bumps plugin version **7.0.0 → 7.1.0**. Bundles the scheduler POC (task-20260419-008) with the version bump + CHANGELOG so users running `/plugin update dynos-work` get both at once.

Two commits:
1. `close LLM-owns-stage-transitions anti-pattern` — the scheduler POC + audit DONE escape hatch deletion (task-20260419-008)
2. `release 7.1.0` — plugin.json + marketplace.json + CHANGELOG

## Why this release

Since v7.0.0 (2026-04-16) the main branch has had 47+ commits covering:

- **Enforcement / state-machine hardening** (#123, #124, #125, #126, #127, #128, #130, #131, #132, #133 + this PR): receipt writers self-compute machine-derivable fields, caller-supplied scores/counts raise TypeError, contract version bumped 2 → 4 in two waves.
- **Scheduler POC** (this PR): SPEC_REVIEW → PLANNING advances when the human-approval receipt hits disk. Opens the pattern for future stage migrations without ripping out the existing pull-based path.
- **LLM-powered postmortem analysis** with structured rule templates that merge into the prevention-rules registry.
- **Plug-and-play modularity**: auditor registry, executor discovery, action spaces, ensemble wiring, handler discovery.
- **5 new CI linters**: event emit/consume parity, ValueError coverage, receipt self-verify parity, manual-stage-edit detector, scheduler-owned marker scope-ceiling.
- **Router executor-plan cache** (#113, #114): eliminates re-rolled epsilon-greedy dice between `executor-plan` and `inject-prompt` — the model the executor is spawned under always matches the model the prompt was injected for.
- **Worktree slug normalization** (#122): retrospectives / benchmarks / learned agents flow back to the same persistent dir regardless of which worktree executed.

See `CHANGELOG.md` for the full list.

## The stale-skill-cache motivation

This release is motivated in part by the fact that users running v7.0.0 hit errors like `TypeError: receipt_retrospective no longer accepts caller-supplied ['cost_score', ...]` because the cached skill prompt shows an intermediate-state 5-arg signature that no longer matches the writer. The v7.0.0 cache in `~/.claude/plugins/cache/dynos-work/dynos-work/7.0.0/` is frozen at the v7.0.0 tag and cannot update until a new plugin version lands. Landing 7.1.0 fixes the stale-skill issue for every user on next `/plugin update`.

## Test plan

- [x] `python3 -m pytest tests/` — 1511 passed, 2 skipped
- [x] task-20260419-008 ran cleanly through the full foundry pipeline (start → execute → audit → DONE → CALIBRATED)
- [x] `/dynos-work:audit` ensemble voting exercised (haiku + sonnet split; opus escalation overturned sonnet's CRITICAL finding)
- [ ] `/plugin update dynos-work` in a fresh checkout pulls 7.1.0 and the updated skills (requires merge + release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)