### PR TITLE
feat: derive verbatim user_summary for audit-finish

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2905,6 +2905,11 @@ def cmd_run_audit_summary(args: argparse.Namespace) -> int:
             "total_blocking": total_blocking,
             "audit_result": "pass" if total_blocking == 0 else "fail",
         }
+        # task-20260503-002: derive user_summary BEFORE persisting audit-summary.json
+        # so the chain entry's sha256 captures it. cmd_run_audit_finish reads this
+        # field (via load_json of audit-summary.json) and copies it verbatim.
+        from lib_validate import derive_user_summary
+        summary["user_summary"] = derive_user_summary(summary)
         summary_path = task_dir / "audit-summary.json"
         write_json(summary_path, summary)
         print(json.dumps({
@@ -3673,12 +3678,15 @@ def cmd_run_audit_finish(args: argparse.Namespace) -> int:
             _try_extend_chain_for_artifact(task_dir, completion_path)
 
         _, updated = transition_task(task_dir, "DONE")
+        # task-20260503-002: emit user_summary in stdout JSON (read verbatim from
+        # the just-copied completion.json — no re-derivation).
         print(json.dumps({
             "status": "done",
             "task_dir": str(task_dir),
             "stage": updated.get("stage"),
             "completion_path": str(completion_path),
             "completed_at": updated.get("completed_at"),
+            "user_summary": completion.get("user_summary"),
         }, indent=2))
         return 0
     except Exception as exc:
@@ -3787,6 +3795,72 @@ def cmd_run_task_receipt_chain(args: argparse.Namespace) -> int:
         "appended": len(pending),
     }, indent=2))
     return 0
+
+
+def cmd_verify_audit_summary_text(args: argparse.Namespace) -> int:
+    """task-20260503-002: verify completion.json::user_summary matches a fresh
+    re-derivation from audit-summary.json. Byte-exact compare.
+
+    Exit codes:
+      0 — match
+      1 — mismatch (stderr JSON: stored_sha, derived_sha, diff_first_line)
+      2 — completion.json or audit-summary.json missing
+      3 — completion.json has no user_summary key (legacy task)
+    """
+    task_dir = Path(args.task_dir).resolve()
+    completion_path = task_dir / "completion.json"
+    summary_path = task_dir / "audit-summary.json"
+
+    if not completion_path.exists() or not summary_path.exists():
+        print(json.dumps({
+            "error": "missing_file",
+            "completion_exists": completion_path.exists(),
+            "audit_summary_exists": summary_path.exists(),
+        }), file=sys.stderr)
+        return 2
+
+    try:
+        completion = load_json(completion_path)
+        audit_summary = load_json(summary_path)
+    except Exception as exc:
+        print(json.dumps({"error": "unparseable_json", "detail": str(exc)}), file=sys.stderr)
+        return 2
+
+    stored = completion.get("user_summary") if isinstance(completion, dict) else None
+    if stored is None:
+        print(json.dumps({"error": "legacy_completion_missing_user_summary"}), file=sys.stderr)
+        return 3
+
+    from lib_validate import derive_user_summary
+    derived = derive_user_summary(audit_summary if isinstance(audit_summary, dict) else {})
+
+    if stored == derived:
+        print(json.dumps({"status": "match"}))
+        return 0
+
+    import hashlib as _hashlib
+    stored_sha = _hashlib.sha256(stored.encode("utf-8")).hexdigest()
+    derived_sha = _hashlib.sha256(derived.encode("utf-8")).hexdigest()
+    stored_lines = stored.splitlines()
+    derived_lines = derived.splitlines()
+    diff_first_line = None
+    for i, (s, d) in enumerate(zip(stored_lines, derived_lines)):
+        if s != d:
+            diff_first_line = stored_lines[i] if i < len(stored_lines) else None
+            break
+    else:
+        # All shared lines match; the longer one diverges at its tail.
+        if len(stored_lines) != len(derived_lines):
+            idx = min(len(stored_lines), len(derived_lines))
+            diff_first_line = stored_lines[idx] if idx < len(stored_lines) else None
+
+    print(json.dumps({
+        "error": "mismatch",
+        "stored_sha": stored_sha,
+        "derived_sha": derived_sha,
+        "diff_first_line": diff_first_line,
+    }), file=sys.stderr)
+    return 1
 
 
 def cmd_validate_task_receipt_chain(args: argparse.Namespace) -> int:
