### PR TITLE
feat: enforce audit-* read scope at pre_tool_use hook

### DIFF
--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -79,6 +79,17 @@ DIAGNOSTIC_ONLY_EVENTS: frozenset[str] = frozenset({
     "pre_tool_use_role_missing",
     "pre_tool_use_bash_check",
     "pre_tool_use_role_file_missing",
+    # Audit-plan presence/shape diagnostics (pre_tool_use.py audit-plan
+    # check, task-20260501-002). Emitted when audit-plan.json is missing
+    # or malformed at PreToolUse time. Forensic trace only — no gate or
+    # state machine depends on these events.
+    "pre_tool_use_audit_plan_missing",
+    "pre_tool_use_audit_plan_invalid",
+    # Read-policy decision observability (read_policy gate, task-20260501-002).
+    # Forensic trace recording allow/deny decisions for read attempts.
+    # Observability only — no gate or state machine depends on these events.
+    "read_policy_allowed",
+    "read_policy_denied",
     # Risk level override observability (ctl._normalize_classification_payload).
     # Forensic trace — records when an observed_floor overrides the planner's
     # risk_level upward. No gate or state machine blocks on this event.

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -648,13 +648,17 @@ def validate_repair_log(task_dir: Path) -> list[str]:
                     f"repair-log={auditor!r} audit-report={live_finding.get('_auditor_name')!r}"
                 )
             severity = task.get("severity")
+            _SEV_ALIASES = {"major": "high", "minor": "low"}
+            severity = _SEV_ALIASES.get(severity, severity) if severity is not None else None
+            live_sev = live_finding.get("severity") if live_finding is not None else None
+            live_sev_norm = _SEV_ALIASES.get(live_sev, live_sev) if isinstance(live_sev, str) else live_sev
             if severity is not None and severity not in {"critical", "high", "medium", "low"}:
                 errors.append(f"{batch_id}: invalid severity {severity!r}")
             elif (
                 severity is not None
                 and live_finding is not None
                 and isinstance(live_finding.get("severity"), str)
-                and severity != live_finding.get("severity")
+                and severity != live_sev_norm
             ):
                 errors.append(
                     f"{batch_id}: severity mismatch for {finding_id}: "

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -82,6 +82,11 @@ _BASH_WRITE_PATTERNS: list[tuple[re.Pattern[str], int]] = [
     (re.compile(r"\brsync\s+(?:\S+\s+)+([^\s;|&]+)"), 1),
     # install: install [-m MODE] [opts] src dst
     (re.compile(r"\binstall\s+(?:-[a-zA-Z]+\s+(?:\S+\s+)?)?(?:\S+\s+)+([^\s;|&]+)"), 1),
+    # rm: rm [opts] file — sec-1 fix: deletion of audit-grep-quota.json
+    # was the quota-bypass primitive. Each non-flag argument is checked.
+    (re.compile(r"\brm\s+(?:-[a-zA-Z]+\s+)*([^\s;|&]+)"), 1),
+    # unlink: unlink file
+    (re.compile(r"\bunlink\s+([^\s;|&]+)"), 1),
 ]
 
 

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -29,11 +29,11 @@ _EXECUTOR_ROLE_ALLOWLIST: frozenset[str] = frozenset({
     "ml-executor", "db-executor", "refactor-executor", "docs-executor",
     "planning", "execute-inline", "repair-coordinator",
     "audit-spec-completion", "audit-security", "audit-code-quality",
-    "audit-performance", "audit-dead-code", "audit-db-schema", "audit-ui",
+    "audit-performance", "audit-dead-code", "audit-db-schema", "audit-ui", "audit-claude-md",
 })
 
 # ---------------------------------------------------------------------------
-# Module-level imports for write_policy and lib_log.
+# Module-level imports for write_policy, read_policy, and lib_log.
 # These are resolved lazily at first-use inside main() so the hook can still
 # run when the hooks directory is not yet on sys.path (the path is added at
 # the start of main()). The module-level names are set to None initially and
@@ -43,6 +43,9 @@ _EXECUTOR_ROLE_ALLOWLIST: frozenset[str] = frozenset({
 decide_write = None  # type: ignore[assignment]
 _emit_policy_event = None  # type: ignore[assignment]
 WriteAttempt = None  # type: ignore[assignment]
+decide_read = None  # type: ignore[assignment]
+ReadAttempt_RP = None  # type: ignore[assignment]
+_emit_read_policy_event = None  # type: ignore[assignment]
 log_event = None  # type: ignore[assignment]
 
 
@@ -105,9 +108,9 @@ def _resolve_path(raw: str, cwd: Path) -> Path:
 
 def main() -> int:
     """Main entry point. Returns exit code."""
-    global decide_write, _emit_policy_event, WriteAttempt, log_event
+    global decide_write, _emit_policy_event, WriteAttempt, decide_read, ReadAttempt_RP, _emit_read_policy_event, log_event
 
-    # Add hooks directory to sys.path so we can import write_policy and lib_log
+    # Add hooks directory to sys.path so we can import write_policy, read_policy, and lib_log
     script_dir = Path(__file__).resolve().parent
     if str(script_dir) not in sys.path:
         sys.path.insert(0, str(script_dir))
@@ -155,6 +158,21 @@ def main() -> int:
             return 1
         # If decide_write was pre-populated (test context), proceed without
         # write_policy — WriteAttempt and _emit_policy_event may be None
+
+    # Import read_policy -- failure is non-fatal if decide_read was pre-populated
+    try:
+        import read_policy as _rp
+        if decide_read is None:
+            decide_read = _rp.decide_read
+        if ReadAttempt_RP is None:
+            ReadAttempt_RP = _rp.ReadAttempt
+        if _emit_read_policy_event is None:
+            _emit_read_policy_event = _rp._emit_read_policy_event
+    except ImportError as exc:
+        # Only fatal if decide_read itself is not yet available
+        if decide_read is None:
+            print(f"pre-tool-use: cannot import read_policy: {exc}", file=sys.stderr)
+            return 1
 
     # Import lib_log -- failure is non-fatal (event logging is optional)
     if log_event is None:
@@ -368,6 +386,130 @@ def main() -> int:
                 print(f"write-policy: {decision.reason}", file=sys.stderr)
                 return 2
 
+        return 0
+
+    # -----------------------------------------------------------------
+    # Handle Read, Grep, Glob tools: enforce read policy for audit roles
+    # -----------------------------------------------------------------
+    if tool_name in ("Read", "Grep", "Glob"):
+        # AC 16: non-audit roles bypass read-policy enforcement entirely.
+        if not role.startswith("audit-"):
+            return 0
+
+        # No task_dir: cannot enforce stage/diff scope; passthrough.
+        if task_dir is None:
+            return 0
+
+        # AC 15: stage guard. Read manifest.json; on any read/parse exception
+        # (including FileNotFoundError when the file is missing), fail-closed.
+        # Permitted stages source: spec.md AC 15 (PLAN_AUDIT, CHECKPOINT_AUDIT,
+        # FINAL_AUDIT, REPAIR_PLANNING, REPAIR_EXECUTION).
+        permitted_stages = {
+            "PLAN_AUDIT", "CHECKPOINT_AUDIT", "FINAL_AUDIT",
+            "REPAIR_PLANNING", "REPAIR_EXECUTION",
+        }
+        try:
+            manifest_data = json.loads((task_dir / "manifest.json").read_text())
+            stage = manifest_data.get("stage", "")
+        except Exception:
+            print(
+                "read-policy: manifest unreadable; denying audit-* tool call",
+                file=sys.stderr,
+            )
+            return 2
+        if stage not in permitted_stages:
+            print(
+                f"read-policy: audit role not permitted at stage {stage}",
+                file=sys.stderr,
+            )
+            return 2
+
+        # AC 13/14: load audit-plan.json with distinct missing/invalid events.
+        audit_plan = None
+        audit_plan_path = task_dir / "audit-plan.json"
+        if not audit_plan_path.exists():
+            # Missing: emit pre_tool_use_audit_plan_missing
+            try:
+                if log_event is not None:
+                    log_event(
+                        task_dir.parent.parent,
+                        "pre_tool_use_audit_plan_missing",
+                        task=task_dir.name,
+                        tool_name=tool_name,
+                    )
+            except Exception:
+                pass
+        else:
+            # Exists: parse and validate. Any failure → audit_plan=None +
+            # pre_tool_use_audit_plan_invalid.
+            invalid = False
+            try:
+                parsed = json.loads(audit_plan_path.read_text())
+                if isinstance(parsed, dict) and isinstance(parsed.get("diff_files"), list):
+                    audit_plan = parsed
+                else:
+                    invalid = True
+            except Exception:
+                invalid = True
+            if invalid:
+                audit_plan = None
+                try:
+                    if log_event is not None:
+                        log_event(
+                            task_dir.parent.parent,
+                            "pre_tool_use_audit_plan_invalid",
+                            task=task_dir.name,
+                            tool_name=tool_name,
+                        )
+                except Exception:
+                    pass
+
+        # AC 3: extract target per tool. tool_input must be a dict.
+        if not isinstance(tool_input, dict):
+            print(f"pre-tool-use: {tool_name} tool_input is not a dict", file=sys.stderr)
+            return 1
+
+        raw_pattern: str | None = None
+        if tool_name == "Read":
+            raw_path = tool_input.get("file_path") or tool_input.get("path") or ""
+            if not raw_path:
+                print("pre-tool-use: Read has no file_path in tool_input", file=sys.stderr)
+                return 1
+            target = _resolve_path(raw_path, cwd)
+        elif tool_name == "Grep":
+            # CRITICAL: Grep target is `path` (search root), NOT `pattern` (regex).
+            raw_path = tool_input.get("path", "")
+            if not raw_path:
+                # No explicit search root: fall back to cwd. This still allows
+                # decide_read to apply the diff/task_dir allowlist on cwd.
+                raw_path = str(cwd)
+            target = _resolve_path(raw_path, cwd)
+        else:  # Glob
+            pattern = tool_input.get("pattern", "")
+            if not pattern:
+                print("pre-tool-use: Glob has no pattern in tool_input", file=sys.stderr)
+                return 1
+            raw_pattern = pattern
+            # Best-effort: resolve pattern as a path so prefix checks see
+            # an absolute string. The original pattern is preserved in raw_pattern.
+            target = _resolve_path(pattern, cwd)
+
+        attempt = ReadAttempt_RP(
+            role=role,
+            task_dir=task_dir,
+            target=target,
+            tool_name=tool_name,
+            raw_pattern=raw_pattern,
+        )
+        decision = decide_read(attempt, audit_plan=audit_plan)
+        try:
+            _emit_read_policy_event(attempt, decision)
+        except Exception:
+            pass
+
+        if not decision.allowed:
+            print(f"read-policy: {decision.reason}", file=sys.stderr)
+            return 2
         return 0
 
     # Unknown tool name -- pass without policy check

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -309,6 +309,24 @@ def main() -> int:
 
         destinations = _extract_bash_destinations(command)
 
+        # Substring-scan defense for control-plane filenames against deletion
+        # primitives that bypass _extract_bash_destinations. Only scans when
+        # the command contains a deletion verb (rm/rmdir/unlink/shred/find-
+        # -delete/truncate) — avoids false positives on `git commit -m
+        # "...audit-grep-quota.json..."` and similar non-destructive uses.
+        # Parser-independent within the deletion class; closes V1-V5 from
+        # sec-1-residual.
+        _DELETION_VERB = re.compile(
+            r"\b(rm|rmdir|unlink|shred|truncate)\b|\bfind\b[^|;&]*-delete\b"
+        )
+        if task_dir is not None and _DELETION_VERB.search(command):
+            from write_policy import _CONTROL_PLANE_EXACT
+            for cp_name in _CONTROL_PLANE_EXACT:
+                if cp_name in command:
+                    cp_path = (task_dir / cp_name).resolve()
+                    if str(cp_path) not in destinations and cp_name not in destinations:
+                        destinations.append(str(cp_path))
+
         if not destinations:
             # No write pattern matched -- pass without policy check
             return 0

--- a/hooks/read_policy.py
+++ b/hooks/read_policy.py
@@ -1,0 +1,227 @@
+"""Central read-boundary policy for audit roles."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReadAttempt:
+    """Represents an attempt to read a file via a tool.
+
+    Fields:
+        role: The executor role attempting the read
+        task_dir: The task directory (or None for non-task operations)
+        target: The resolved path being read
+        tool_name: The tool being used ("Read", "Grep", or "Glob")
+        raw_pattern: The raw pattern for Glob tool (None for Read/Grep)
+    """
+    role: str
+    task_dir: Path | None
+    target: Path
+    tool_name: str  # "Read" | "Grep" | "Glob"
+    raw_pattern: str | None
+
+
+@dataclass(frozen=True)
+class ReadDecision:
+    """Represents a decision to allow or deny a read.
+
+    Fields:
+        allowed: True if the read is allowed, False otherwise
+        reason: Human-readable explanation of the decision
+        quota_used: Number of quota slots used (only for dead-code Grep quota)
+    """
+    allowed: bool
+    reason: str
+    quota_used: int | None
+
+
+def decide_read(attempt: ReadAttempt, *, audit_plan: dict | None) -> ReadDecision:
+    """Decide whether to allow a read based on role, task_dir, and allowlist.
+
+    Decision tree (in order):
+    1. Non-audit roles: fast-exit allow
+    2. CLAUDE.md carve-out: allow for audit-claude-md only
+    3. task_dir allowlist: allow if target inside task_dir
+    4. diff_files allowlist: allow if target in audit_plan["diff_files"]
+    5. Glob prefix matching: allow if pattern starts with task_dir prefix
+    6. Dead-code Grep quota: allow up to 10, increment quota file
+    7. Default deny
+    """
+    # Decision tree step 1: Non-audit roles bypass all checks
+    if not attempt.role.startswith("audit-"):
+        return ReadDecision(allowed=True, reason="non-audit role", quota_used=None)
+
+    # Decision tree step 2: CLAUDE.md carve-out for audit-claude-md only
+    if attempt.role == "audit-claude-md" and attempt.target.name == "CLAUDE.md":
+        return ReadDecision(
+            allowed=True,
+            reason="audit-claude-md CLAUDE.md carve-out",
+            quota_used=None,
+        )
+
+    # Decision tree step 3: task_dir allowlist
+    if attempt.task_dir is not None:
+        try:
+            attempt.target.resolve().relative_to(attempt.task_dir.resolve())
+            return ReadDecision(allowed=True, reason="inside task_dir", quota_used=None)
+        except ValueError:
+            # target is not relative to task_dir; continue to next check
+            pass
+
+    # Decision tree step 4: diff_files allowlist
+    if audit_plan is not None and isinstance(audit_plan, dict):
+        diff_files = audit_plan.get("diff_files")
+        if isinstance(diff_files, list) and attempt.task_dir is not None:
+            # Resolve each diff_files entry against task_dir.parent.parent (repo root)
+            repo_root = attempt.task_dir.parent.parent
+            for entry in diff_files:
+                diff_path = (repo_root / entry).resolve()
+                if diff_path == attempt.target.resolve():
+                    return ReadDecision(
+                        allowed=True,
+                        reason="in diff_files allowlist",
+                        quota_used=None,
+                    )
+
+    # Decision tree step 5: Glob prefix matching
+    if attempt.tool_name == "Glob" and attempt.raw_pattern is not None:
+        normalized = os.path.normpath(attempt.raw_pattern)
+        if attempt.task_dir is not None:
+            # Check if pattern starts with task_dir prefix
+            try:
+                task_dir_str = str(attempt.task_dir.resolve())
+                norm_str = normalized
+                if norm_str.startswith(task_dir_str):
+                    return ReadDecision(allowed=True, reason="glob task_dir prefix", quota_used=None)
+            except Exception:
+                pass
+
+    # Decision tree step 6: Dead-code Grep quota
+    if attempt.role == "audit-dead-code" and attempt.tool_name == "Grep":
+        if attempt.task_dir is not None:
+            return _handle_dead_code_grep_quota(attempt)
+
+    # Decision tree step 7: Default deny
+    return ReadDecision(
+        allowed=False,
+        reason=f"read-policy: target outside allowlist for role={attempt.role}",
+        quota_used=None,
+    )
+
+
+def _handle_dead_code_grep_quota(attempt: ReadAttempt) -> ReadDecision:
+    """Handle audit-dead-code Grep quota logic.
+
+    - First 10 Greps allowed with quota_used incrementing
+    - 11th+ Grep denied without mutating quota file
+    - Unreadable quota file → fail-closed denial
+    - FileNotFoundError on first read → treat as count=0
+    """
+    quota_file = attempt.task_dir / "audit-grep-quota.json"  # type: ignore[union-attr]
+
+    try:
+        # Try to read existing quota
+        if quota_file.exists():
+            try:
+                quota_data = json.loads(quota_file.read_text())
+                count = quota_data.get("count", 0)
+            except (json.JSONDecodeError, OSError, PermissionError) as e:
+                # Unreadable quota file → fail-closed
+                return ReadDecision(
+                    allowed=False,
+                    reason="read-policy: quota state unreadable; denying repo-wide grep",
+                    quota_used=None,
+                )
+        else:
+            # File doesn't exist yet → treat as count=0
+            count = 0
+
+        # Check if quota exhausted
+        if count >= 10:
+            return ReadDecision(
+                allowed=False,
+                reason="read-policy: dead-code grep quota exhausted (10/10)",
+                quota_used=None,
+            )
+
+        # Increment quota atomically
+        new_count = count + 1
+        try:
+            # Write atomically via tempfile + os.replace
+            with tempfile.NamedTemporaryFile(
+                mode='w',
+                dir=quota_file.parent,
+                delete=False,
+                suffix='.tmp',
+            ) as tmp:
+                json.dump({"count": new_count}, tmp)
+                tmp_path = tmp.name
+
+            # Atomic replace
+            os.replace(tmp_path, quota_file)
+        except Exception:
+            # If we can't write, still allow this call but don't track it
+            # (this matches the "silently swallow exceptions" pattern)
+            pass
+
+        return ReadDecision(
+            allowed=True,
+            reason="dead-code quota slot consumed",
+            quota_used=new_count,
+        )
+    except Exception:
+        # Any unexpected exception → fail-closed
+        return ReadDecision(
+            allowed=False,
+            reason="read-policy: quota state unreadable; denying repo-wide grep",
+            quota_used=None,
+        )
+
+
+def _emit_read_policy_event(attempt: ReadAttempt, decision: ReadDecision) -> None:
+    """Emit a read policy event to the event log.
+
+    Mirrors write_policy._emit_policy_event:
+    - Import lib_log lazily, swallow ImportError
+    - If attempt.task_dir is None, return early
+    - Emit "read_policy_allowed" or "read_policy_denied" event
+    - Silently swallow all exceptions
+    """
+    if attempt.task_dir is None:
+        return
+
+    try:
+        from lib_log import log_event
+    except Exception:
+        return
+
+    try:
+        root = attempt.task_dir.parent.parent
+        task_id = attempt.task_dir.name
+
+        # Compute relative path for the event
+        rel = attempt.target.resolve()
+        try:
+            rel = rel.relative_to(root.resolve())
+        except Exception:
+            pass
+
+        payload = {
+            "role": attempt.role,
+            "target": str(rel),
+            "tool_name": attempt.tool_name,
+            "reason": decision.reason,
+        }
+
+        if decision.allowed:
+            log_event(root, "read_policy_allowed", task=task_id, **payload)
+        else:
+            log_event(root, "read_policy_denied", task=task_id, **payload)
+    except Exception:
+        pass

--- a/hooks/read_policy.py
+++ b/hooks/read_policy.py
@@ -57,13 +57,36 @@ def decide_read(attempt: ReadAttempt, *, audit_plan: dict | None) -> ReadDecisio
     if not attempt.role.startswith("audit-"):
         return ReadDecision(allowed=True, reason="non-audit role", quota_used=None)
 
-    # Decision tree step 2: CLAUDE.md carve-out for audit-claude-md only
-    if attempt.role == "audit-claude-md" and attempt.target.name == "CLAUDE.md":
-        return ReadDecision(
-            allowed=True,
-            reason="audit-claude-md CLAUDE.md carve-out",
-            quota_used=None,
-        )
+    # Decision tree step 2: CLAUDE.md carve-out for audit-claude-md only.
+    # Restricted to repo root, ~/.claude/, ~/.config/claude/ (sec-4 fix —
+    # an unrestricted basename match allowed prompt-injection via attacker-
+    # planted /tmp/evil/CLAUDE.md). Read-tool only — Globs/Greps don't
+    # benefit from the basename match.
+    if (
+        attempt.role == "audit-claude-md"
+        and attempt.tool_name == "Read"
+        and attempt.target.name == "CLAUDE.md"
+        and attempt.task_dir is not None
+    ):
+        try:
+            target_resolved = attempt.target.resolve()
+            allowed_roots = [
+                attempt.task_dir.parent.parent.resolve(),
+                (Path.home() / ".claude").resolve(),
+                (Path.home() / ".config" / "claude").resolve(),
+            ]
+            for root in allowed_roots:
+                try:
+                    target_resolved.relative_to(root)
+                    return ReadDecision(
+                        allowed=True,
+                        reason="audit-claude-md CLAUDE.md carve-out",
+                        quota_used=None,
+                    )
+                except ValueError:
+                    continue
+        except Exception:
+            pass
 
     # Decision tree step 3: task_dir allowlist
     if attempt.task_dir is not None:
@@ -97,7 +120,9 @@ def decide_read(attempt: ReadAttempt, *, audit_plan: dict | None) -> ReadDecisio
             try:
                 task_dir_str = str(attempt.task_dir.resolve())
                 norm_str = normalized
-                if norm_str.startswith(task_dir_str):
+                # sec-2 fix: enforce directory boundary so task-XX-evil/* doesn't
+                # match the prefix of task-XX/.
+                if norm_str == task_dir_str or norm_str.startswith(task_dir_str + os.sep):
                     return ReadDecision(allowed=True, reason="glob task_dir prefix", quota_used=None)
             except Exception:
                 pass
@@ -166,9 +191,15 @@ def _handle_dead_code_grep_quota(attempt: ReadAttempt) -> ReadDecision:
             # Atomic replace
             os.replace(tmp_path, quota_file)
         except Exception:
-            # If we can't write, still allow this call but don't track it
-            # (this matches the "silently swallow exceptions" pattern)
-            pass
+            # sec-3 / cq-001 fix: write failure must fail-closed, not silently
+            # allow. The quota state is corrupt (slot consumed but not
+            # persisted); subsequent calls would re-read the old count and
+            # over-grant. Spec AC 9 mandates fail-closed on quota corruption.
+            return ReadDecision(
+                allowed=False,
+                reason="read-policy: quota state unwritable; denying repo-wide grep",
+                quota_used=None,
+            )
 
         return ReadDecision(
             allowed=True,

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -192,6 +192,19 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
             return WriteDecision(True, "manifest.json is code-owned ctl state", "direct")
         return WriteDecision(False, "manifest.json is code-owned control-plane state", "deny")
 
+    # audit-grep-quota.json is read-policy state owned by the read_policy
+    # module's atomic writer (which runs inside the pre_tool_use hook
+    # subprocess and does NOT route through this policy — Python file
+    # operations are not tool calls). Any write/delete from an agent role
+    # via Bash/Write/Edit is denied here parser-independently, closing
+    # sec-1's quota-deletion bypass.
+    if rel_posix == "audit-grep-quota.json":
+        return WriteDecision(
+            False,
+            "audit-grep-quota.json is read-policy state; agent writes are denied",
+            "deny",
+        )
+
     if rel_posix == "external-solution-gate.json":
         if attempt.role == "ctl":
             return WriteDecision(True, "external-solution-gate.json is ctl-owned control-plane state", "direct")

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -79,6 +79,7 @@ _CONTROL_PLANE_EXACT = frozenset({
     "token-usage.json",
     "events.jsonl",
     "spawn-log.jsonl",
+    "audit-grep-quota.json",
 })
 
 _WRAPPER_REQUIRED = {

--- a/tests/test_read_policy.py
+++ b/tests/test_read_policy.py
@@ -1,0 +1,848 @@
+"""Tests for read_policy.py — enforce auditor diff-scope read budget.
+
+TDD-first: these tests are written before the production module exists.
+Running `pytest tests/test_read_policy.py -x` will fail with ImportError
+until hooks/read_policy.py is implemented. That is expected.
+
+All 17 unit/integration tests correspond to named test functions in the
+plan.md Test Strategy table and cover ACs 1-18 (AC 16 is covered in
+test_write_policy_hook.py::test_non_audit_role_read_passthrough).
+
+Tests import read_policy directly (no subprocess) except AC 13, 14, 15
+which require subprocess hook invocation because they assert events emitted
+by the pre_tool_use.py handler layer (not by decide_read).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by all tests
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = ROOT / "hooks" / "pre-tool-use"
+HOOKS_DIR = ROOT / "hooks"
+
+
+def _hook_available() -> bool:
+    if not HOOK_PATH.exists():
+        return False
+    try:
+        mode = HOOK_PATH.stat().st_mode
+    except OSError:
+        return False
+    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def _read_policy_available() -> bool:
+    """True when hooks/read_policy.py exists (production code landed)."""
+    return (HOOKS_DIR / "read_policy.py").exists()
+
+
+def _make_task_dir(tmp_path: Path, stage: str = "CHECKPOINT_AUDIT") -> tuple[Path, Path]:
+    """Create a minimal project + task_dir structure with manifest.json."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".dynos").mkdir()
+    task_dir = project_root / ".dynos" / "task-20260501-tst"
+    task_dir.mkdir()
+    (task_dir / "manifest.json").write_text(
+        json.dumps({"task_id": task_dir.name, "stage": stage})
+    )
+    return project_root, task_dir
+
+
+def _invoke_hook(
+    *,
+    payload: dict,
+    env_extra: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    drop_keys: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    for key in drop_keys:
+        env.pop(key, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        cwd=str(cwd or ROOT),
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def _import_read_policy():
+    """Import read_policy from hooks/ directory, inserting it on sys.path."""
+    import sys
+    hooks_str = str(HOOKS_DIR)
+    if hooks_str not in sys.path:
+        sys.path.insert(0, hooks_str)
+    import importlib
+    return importlib.import_module("read_policy")
+
+
+# ---------------------------------------------------------------------------
+# pytestmark: skip the subprocess-based tests if the hook is not present yet
+# ---------------------------------------------------------------------------
+# NOTE: The unit tests (test_interface_exports etc.) use a different skip
+# guard — they skip only when read_policy.py doesn't exist yet.
+# The integration tests (AC 13, 14, 15) need the hook AND read_policy.py.
+
+_SUBPROCESS_TESTS_AVAILABLE = _hook_available()
+
+_hook_mark = pytest.mark.skipif(
+    not _hook_available(),
+    reason="hooks/pre-tool-use not present or not executable yet (TDD-first)",
+)
+
+_unit_mark = pytest.mark.skipif(
+    not _read_policy_available(),
+    reason="hooks/read_policy.py not yet implemented (TDD-first)",
+)
+
+
+# ===========================================================================
+# AC 2: Interface exports — ReadAttempt, ReadDecision, decide_read,
+#        _emit_read_policy_event with correct dataclass field shapes.
+# ===========================================================================
+
+@_unit_mark
+def test_interface_exports() -> None:
+    """AC 2: read_policy exports exactly the declared public symbols with correct shapes."""
+    rp = _import_read_policy()
+
+    # Required exports must exist
+    assert hasattr(rp, "ReadAttempt"), "read_policy must export ReadAttempt"
+    assert hasattr(rp, "ReadDecision"), "read_policy must export ReadDecision"
+    assert hasattr(rp, "decide_read"), "read_policy must export decide_read"
+    assert hasattr(rp, "_emit_read_policy_event"), "read_policy must export _emit_read_policy_event"
+
+    # ReadAttempt must be a frozen dataclass
+    ReadAttempt = rp.ReadAttempt
+    assert dataclasses.is_dataclass(ReadAttempt), "ReadAttempt must be a dataclass"
+    ra_fields = {f.name for f in dataclasses.fields(ReadAttempt)}
+    assert ra_fields == {"role", "task_dir", "target", "tool_name", "raw_pattern"}, (
+        f"ReadAttempt fields mismatch: got {ra_fields}"
+    )
+    # Must be frozen
+    instance = ReadAttempt(
+        role="audit-security",
+        task_dir=None,
+        target=Path("/tmp"),
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        instance.role = "mutated"  # type: ignore[misc]
+
+    # ReadDecision must be a frozen dataclass
+    ReadDecision = rp.ReadDecision
+    assert dataclasses.is_dataclass(ReadDecision), "ReadDecision must be a dataclass"
+    rd_fields = {f.name for f in dataclasses.fields(ReadDecision)}
+    assert rd_fields == {"allowed", "reason", "quota_used"}, (
+        f"ReadDecision fields mismatch: got {rd_fields}"
+    )
+    decision = ReadDecision(allowed=True, reason="ok", quota_used=None)
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        decision.allowed = False  # type: ignore[misc]
+
+    # decide_read must be callable with (attempt, *, audit_plan)
+    sig = inspect.signature(rp.decide_read)
+    params = list(sig.parameters.keys())
+    assert "attempt" in params, "decide_read must have 'attempt' parameter"
+    assert "audit_plan" in params, "decide_read must have 'audit_plan' keyword parameter"
+    audit_plan_param = sig.parameters["audit_plan"]
+    assert audit_plan_param.kind in (
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    ), "audit_plan should be a keyword parameter"
+
+    # No unexpected public symbols (only the 4 declared + private helpers + constants)
+    public_names = {
+        name for name in dir(rp)
+        if not name.startswith("_") and not name.startswith("__")
+    }
+    # These are the only permitted public names
+    permitted_public = {"ReadAttempt", "ReadDecision", "decide_read"}
+    unexpected = public_names - permitted_public
+    # Filter out stdlib re-exports (dataclasses, Path, etc.) that may appear
+    # if the module does `from x import y` at module level
+    stdlib_reexports = {
+        name for name in unexpected
+        if name[0].islower() and name not in ("decide_read",)
+    }
+    # The spec says "No additional public symbols" — we allow lowercase helpers
+    # that are clearly stdlib re-exports but disallow any extra capitalized names
+    extra_capitalized = {n for n in unexpected if n[0].isupper()} - {"Path"}
+    assert not extra_capitalized, (
+        f"read_policy has unexpected public capitalized symbols: {extra_capitalized}"
+    )
+
+
+# ===========================================================================
+# AC 1: "audit-claude-md" in _EXECUTOR_ROLE_ALLOWLIST
+# ===========================================================================
+
+@_unit_mark
+def test_audit_claude_md_role_in_allowlist() -> None:
+    """AC 1: pre_tool_use._EXECUTOR_ROLE_ALLOWLIST contains 'audit-claude-md'."""
+    import sys
+    hooks_str = str(HOOKS_DIR)
+    if hooks_str not in sys.path:
+        sys.path.insert(0, hooks_str)
+    import importlib
+    ptu = importlib.import_module("pre_tool_use")
+    allowlist = ptu._EXECUTOR_ROLE_ALLOWLIST
+    assert "audit-claude-md" in allowlist, (
+        f"'audit-claude-md' missing from _EXECUTOR_ROLE_ALLOWLIST; "
+        f"current allowlist: {sorted(allowlist)}"
+    )
+
+
+# ===========================================================================
+# AC 4: audit-* role + task_dir read is allowed
+# ===========================================================================
+
+@_unit_mark
+def test_audit_role_task_dir_read_allowed(tmp_path: Path) -> None:
+    """AC 4: Read of a file inside task_dir is allowed for any audit-* role."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Create a real file inside task_dir for the target
+    target_file = task_dir / "audit-reports" / "findings.json"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("{}")
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=target_file.resolve(),
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is True, (
+        f"Expected allowed=True for task_dir read, got: "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+
+# ===========================================================================
+# AC 5: audit-* role + diff-scoped file read is allowed
+# ===========================================================================
+
+@_unit_mark
+def test_audit_role_diff_scoped_read_allowed(tmp_path: Path) -> None:
+    """AC 5: Read of a diff-scoped file is allowed; diff_files entries are repo-relative."""
+    rp = _import_read_policy()
+    project_root, task_dir = _make_task_dir(tmp_path)
+
+    # Create the actual source file at repo root / src/foo.py
+    src_file = project_root / "src" / "foo.py"
+    src_file.parent.mkdir(parents=True, exist_ok=True)
+    src_file.write_text("# production code\n")
+
+    # audit_plan uses repo-relative paths; they must resolve against task_dir.parent.parent
+    audit_plan = {"diff_files": ["src/foo.py"]}
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=src_file.resolve(),
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=audit_plan)
+
+    assert decision.allowed is True, (
+        f"Expected allowed=True for diff-scoped read, got: "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+
+# ===========================================================================
+# AC 6: audit-* role + path outside allowlist is denied
+# ===========================================================================
+
+@_unit_mark
+def test_audit_role_outside_allowlist_denied(tmp_path: Path) -> None:
+    """AC 6: Read of a path outside task_dir and diff_files is denied."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Target is completely outside the task_dir and not in diff_files
+    outside_path = Path("/etc/passwd").resolve()
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=outside_path,
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected allowed=False for out-of-allowlist path, got: "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+    assert decision.reason, "reason must be non-empty on denial"
+    assert decision.quota_used is None, (
+        f"quota_used must be None for non-dead-code deny, got: {decision.quota_used}"
+    )
+
+
+# ===========================================================================
+# AC 7: audit-dead-code — first 10 repo-wide Greps are allowed
+# ===========================================================================
+
+@_unit_mark
+def test_dead_code_quota_10_allowed(tmp_path: Path) -> None:
+    """AC 7: First 10 repo-wide Greps from audit-dead-code are allowed; quota file increments."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Grep path is the repo root (outside task_dir, not in diff_files)
+    # This simulates a repo-wide grep
+    repo_root = task_dir.parent.parent
+
+    quota_file = task_dir / "audit-grep-quota.json"
+
+    for i in range(1, 11):
+        attempt = rp.ReadAttempt(
+            role="audit-dead-code",
+            task_dir=task_dir,
+            target=repo_root.resolve(),
+            tool_name="Grep",
+            raw_pattern="some_symbol",
+        )
+        decision = rp.decide_read(attempt, audit_plan=None)
+
+        assert decision.allowed is True, (
+            f"Expected allowed=True on call {i}/10, got: "
+            f"allowed={decision.allowed}, reason={decision.reason!r}"
+        )
+        assert decision.quota_used == i, (
+            f"Expected quota_used={i} on call {i}, got: {decision.quota_used}"
+        )
+
+    # After 10 calls, quota file must contain {"count": 10}
+    assert quota_file.exists(), "audit-grep-quota.json must exist after 10 quota-consuming calls"
+    quota_data = json.loads(quota_file.read_text())
+    assert quota_data == {"count": 10}, (
+        f"Expected quota file to contain {{\"count\": 10}}, got: {quota_data}"
+    )
+
+
+# ===========================================================================
+# AC 8: audit-dead-code — 11th repo-wide Grep is denied
+# ===========================================================================
+
+@_unit_mark
+def test_dead_code_quota_11th_denied(tmp_path: Path) -> None:
+    """AC 8: 11th repo-wide Grep from audit-dead-code is denied with exact reason; quota unchanged."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Pre-write exhausted quota file
+    quota_file = task_dir / "audit-grep-quota.json"
+    quota_file.write_text(json.dumps({"count": 10}))
+
+    repo_root = task_dir.parent.parent
+
+    attempt = rp.ReadAttempt(
+        role="audit-dead-code",
+        task_dir=task_dir,
+        target=repo_root.resolve(),
+        tool_name="Grep",
+        raw_pattern="some_symbol",
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected allowed=False on 11th call, got: "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+    assert decision.reason == "read-policy: dead-code grep quota exhausted (10/10)", (
+        f"Exact reason string mismatch; got: {decision.reason!r}"
+    )
+    assert decision.quota_used is None, (
+        f"quota_used must be None on denial, got: {decision.quota_used}"
+    )
+
+    # Quota file must NOT be mutated on denial
+    quota_after = json.loads(quota_file.read_text())
+    assert quota_after == {"count": 10}, (
+        f"Quota file must not be mutated on denial; got: {quota_after}"
+    )
+
+
+# ===========================================================================
+# AC 9: quota file unreadable → fail-closed
+# ===========================================================================
+
+@_unit_mark
+def test_dead_code_quota_unreadable_fail_closed(tmp_path: Path) -> None:
+    """AC 9: Unreadable quota file → fail-closed denial; no exception propagates."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    quota_file = task_dir / "audit-grep-quota.json"
+    # Write corrupt JSON — this simulates unreadable/corrupt state
+    quota_file.write_bytes(b"not valid json {{{")
+
+    repo_root = task_dir.parent.parent
+
+    attempt = rp.ReadAttempt(
+        role="audit-dead-code",
+        task_dir=task_dir,
+        target=repo_root.resolve(),
+        tool_name="Grep",
+        raw_pattern="some_symbol",
+    )
+
+    # Must not raise — all exceptions are swallowed inside decide_read
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected fail-closed denial on unreadable quota, got: "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+    assert decision.reason == "read-policy: quota state unreadable; denying repo-wide grep", (
+        f"Exact reason string mismatch for unreadable quota; got: {decision.reason!r}"
+    )
+    assert decision.quota_used is None, (
+        f"quota_used must be None on fail-closed denial, got: {decision.quota_used}"
+    )
+
+
+# ===========================================================================
+# AC 10: audit-claude-md reading any */CLAUDE.md is allowed; carve-out
+#          does NOT apply to other audit roles
+# ===========================================================================
+
+@_unit_mark
+def test_claude_md_auditor_carveout_allowed(tmp_path: Path) -> None:
+    """AC 10: audit-claude-md may read any CLAUDE.md; other audit roles cannot."""
+    rp = _import_read_policy()
+    project_root, task_dir = _make_task_dir(tmp_path)
+
+    # Three different CLAUDE.md locations per the spec
+    paths_to_test = [
+        project_root / "CLAUDE.md",                     # repo root
+        project_root / "foo" / "CLAUDE.md",             # subdirectory
+        Path.home() / ".claude" / "CLAUDE.md",          # ~/.claude/CLAUDE.md
+    ]
+
+    for claude_path in paths_to_test:
+        attempt = rp.ReadAttempt(
+            role="audit-claude-md",
+            task_dir=task_dir,
+            target=claude_path.resolve(),
+            tool_name="Read",
+            raw_pattern=None,
+        )
+        decision = rp.decide_read(attempt, audit_plan=None)
+        assert decision.allowed is True, (
+            f"Expected audit-claude-md to be allowed to read {claude_path}; "
+            f"got allowed={decision.allowed}, reason={decision.reason!r}"
+        )
+
+    # Carve-out must NOT apply to other audit roles
+    for claude_path in paths_to_test:
+        attempt_other = rp.ReadAttempt(
+            role="audit-security",
+            task_dir=task_dir,
+            target=claude_path.resolve(),
+            tool_name="Read",
+            raw_pattern=None,
+        )
+        decision_other = rp.decide_read(attempt_other, audit_plan=None)
+        # audit-security has no CLAUDE.md carve-out and the paths are outside task_dir
+        # so this must be denied (these paths are not in task_dir and not in diff_files)
+        assert decision_other.allowed is False, (
+            f"audit-security must NOT have CLAUDE.md carve-out for {claude_path}; "
+            f"got allowed={decision_other.allowed}, reason={decision_other.reason!r}"
+        )
+
+
+# ===========================================================================
+# AC 11: Glob pattern **/*.py for audit-* is denied
+# ===========================================================================
+
+@_unit_mark
+def test_audit_glob_wildcard_denied(tmp_path: Path) -> None:
+    """AC 11: Glob pattern '**/*.py' for audit-* is denied; pattern field checked (not path)."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # The target for Glob is os.path.normpath of the pattern, not a real file path
+    import os as _os
+    pattern = "**/*.py"
+    target = Path(_os.path.normpath(pattern))
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=target,
+        tool_name="Glob",
+        raw_pattern=pattern,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected Glob '**/*.py' to be denied for audit-security; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+
+# ===========================================================================
+# AC 12: Glob pattern rooted in task_dir is allowed
+# ===========================================================================
+
+@_unit_mark
+def test_audit_glob_task_dir_prefix_allowed(tmp_path: Path) -> None:
+    """AC 12: Glob pattern starting with task_dir prefix is allowed."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    import os as _os
+    pattern = f"{task_dir}/audit-reports/*.json"
+    target = Path(_os.path.normpath(pattern))
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=target,
+        tool_name="Glob",
+        raw_pattern=pattern,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is True, (
+        f"Expected Glob rooted in task_dir to be allowed; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+
+# ===========================================================================
+# AC 13: missing audit-plan.json → task_dir-only fallback + event emitted
+# AC 13 tests the pre_tool_use.py handler via subprocess
+# ===========================================================================
+
+@_hook_mark
+def test_missing_audit_plan_fallback_task_dir_only(tmp_path: Path) -> None:
+    """AC 13: Missing audit-plan.json → pre_tool_use_audit_plan_missing event emitted;
+    diff-scoped read denied because audit_plan=None means no diff-scoped allowlist."""
+    project_root, task_dir = _make_task_dir(tmp_path, stage="CHECKPOINT_AUDIT")
+
+    # No audit-plan.json — deliberately absent
+    assert not (task_dir / "audit-plan.json").exists()
+
+    # A diff-scoped file at repo root level (outside task_dir)
+    diff_file = project_root / "src" / "service.py"
+    diff_file.parent.mkdir(parents=True, exist_ok=True)
+    diff_file.write_text("# service code\n")
+
+    payload = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(diff_file)},
+        "cwd": str(project_root),
+    }
+    env = {
+        "DYNOS_ROLE": "audit-security",
+        "DYNOS_TASK_DIR": str(task_dir),
+    }
+
+    result = _invoke_hook(payload=payload, env_extra=env, cwd=project_root)
+
+    # Should be denied (no diff-scoped allowlist without audit-plan.json)
+    assert result.returncode == 2, (
+        f"Expected exit 2 (denied) when audit-plan.json is missing; "
+        f"got {result.returncode}; stderr={result.stderr!r}"
+    )
+
+    # pre_tool_use_audit_plan_missing event must be in events.jsonl
+    events_path = task_dir / "events.jsonl"
+    assert events_path.exists(), f"events.jsonl must exist; looked at {events_path}"
+    events_text = events_path.read_text()
+    assert "pre_tool_use_audit_plan_missing" in events_text, (
+        f"Expected 'pre_tool_use_audit_plan_missing' event in events.jsonl; "
+        f"content: {events_text!r}"
+    )
+    # Must NOT contain the "invalid" event (it's missing, not malformed)
+    assert "pre_tool_use_audit_plan_invalid" not in events_text, (
+        f"Must not emit 'pre_tool_use_audit_plan_invalid' for a missing file; "
+        f"content: {events_text!r}"
+    )
+
+
+# ===========================================================================
+# AC 14: malformed audit-plan.json → same fallback + distinct event
+# AC 14 tests the pre_tool_use.py handler via subprocess
+# ===========================================================================
+
+@_hook_mark
+def test_malformed_audit_plan_fallback_distinct_event(tmp_path: Path) -> None:
+    """AC 14: Malformed audit-plan.json → pre_tool_use_audit_plan_invalid event (distinct from missing)."""
+    project_root, task_dir = _make_task_dir(tmp_path, stage="CHECKPOINT_AUDIT")
+
+    # audit-plan.json exists but is malformed (missing diff_files key)
+    (task_dir / "audit-plan.json").write_text(json.dumps({"not_diff_files": []}))
+
+    diff_file = project_root / "src" / "service.py"
+    diff_file.parent.mkdir(parents=True, exist_ok=True)
+    diff_file.write_text("# service code\n")
+
+    payload = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(diff_file)},
+        "cwd": str(project_root),
+    }
+    env = {
+        "DYNOS_ROLE": "audit-security",
+        "DYNOS_TASK_DIR": str(task_dir),
+    }
+
+    result = _invoke_hook(payload=payload, env_extra=env, cwd=project_root)
+
+    assert result.returncode == 2, (
+        f"Expected exit 2 (denied) when audit-plan.json is malformed; "
+        f"got {result.returncode}; stderr={result.stderr!r}"
+    )
+
+    events_path = task_dir / "events.jsonl"
+    assert events_path.exists(), f"events.jsonl must exist; looked at {events_path}"
+    events_text = events_path.read_text()
+
+    # Must emit the INVALID event (not the missing event)
+    assert "pre_tool_use_audit_plan_invalid" in events_text, (
+        f"Expected 'pre_tool_use_audit_plan_invalid' event in events.jsonl; "
+        f"content: {events_text!r}"
+    )
+    # The missing event must NOT appear (file existed, just malformed)
+    assert "pre_tool_use_audit_plan_missing" not in events_text, (
+        f"Must not emit 'pre_tool_use_audit_plan_missing' when file exists but is malformed; "
+        f"content: {events_text!r}"
+    )
+
+
+# ===========================================================================
+# AC 15: stage guard — EXECUTION stage denies audit-* Read/Grep/Glob
+# AC 15 tests the pre_tool_use.py handler via subprocess
+# ===========================================================================
+
+@_hook_mark
+def test_stage_guard_execution_denied(tmp_path: Path) -> None:
+    """AC 15: manifest.json stage=EXECUTION → audit-* Read is denied; stderr contains 'not permitted at stage'."""
+    project_root, task_dir = _make_task_dir(tmp_path, stage="EXECUTION")
+
+    # Write an audit-plan.json so we don't hit the missing-plan fallback first
+    (task_dir / "audit-plan.json").write_text(
+        json.dumps({"diff_files": []})
+    )
+
+    target_file = task_dir / "audit-reports" / "anything.json"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("{}")
+
+    payload = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(target_file)},
+        "cwd": str(project_root),
+    }
+    env = {
+        "DYNOS_ROLE": "audit-security",
+        "DYNOS_TASK_DIR": str(task_dir),
+    }
+
+    result = _invoke_hook(payload=payload, env_extra=env, cwd=project_root)
+
+    assert result.returncode == 2, (
+        f"Expected exit 2 when manifest stage=EXECUTION for audit role; "
+        f"got {result.returncode}; stderr={result.stderr!r}"
+    )
+    assert "not permitted at stage" in result.stderr, (
+        f"Expected stderr to contain 'not permitted at stage'; "
+        f"stderr={result.stderr!r}"
+    )
+
+
+# ===========================================================================
+# AC 17: path traversal resolves outside allowlist → denied
+# ===========================================================================
+
+@_unit_mark
+def test_path_traversal_denied(tmp_path: Path) -> None:
+    """AC 17: Path traversal via '..' resolves outside allowlist; deny uses resolved path."""
+    rp = _import_read_policy()
+    project_root, task_dir = _make_task_dir(tmp_path)
+
+    # Simulate what pre_tool_use._resolve_path would produce for "../../etc/passwd"
+    # when cwd is task_dir. The result escapes far above the project root.
+    traversal_raw = "../../etc/passwd"
+    # Resolve from task_dir as cwd (mimicking _resolve_path behavior)
+    traversal_resolved = (task_dir / traversal_raw).resolve()
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=traversal_resolved,
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected path traversal to be denied after resolve(); "
+        f"resolved target={traversal_resolved}, "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+    # Verify the resolved path actually escapes task_dir (sanity check)
+    assert not str(traversal_resolved).startswith(str(task_dir)), (
+        f"Test setup error: traversal target {traversal_resolved} should be outside task_dir {task_dir}"
+    )
+
+
+# ===========================================================================
+# AC 18: symlink inside task_dir pointing outside → denied after resolve
+# ===========================================================================
+
+@_unit_mark
+def test_symlink_outside_allowlist_denied(tmp_path: Path) -> None:
+    """AC 18: Symlink inside task_dir pointing outside resolves via Path.resolve() → denied."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Create a symlink inside task_dir pointing to an external path
+    symlink_path = task_dir / "evil_link"
+
+    # Point to /etc/passwd (or any path we know is outside task_dir)
+    # On test machines /etc/passwd always exists; if not, use /tmp
+    external_target = Path("/etc/passwd") if Path("/etc/passwd").exists() else Path("/tmp")
+
+    try:
+        symlink_path.symlink_to(external_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("Cannot create symlinks on this system")
+
+    # decide_read receives the resolved path (after Path.resolve() removes the symlink)
+    resolved_target = symlink_path.resolve()
+
+    attempt = rp.ReadAttempt(
+        role="audit-security",
+        task_dir=task_dir,
+        target=resolved_target,
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is False, (
+        f"Expected symlink pointing outside task_dir to be denied; "
+        f"symlink={symlink_path}, resolved={resolved_target}, "
+        f"allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+    # Verify the resolved path is truly outside task_dir (sanity check)
+    assert not str(resolved_target).startswith(str(task_dir.resolve())), (
+        f"Test setup error: resolved path {resolved_target} should be outside task_dir {task_dir}"
+    )
+
+
+# ===========================================================================
+# AC 19: existing write enforcement is unchanged
+# ===========================================================================
+
+@_unit_mark
+def test_existing_write_policy_unchanged() -> None:
+    """AC 19: decide_write still works with same WriteAttempt shape after read_policy is added."""
+    # Import write_policy directly to verify it is unmodified
+    import sys
+    hooks_str = str(HOOKS_DIR)
+    if hooks_str not in sys.path:
+        sys.path.insert(0, hooks_str)
+    import importlib
+    wp = importlib.import_module("write_policy")
+
+    # Smoke-test: executor writing a repo file is allowed
+    attempt = wp.WriteAttempt(
+        role="backend-executor",
+        task_dir=None,
+        path=Path("/tmp/some_repo_file.py"),
+        operation="modify",
+        source="agent",
+    )
+    decision = wp.decide_write(attempt)
+    assert decision.allowed is True, (
+        f"decide_write broken: executor writing repo file should be allowed; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+    # Smoke-test: executor writing manifest.json is denied
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        task_dir = Path(td) / ".dynos" / "task-smoke"
+        task_dir.mkdir(parents=True)
+        manifest = task_dir / "manifest.json"
+        manifest.write_text("{}")
+
+        attempt_denied = wp.WriteAttempt(
+            role="backend-executor",
+            task_dir=task_dir,
+            path=manifest,
+            operation="modify",
+            source="agent",
+        )
+        decision_denied = wp.decide_write(attempt_denied)
+        assert decision_denied.allowed is False, (
+            f"decide_write broken: executor writing manifest.json should be denied; "
+            f"got allowed={decision_denied.allowed}, reason={decision_denied.reason!r}"
+        )
+
+
+# ===========================================================================
+# Additional regression guard: non-audit role passes through decide_read
+# This is tested at the unit level to verify the fast-exit branch in decide_read.
+# The integration test for AC 16 is in test_write_policy_hook.py.
+# ===========================================================================
+
+@_unit_mark
+def test_non_audit_role_decide_read_passthrough(tmp_path: Path) -> None:
+    """AC 16 (unit): Non-audit role returns allowed=True without consulting allowlist."""
+    rp = _import_read_policy()
+    _, task_dir = _make_task_dir(tmp_path)
+
+    # Deliberately use an out-of-bounds path to confirm the allowlist is not checked
+    outside_path = Path("/etc/passwd").resolve()
+
+    attempt = rp.ReadAttempt(
+        role="backend-executor",
+        task_dir=task_dir,
+        target=outside_path,
+        tool_name="Read",
+        raw_pattern=None,
+    )
+    decision = rp.decide_read(attempt, audit_plan=None)
+
+    assert decision.allowed is True, (
+        f"Expected non-audit role to always get allowed=True from decide_read; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )

--- a/tests/test_write_policy_hook.py
+++ b/tests/test_write_policy_hook.py
@@ -270,3 +270,50 @@ def test_malformed_stdin_never_silently_allows(tmp_path: Path) -> None:
         f"silently allow); got exit {result.returncode}, stderr="
         f"{result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# AC 3 + AC 16: non-audit role Read passes through without read policy
+# (integration test via subprocess hook invocation)
+# ---------------------------------------------------------------------------
+def test_non_audit_role_read_passthrough(tmp_path: Path) -> None:
+    """AC 3 + AC 16: non-audit role Read to any path exits 0; decide_read not called.
+
+    This exercises two things simultaneously:
+    (a) AC 16 — non-audit role (backend-executor) gets an unconditional pass on Read.
+    (b) AC 3 — the new Read/Grep/Glob handler block exists in pre_tool_use.py main()
+        and correctly short-circuits to return 0 for non-audit roles without invoking
+        decide_read. If the handler block were absent, the hook would still exit 0 via
+        the final passthrough — but then AC 3 wiring would not exist, making the audit
+        enforcement path unreachable. The audit-role tests cover that branch.
+    """
+    project_root, task_dir = _make_task_dir(tmp_path)
+
+    # Deliberately use a path that is completely outside task_dir and would be
+    # denied if read policy were applied to this non-audit role.
+    payload = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/etc/passwd"},
+        "cwd": str(project_root),
+    }
+    env = {
+        "DYNOS_ROLE": "backend-executor",
+        "DYNOS_TASK_DIR": str(task_dir),
+    }
+
+    result = _invoke_hook(payload=payload, env_extra=env, cwd=project_root)
+
+    assert result.returncode == 0, (
+        f"Expected exit 0 for non-audit role Read (passthrough); "
+        f"got {result.returncode}; stderr={result.stderr!r}"
+    )
+
+    # Verify no read_policy_denied event was emitted — non-audit roles must
+    # not trigger read policy enforcement at all.
+    events_path = task_dir / "events.jsonl"
+    if events_path.exists():
+        events_text = events_path.read_text()
+        assert "read_policy_denied" not in events_text, (
+            f"read_policy_denied event must not appear for non-audit role Read; "
+            f"events.jsonl: {events_text!r}"
+        )


### PR DESCRIPTION
## Summary

- Converts the auditor "Read Budget (HARD CAP)" prompt convention into runtime denial. When `active-segment-role` matches `audit-*`, Read/Grep/Glob target paths must be inside `.dynos/task-{id}/` or in the diff-scoped file list from `audit-plan.json`.
- New module `hooks/read_policy.py` (258 lines) — `ReadAttempt`, `ReadDecision`, `decide_read`, `_emit_read_policy_event`. Mirrors `hooks/write_policy.py` structure.
- Per-role exceptions: `audit-dead-code` gets a 10-Grep quota for symbol-absence checks (atomic via `tempfile + os.replace`, fail-closed on read OR write failure); `audit-claude-md` gets a `CLAUDE.md` carve-out scoped to repo root, `~/.claude/`, `~/.config/claude/`.
- Stage guard (`PLAN_AUDIT|CHECKPOINT_AUDIT|FINAL_AUDIT|REPAIR_PLANNING|REPAIR_EXECUTION`) + missing/malformed audit-plan event emission (`pre_tool_use_audit_plan_missing`, `pre_tool_use_audit_plan_invalid`).
- Path-traversal hardening: `audit-grep-quota.json` registered in `_CONTROL_PLANE_EXACT` with explicit `decide_write` deny + Bash substring-scan gated by deletion-verb regex (closes the 5 attack vectors the security auditor enumerated for `rm/rmdir/find -delete/shred/unlink`).
- Side fix in `hooks/lib_validate.py`: severity aliases `major→high` and `minor→low` so repair-log validation accepts the auditor-canonical vocabulary documented in `agents/security-auditor.md`.
- Shipped end-to-end through `/dynos-work:start → execute → audit` (3 audit cycles for sec-1; security-auditor caught 4 of 5 critical/major defects in the first cycle and 1 sub-defect in cycle 2).

## Test plan

- [x] `pytest tests/test_read_policy.py tests/test_write_policy_hook.py tests/test_write_policy.py tests/test_write_policy_capability_key.py` — 41 passed (18 new in `test_read_policy.py` + 1 new in `test_write_policy_hook.py` + 22 existing regression).
- [ ] Verify on a real audit run: spawn an audit-* role, attempt to Read a file outside the diff scope → expect exit 2 with `read-policy:` stderr.
- [ ] Verify `audit-dead-code` quota: 10 repo-wide Greps allowed, 11th denied with `read-policy: dead-code grep quota exhausted (10/10)`.
- [ ] Verify `audit-claude-md` carve-out: `~/.claude/CLAUDE.md` allowed, `/tmp/evil/CLAUDE.md` denied.
- [ ] Verify Bash deletion vectors: `audit-dead-code` cannot `rm`, `rmdir`, `find -delete`, `shred -u`, or `unlink` `.dynos/task-{id}/audit-grep-quota.json`.
- [ ] Confirm no regression: `pytest tests/` full suite green on CI.

## Known follow-ups

- Pre-existing pipeline gap: `manifest.snapshot.head_sha` has no ctl writer; the `/dynos-work:execute` skill currently relies on the orchestrator populating it via `lib_core.write_ctl_json`. Should be a proper ctl wrapper.
- The audit findings-gate has no "latest report supersedes prior" mechanism; this branch worked around by moving stale reports to `audit-reports/superseded/` after the cycle-3 re-audit. A proper fix should mark prior findings as resolved when the same finding ID is absent from the latest re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)