@@ -4705,6 +4779,13 @@ def register_meta_parsers(subparsers: argparse._SubParsersAction) -> None:
     )
     chain_validate_parser.add_argument("task_dir")
     chain_validate_parser.set_defaults(func=cmd_validate_task_receipt_chain)
+
+    verify_summary_parser = subparsers.add_parser(
+        "verify-audit-summary-text",
+        help="Verify completion.json::user_summary matches a fresh derivation from audit-summary.json (exit 0/1/2/3)",
+    )
+    verify_summary_parser.add_argument("task_dir")
+    verify_summary_parser.set_defaults(func=cmd_verify_audit_summary_text)
 
     rp_parser = subparsers.add_parser("repair-plan", help="Q-learning repair plan (reads findings from stdin)")
     rp_parser.add_argument("--root", default=".")

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -186,6 +186,57 @@ def detect_cycle(graph: dict) -> bool:
     return any(walk(node_id) for node_id in by_id)
 
 
+def derive_user_summary(audit_summary: dict) -> str:
+    """Derive the verbatim user-facing summary from audit-summary.json content.
+
+    Pure function — no I/O, no env reads, no logging. Reads task_id and reports
+    from audit_summary. Returns multi-line string WITHOUT a trailing newline.
+
+    Format (em-dash is U+2014). Per-auditor lines aggregate by auditor_name
+    (handles multi-cycle reaudit reports). Skipped auditors are absent because
+    they don't appear in reports. Empty reports yields header + blank + footer.
+    """
+    task_id = str(audit_summary.get("task_id", ""))
+    reports = audit_summary.get("reports", []) or []
+
+    by_auditor: dict[str, int] = {}
+    for r in reports:
+        if not isinstance(r, dict):
+            continue
+        name = str(r.get("auditor_name") or r.get("auditor") or "")
+        if not name:
+            continue
+        by_auditor[name] = by_auditor.get(name, 0) + int(r.get("blocking_count", 0) or 0)
+
+    total_blocking = sum(by_auditor.values())
+
+    if total_blocking == 0:
+        header = "Audit complete — ALL PASSED"
+    else:
+        header = f"Audit complete — FAILED — {total_blocking} blocking findings"
+
+    auditor_lines: list[str] = []
+    for name in sorted(by_auditor.keys()):
+        bc = by_auditor[name]
+        if bc == 0:
+            auditor_lines.append(f"  {name}: PASS")
+        else:
+            auditor_lines.append(f"  {name}: FAIL ({bc} blocking)")
+
+    footer = (
+        f"Task complete. Snapshot branch dynos/{task_id}-snapshot "
+        f"can be deleted if desired."
+    )
+
+    parts: list[str] = [header]
+    if auditor_lines:
+        parts.append("")
+        parts.extend(auditor_lines)
+    parts.append("")
+    parts.append(footer)
+    return "\n".join(parts)
+
+
 def _collect_audit_findings(task_dir: Path) -> dict[str, dict]:
     """Return audit findings keyed by finding id from live audit reports."""
     findings_by_id: dict[str, dict] = {}

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -215,8 +215,11 @@ def derive_user_summary(audit_summary: dict) -> str:
     else:
         header = f"Audit complete — FAILED — {total_blocking} blocking findings"
 
+    # Per-spec ordering: lines in the order of first appearance of each
+    # auditor_name in the reports array (insertion order — Python 3.7+
+    # dicts preserve insertion order, so iterate by_auditor directly).
     auditor_lines: list[str] = []
-    for name in sorted(by_auditor.keys()):
+    for name in by_auditor:
         bc = by_auditor[name]
         if bc == 0:
             auditor_lines.append(f"  {name}: PASS")

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -402,15 +402,14 @@ python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-finish .dynos/task-{id}
 
 This command writes `completion.json` and advances `CHECKPOINT_AUDIT|FINAL_AUDIT -> DONE` deterministically. Do NOT call `transition_task(...)` directly from prompt logic.
 
-Print (listing only auditors that were actually spawned, not skipped):
-```
-Audit complete — ALL PASSED
-
-  {auditor-name}:  PASS
-  ... (one line per spawned auditor)
-
-Task complete. Snapshot branch dynos/task-{id}-snapshot can be deleted if desired.
-```
+Print verbatim the contents of `.dynos/task-{id}/completion.json::user_summary`.
+Do NOT paraphrase, reorder, or add commentary. The orchestrator's user-facing
+final output for this skill is constrained to a literal echo of that text. The
+text is derived deterministically by `run-audit-summary` (see
+`lib_validate.derive_user_summary`) and copied into `completion.json` by
+`run-audit-finish`. The text is also returned in `run-audit-finish` stdout JSON
+under the `user_summary` key. Run `verify-audit-summary-text .dynos/task-{id}`
+to confirm the stored text matches a fresh derivation (exit 0 = match).
 
 ---
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -404,12 +404,7 @@ This command writes `completion.json` and advances `CHECKPOINT_AUDIT|FINAL_AUDIT
 
 Print verbatim the contents of `.dynos/task-{id}/completion.json::user_summary`.
 Do NOT paraphrase, reorder, or add commentary. The orchestrator's user-facing
-final output for this skill is constrained to a literal echo of that text. The
-text is derived deterministically by `run-audit-summary` (see
-`lib_validate.derive_user_summary`) and copied into `completion.json` by
-`run-audit-finish`. The text is also returned in `run-audit-finish` stdout JSON
-under the `user_summary` key. Run `verify-audit-summary-text .dynos/task-{id}`
-to confirm the stored text matches a fresh derivation (exit 0 = match).
+final output for this skill is constrained to a literal echo of that text.
 
 ---
 

--- a/tests/test_user_summary.py
+++ b/tests/test_user_summary.py
@@ -1,0 +1,213 @@
+"""Tests for derive_user_summary + verify-audit-summary-text (task-20260503-002).
+
+Pure unit tests for derive_user_summary; subprocess tests for the CLI.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+from lib_validate import derive_user_summary  # noqa: E402
+
+
+# ---- Pure derivation tests (AC 1-4, AC 9 cases) ----
+
+def test_derive_clean_pass():
+    """All auditors PASS → header is ALL PASSED, all per-auditor lines PASS."""
+    summary = {
+        "task_id": "task-20260503-001",
+        "reports": [
+            {"auditor_name": "spec-completion-auditor", "blocking_count": 0, "finding_count": 0},
+            {"auditor_name": "security-auditor", "blocking_count": 0, "finding_count": 2},
+            {"auditor_name": "code-quality-auditor", "blocking_count": 0, "finding_count": 5},
+        ],
+    }
+    result = derive_user_summary(summary)
+    assert result.startswith("Audit complete — ALL PASSED\n")
+    assert "  spec-completion-auditor: PASS" in result
+    assert "  security-auditor: PASS" in result
+    assert "  code-quality-auditor: PASS" in result
+    assert "FAIL" not in result
+    assert "Task complete. Snapshot branch dynos/task-20260503-001-snapshot" in result
+    # No trailing newline
+    assert not result.endswith("\n")
+
+
+def test_derive_with_findings():
+    """One auditor with blocking → FAILED header + that auditor's FAIL line."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "spec-completion-auditor", "blocking_count": 0},
+            {"auditor_name": "security-auditor", "blocking_count": 2},
+            {"auditor_name": "code-quality-auditor", "blocking_count": 0},
+        ],
+    }
+    result = derive_user_summary(summary)
+    assert result.startswith("Audit complete — FAILED — 2 blocking findings\n")
+    assert "  security-auditor: FAIL (2 blocking)" in result
+    assert "  spec-completion-auditor: PASS" in result
+
+
+def test_derive_skipped_auditor_not_in_summary():
+    """Audit-plan may have skipped auditors; they don't appear in reports →
+    they're absent from user_summary."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "spec-completion-auditor", "blocking_count": 0},
+            {"auditor_name": "security-auditor", "blocking_count": 0},
+        ],
+    }
+    result = derive_user_summary(summary)
+    # Only the 2 auditors that actually ran
+    assert "spec-completion-auditor" in result
+    assert "security-auditor" in result
+    assert "code-quality-auditor" not in result
+    assert "performance-auditor" not in result
+    # Total count of "auditor:" lines
+    assert result.count("auditor:") == 2
+
+
+def test_derive_multi_cycle_aggregates():
+    """Same auditor with two reports (cycle 1 + reaudit) → blocking_counts sum."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "security-auditor", "blocking_count": 1},  # cycle 1
+            {"auditor_name": "security-auditor", "blocking_count": 0},  # reaudit cycle 2
+        ],
+    }
+    result = derive_user_summary(summary)
+    # Sum of blocking is 1
+    assert "FAILED — 1 blocking findings" in result
+    assert "  security-auditor: FAIL (1 blocking)" in result
+    # Only ONE per-auditor line (aggregated by name)
+    assert result.count("security-auditor") == 1
+
+
+def test_derive_empty_reports():
+    """Empty reports → header + blank line + footer only."""
+    summary = {"task_id": "task-X", "reports": []}
+    result = derive_user_summary(summary)
+    expected = (
+        "Audit complete — ALL PASSED\n"
+        "\n"
+        "Task complete. Snapshot branch dynos/task-X-snapshot can be deleted if desired."
+    )
+    assert result == expected
+
+
+def test_derive_no_trailing_newline():
+    """Result must not end with \\n. Caller can add one if printing."""
+    summary = {"task_id": "task-X", "reports": []}
+    assert not derive_user_summary(summary).endswith("\n")
+    # Also for non-empty case
+    summary2 = {
+        "task_id": "task-X",
+        "reports": [{"auditor_name": "spec-completion-auditor", "blocking_count": 0}],
+    }
+    assert not derive_user_summary(summary2).endswith("\n")
+
+
+def test_derive_em_dash_codepoint():
+    """Header uses U+2014 em-dash, not '--' or U+2013 en-dash."""
+    summary = {"task_id": "task-X", "reports": []}
+    result = derive_user_summary(summary)
+    # The em-dash codepoint is —
+    assert "—" in result, "em-dash U+2014 must be present in header"
+    # Not the en-dash
+    assert "–" not in result
+
+
+# ---- CLI tests for verify-audit-summary-text (AC 7, AC 9 verify cases) ----
+
+def _make_task_with_summary(tmp_path: Path, *, task_id: str = "task-X",
+                             reports: list | None = None,
+                             include_user_summary: bool = True,
+                             tampered_user_summary: str | None = None) -> Path:
+    """Build a task dir with audit-summary.json + completion.json on disk."""
+    task_dir = tmp_path / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    summary = {
+        "task_id": task_id,
+        "reports": reports or [],
+        "total_blocking": sum(r.get("blocking_count", 0) for r in (reports or [])),
+        "audit_result": "pass" if not any(r.get("blocking_count", 0) for r in (reports or [])) else "fail",
+    }
+    summary["user_summary"] = derive_user_summary(summary)
+    (task_dir / "audit-summary.json").write_text(json.dumps(summary))
+
+    completion = dict(summary)
+    if not include_user_summary:
+        completion.pop("user_summary", None)
+    elif tampered_user_summary is not None:
+        completion["user_summary"] = tampered_user_summary
+    (task_dir / "completion.json").write_text(json.dumps(completion))
+    return task_dir
+
+
+def _ctl(*args, env=None) -> subprocess.CompletedProcess:
+    repo_root = Path(__file__).resolve().parent.parent
+    ctl = repo_root / "hooks" / "ctl.py"
+    e = os.environ.copy()
+    if env:
+        e.update(env)
+    return subprocess.run(
+        [sys.executable, str(ctl), *args],
+        capture_output=True, text=True, timeout=30, env=e,
+    )
+
+
+def test_verify_command_pass(tmp_path):
+    """Legitimate completion.json + audit-summary.json → exit 0."""
+    task_dir = _make_task_with_summary(tmp_path)
+    r = _ctl("verify-audit-summary-text", str(task_dir))
+    assert r.returncode == 0, f"expected 0, got {r.returncode}; stderr={r.stderr}"
+
+
+def test_verify_command_tampered_text(tmp_path):
+    """Tampered user_summary in completion.json → exit 1 with stored_sha+derived_sha."""
+    task_dir = _make_task_with_summary(
+        tmp_path,
+        reports=[{"auditor_name": "security-auditor", "blocking_count": 0}],
+        tampered_user_summary="Audit complete — ALL PASSED\n\n  security-auditor: PASS\n\nFAKE FOOTER",
+    )
+    r = _ctl("verify-audit-summary-text", str(task_dir))
+    assert r.returncode == 1
+    err = json.loads(r.stderr)
+    assert err["error"] == "mismatch"
+    assert "stored_sha" in err and "derived_sha" in err
+    assert err["stored_sha"] != err["derived_sha"]
+
+
+def test_verify_command_legacy_completion(tmp_path):
+    """completion.json without user_summary → exit 3."""
+    task_dir = _make_task_with_summary(tmp_path, include_user_summary=False)
+    r = _ctl("verify-audit-summary-text", str(task_dir))
+    assert r.returncode == 3
+    err = json.loads(r.stderr)
+    assert err["error"] == "legacy_completion_missing_user_summary"
+
+
+def test_verify_command_missing_file(tmp_path):
+    """completion.json missing → exit 2."""
+    task_dir = tmp_path / ".dynos" / "task-X"
+    task_dir.mkdir(parents=True)
+    # Only audit-summary.json exists
+    (task_dir / "audit-summary.json").write_text(json.dumps({"task_id": "task-X", "reports": []}))
+    r = _ctl("verify-audit-summary-text", str(task_dir))
+    assert r.returncode == 2
+    err = json.loads(r.stderr)
+    assert err["error"] == "missing_file"
+    assert err["completion_exists"] is False

--- a/tests/test_user_summary.py
+++ b/tests/test_user_summary.py
@@ -120,6 +120,56 @@ def test_derive_no_trailing_newline():
     assert not derive_user_summary(summary2).endswith("\n")
 
 
+def test_derive_single_blocking_finding():
+    """Scenario: one auditor with blocking_count=1 (singular)."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "spec-completion-auditor", "blocking_count": 0},
+            {"auditor_name": "security-auditor", "blocking_count": 1},
+        ],
+    }
+    result = derive_user_summary(summary)
+    assert "Audit complete — FAILED — 1 blocking findings" in result
+    assert "  security-auditor: FAIL (1 blocking)" in result
+    assert "  spec-completion-auditor: PASS" in result
+
+
+def test_derive_multiple_blocking_across_auditors():
+    """Scenario: multiple auditors each contributing blocking findings."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "security-auditor", "blocking_count": 3},
+            {"auditor_name": "code-quality-auditor", "blocking_count": 2},
+            {"auditor_name": "spec-completion-auditor", "blocking_count": 0},
+        ],
+    }
+    result = derive_user_summary(summary)
+    # Total = 3 + 2 + 0 = 5
+    assert "Audit complete — FAILED — 5 blocking findings" in result
+    assert "  security-auditor: FAIL (3 blocking)" in result
+    assert "  code-quality-auditor: FAIL (2 blocking)" in result
+    assert "  spec-completion-auditor: PASS" in result
+
+
+def test_derive_preserves_insertion_order():
+    """Per-auditor lines appear in order of first appearance, not alphabetical."""
+    summary = {
+        "task_id": "task-X",
+        "reports": [
+            {"auditor_name": "zzz-last-auditor", "blocking_count": 0},
+            {"auditor_name": "aaa-first-auditor", "blocking_count": 0},
+        ],
+    }
+    result = derive_user_summary(summary)
+    zzz_pos = result.index("zzz-last-auditor")
+    aaa_pos = result.index("aaa-first-auditor")
+    # Insertion order: zzz comes first because it's first in reports
+    assert zzz_pos < aaa_pos, \
+        f"insertion-order violated: zzz_pos={zzz_pos} aaa_pos={aaa_pos}"
+
+
 def test_derive_em_dash_codepoint():
     """Header uses U+2014 em-dash, not '--' or U+2013 en-dash."""
     summary = {"task_id": "task-X", "reports": []}


### PR DESCRIPTION
## Summary

- Closes the last unenforced trust gap in the dynos-work pipeline. The user-facing summary printed at the end of `/dynos-work:audit` was the only LLM-generated output not bound by any cross-check. The orchestrator could narrate "ALL PASSED" while `audit-summary.json` showed `blocking_count > 0`.
- New deterministic helper `derive_user_summary(audit_summary)` in `hooks/lib_validate.py`. Pure function, no I/O. Aggregates `blocking_count` by `auditor_name` across all reports (handles multi-cycle re-audit). Em-dash is U+2014 literal. Insertion order preserved (no alphabetical sort).
- `cmd_run_audit_summary` now writes `user_summary` into `audit-summary.json` BEFORE persisting it, so the receipt-chain entry's sha256 captures the field.
- `cmd_run_audit_finish` reads `user_summary` from `audit-summary.json` (which is what gets copied into `completion.json`) and emits it in stdout JSON. No re-derivation.
- New ctl command `verify-audit-summary-text` re-derives independently and compares byte-exact. Exit 0 = match. Exit 1 = mismatch (stderr JSON `{stored_sha, derived_sha, diff_first_line}`). Exit 2 = either file missing. Exit 3 = legacy `completion.json` without the field.
- `skills/audit/SKILL.md` final print step replaced with a 3-line verbatim-echo instruction. The orchestrator's user-facing output for the audit skill is now constrained to a literal echo of `completion.json::user_summary`.
- Shipped end-to-end through `/dynos-work:start → execute → audit`. The audit's own `user_summary` was correctly derived, persisted, and returned in stdout — proving the mechanism on its own task.

## Test plan

- [x] `pytest tests/test_user_summary.py` — 14 passed.
- [x] Pure derivation: clean pass, single blocking, multiple blocking across auditors, multi-cycle aggregation, empty reports, no-trailing-newline, em-dash codepoint, insertion order preservation.
- [x] CLI exit codes via subprocess: 0 (match), 1 (tampered text), 2 (missing file), 3 (legacy completion).
- [x] Broader regression: 1701 passed, 6 skipped, 0 failed.
- [ ] On a real task post-merge, run `verify-audit-summary-text .dynos/task-{id}` after `/dynos-work:audit` and confirm exit 0.
- [ ] Confirm orchestrators (the audit skill's final step) actually echo verbatim — observable by comparing chat output against `completion.json::user_summary` byte-for-byte.

## Known follow-ups (non-blocking, surfaced by audit)

- `sec-001`: `verify-audit-summary-text` cannot detect upstream forgery of `audit-summary.json` (an attacker who rewrites the JSON and the user_summary field consistently passes verify). Trust anchor for that file is the receipt-chain HMAC from PR #147; documenting in the help text would help operators not over-trust this command.
- `sec-002`: `cmd_run_audit_summary` persists `audit-summary.json` via raw `write_json` rather than `_write_ctl_json`. Pre-existing pattern; the new field elevates the importance.
- `sec-003`: Em-dash U+2014 source-code fragility — an editor autoformat that normalizes dashes silently breaks every previously stored `user_summary`. Add an `ord() == 0x2014` assertion at import time.
- `cq-002`: Dead branch in `cmd_verify_audit_summary_text`'s diff-first-line computation (`stored_lines[i] if i < len(stored_lines) else None` — the condition is always true inside the zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
