### PR TITLE
feat: ctl record-snapshot wrapper for manifest.snapshot.head_sha

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2077,6 +2077,136 @@ def cmd_write_classification(args: argparse.Namespace) -> int:
     return 0
 
 
+# task-20260504-001: stages where record-snapshot is permitted.
+_SNAPSHOT_ALLOWED_STAGES: frozenset[str] = frozenset({
+    "FOUNDRY_INITIALIZED", "CLASSIFY_AND_SPEC", "SPEC_NORMALIZATION",
+    "SPEC_REVIEW", "PLANNING", "PLAN_REVIEW", "PLAN_AUDIT", "TDD_REVIEW",
+    "PRE_EXECUTION_SNAPSHOT", "EXECUTION_GRAPH_BUILD",
+})
+
+
+def cmd_record_snapshot(args: argparse.Namespace) -> int:
+    """task-20260504-001: record manifest.snapshot.head_sha via an audited
+    ctl path. Replaces the lib_core.write_ctl_json bypass.
+
+    Stage gate: refused at or beyond EXECUTION.
+    Idempotency: same head_sha = no-op (already_recorded). Different
+    head_sha = refused (no --force flag).
+    """
+    import re as _re
+    import subprocess as _sub
+
+    task_dir = Path(args.task_dir).resolve()
+    task_id = task_dir.name
+    root = _root_for_task_dir(task_dir)
+    manifest_path = task_dir / "manifest.json"
+
+    if not manifest_path.exists():
+        print(f"manifest.json not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    # 1. Resolve head_sha (explicit arg wins; else git rev-parse HEAD)
+    head_sha = args.head_sha
+    if head_sha is None:
+        try:
+            r = _sub.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if r.returncode != 0:
+                print(
+                    f"cannot auto-detect HEAD SHA: git rev-parse failed "
+                    f"(returncode={r.returncode}); provide --head-sha",
+                    file=sys.stderr,
+                )
+                return 1
+            head_sha = r.stdout.strip()
+        except (OSError, _sub.TimeoutExpired) as exc:
+            print(f"git auto-detect failed: {exc}; provide --head-sha", file=sys.stderr)
+            return 1
+
+    # 2. Validate head_sha format
+    if not _re.fullmatch(r"[0-9a-f]{40}", head_sha or ""):
+        print(f"invalid head_sha: {head_sha!r} (must be 40 hex chars, lowercase)", file=sys.stderr)
+        return 1
+
+    # 3. Resolve branch (explicit arg wins; else git symbolic-ref; else fallback)
+    branch = args.branch
+    if branch is None:
+        try:
+            r = _sub.run(
+                ["git", "-C", str(root), "symbolic-ref", "--short", "HEAD"],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            branch = r.stdout.strip() if r.returncode == 0 else ""
+        except (OSError, _sub.TimeoutExpired):
+            branch = ""
+        if not branch:
+            branch = f"dynos/{task_id}-snapshot"
+
+    # 4. Validate branch
+    branch = branch if isinstance(branch, str) else ""
+    branch_stripped = branch.strip()
+    if not branch_stripped:
+        print(f"invalid branch: {branch!r} (must be non-empty after strip)", file=sys.stderr)
+        return 1
+    if len(branch_stripped) > 200:
+        print(f"invalid branch: too long ({len(branch_stripped)} chars; max 200)", file=sys.stderr)
+        return 1
+    branch = branch_stripped
+
+    # 5. Stage gate
+    try:
+        manifest = _load_manifest(task_dir)
+    except Exception as exc:
+        print(f"failed to load manifest: {exc}", file=sys.stderr)
+        return 1
+
+    stage = manifest.get("stage", "")
+    if stage not in _SNAPSHOT_ALLOWED_STAGES:
+        print(f"cannot record snapshot: task is already at stage {stage}", file=sys.stderr)
+        return 1
+
+    # 6. Idempotency check
+    existing = manifest.get("snapshot")
+    if isinstance(existing, dict):
+        existing_sha = existing.get("head_sha")
+        if isinstance(existing_sha, str) and existing_sha == head_sha:
+            print(json.dumps({"status": "already_recorded", "head_sha": head_sha}))
+            return 0
+        if isinstance(existing_sha, str) and existing_sha and existing_sha != head_sha:
+            print(
+                f"cannot record snapshot: already recorded at {existing_sha}; "
+                f"re-recording with a different SHA is not supported",
+                file=sys.stderr,
+            )
+            return 1
+
+    # 7. Build payload + write
+    recorded_at = now_iso()
+    manifest["snapshot"] = {
+        "head_sha": head_sha,
+        "branch": branch,
+        "recorded_at": recorded_at,
+    }
+    try:
+        _write_ctl_json(task_dir, manifest_path, manifest)
+    except Exception as exc:
+        print(f"failed to write manifest: {exc}", file=sys.stderr)
+        return 1
+
+    # 8. Chain extension (manifest.json is in _FIXED_CHAIN_ARTIFACTS)
+    _try_extend_chain_for_artifact(task_dir, manifest_path)
+
+    print(json.dumps({
+        "status": "recorded",
+        "head_sha": head_sha,
+        "branch": branch,
+        "recorded_at": recorded_at,
+    }))
+    return 0
+
+
 def cmd_run_spec_ready(args: argparse.Namespace) -> int:
     task_dir = Path(args.task_dir).resolve()
     root = _root_for_task_dir(task_dir)
@@ -4712,6 +4842,22 @@ def register_artifact_parsers(subparsers: argparse._SubParsersAction) -> None:
     classification_write_parser.add_argument("task_dir")
     classification_write_parser.add_argument("--from", dest="from_path", required=True)
     classification_write_parser.set_defaults(func=cmd_write_classification)
+
+    record_snapshot_parser = subparsers.add_parser(
+        "record-snapshot",
+        help="Record manifest.snapshot.head_sha (auto-detected from git or via --head-sha)",
+    )
+    record_snapshot_parser.add_argument("task_dir")
+    record_snapshot_parser.add_argument(
+        "--head-sha", dest="head_sha", default=None,
+        help="40-char lowercase hex SHA. Auto-detected via git rev-parse HEAD when omitted.",
+    )
+    record_snapshot_parser.add_argument(
+        "--branch", dest="branch", default=None,
+        help="Branch name. Auto-detected via git symbolic-ref --short HEAD when omitted; "
+             "detached HEAD falls back to dynos/{task_id}-snapshot.",
+    )
+    record_snapshot_parser.set_defaults(func=cmd_record_snapshot)
 
     write_search_receipt_parser = subparsers.add_parser(
         "write-search-receipt",

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -35,12 +35,22 @@ Read `spec.md`, `plan.md`, and `execution-graph.json`. Ensure you understand the
 ### Step 2 — Snapshot the Base
 
 Before any modification starts:
-1. Capture the current HEAD SHA.
-2. Create a temporary git branch `dynos/task-{id}-snapshot`.
+1. Create a temporary git branch and return to the working branch:
+   ```
+   git checkout -b dynos/task-{id}-snapshot && git checkout -
+   ```
+2. Record the snapshot SHA into manifest.snapshot via the audited ctl wrapper:
+   ```
+   python3 hooks/ctl.py record-snapshot .dynos/task-{id}
+   ```
+   The command auto-detects HEAD SHA and branch from git. It accepts optional
+   `--head-sha SHA` and `--branch NAME` to override. Stage gate refuses anything
+   at or beyond `EXECUTION`. Re-run with the same SHA is a no-op
+   (`status: already_recorded`); a different SHA is refused.
 
-Append to log:
+Read the printed JSON for `head_sha` and `branch`. Append to log:
 ```
-{timestamp} [DECISION] snapshot created — branch dynos/task-{id}-snapshot at {head_sha}
+{timestamp} [DECISION] snapshot recorded — branch {branch} at {head_sha}
 ```
 
 ### Step 3 — Execute segments (Optimized Scheduler)

--- a/tests/test_record_snapshot.py
+++ b/tests/test_record_snapshot.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_record_snapshot.py
+++ b/tests/test_record_snapshot.py
@@ -1,0 +1,207 @@
+"""Tests for ctl record-snapshot subcommand (task-20260504-001).
+
+Pure subprocess tests against ctl.py. Each test creates a tmp_path-isolated
+.dynos/task-X/ directory with a minimal manifest, then invokes
+`python3 hooks/ctl.py record-snapshot ...` and asserts the subprocess
+returncode plus the on-disk manifest mutation (or absence of mutation).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CTL = REPO_ROOT / "hooks" / "ctl.py"
+
+
+def _make_task_dir(tmp_path: Path, *, task_id: str = "task-20260504-001",
+                    stage: str = "PRE_EXECUTION_SNAPSHOT",
+                    extra: dict | None = None) -> Path:
+    """Build a tmp_path-isolated .dynos/task-X/ with a minimal manifest."""
+    task_dir = tmp_path / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    manifest = {
+        "task_id": task_id,
+        "created_at": "2026-05-04T00:00:00Z",
+        "title": "test",
+        "raw_input": "test",
+        "input_type": "text",
+        "stage": stage,
+        "classification": None,
+        "retry_counts": {},
+        "blocked_reason": None,
+        "completed_at": None,
+    }
+    if extra:
+        manifest.update(extra)
+    (task_dir / "manifest.json").write_text(json.dumps(manifest))
+    return task_dir
+
+
+def _ctl(*args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(CTL), *args],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+
+
+def _init_git(repo_dir: Path, *, sha: str | None = None,
+              branch: str = "main", detached: bool = False) -> str:
+    """Initialize a git repo in repo_dir and return the head SHA."""
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo_dir, check=True)
+    (repo_dir / "stub.txt").write_text("hello")
+    subprocess.run(["git", "add", "stub.txt"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], cwd=repo_dir, check=True)
+    real_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo_dir, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    if detached:
+        subprocess.run(["git", "checkout", "-q", "--detach"], cwd=repo_dir, check=True)
+    return real_sha
+
+
+def test_happy_path_auto_detect(tmp_path):
+    """Auto-detect from git: no --head-sha, no --branch."""
+    real_sha = _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-auto")
+    r = _ctl("record-snapshot", str(task_dir))
+    assert r.returncode == 0, f"stderr={r.stderr}"
+    out = json.loads(r.stdout.strip().splitlines()[-1])
+    assert out["status"] == "recorded"
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["snapshot"]["head_sha"] == real_sha
+    assert manifest["snapshot"]["branch"] == "main"
+    assert "recorded_at" in manifest["snapshot"]
+
+
+def test_explicit_head_sha_and_branch(tmp_path):
+    """Explicit --head-sha + --branch bypasses git auto-detect."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-explicit")
+    explicit_sha = "a" * 40
+    r = _ctl("record-snapshot", str(task_dir),
+             "--head-sha", explicit_sha, "--branch", "feature-x")
+    assert r.returncode == 0, f"stderr={r.stderr}"
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["snapshot"]["head_sha"] == explicit_sha
+    assert manifest["snapshot"]["branch"] == "feature-x"
+
+
+def test_idempotent_same_sha(tmp_path):
+    """Re-running with the same SHA is a no-op."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-idem")
+    explicit_sha = "b" * 40
+    r1 = _ctl("record-snapshot", str(task_dir), "--head-sha", explicit_sha, "--branch", "x")
+    assert r1.returncode == 0
+    first_manifest = (task_dir / "manifest.json").read_bytes()
+
+    r2 = _ctl("record-snapshot", str(task_dir), "--head-sha", explicit_sha, "--branch", "x")
+    assert r2.returncode == 0
+    out = json.loads(r2.stdout.strip().splitlines()[-1])
+    assert out["status"] == "already_recorded"
+    # Byte-identical manifest after second call (no mutation, including recorded_at)
+    assert (task_dir / "manifest.json").read_bytes() == first_manifest
+
+
+def test_refusal_different_sha(tmp_path):
+    """Re-running with a different SHA is refused; manifest unchanged."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-diff")
+    r1 = _ctl("record-snapshot", str(task_dir), "--head-sha", "c" * 40, "--branch", "x")
+    assert r1.returncode == 0
+    before = (task_dir / "manifest.json").read_bytes()
+
+    r2 = _ctl("record-snapshot", str(task_dir), "--head-sha", "d" * 40, "--branch", "x")
+    assert r2.returncode == 1
+    assert "already recorded" in r2.stderr.lower()
+    # Manifest must NOT have been mutated
+    assert (task_dir / "manifest.json").read_bytes() == before
+
+
+def test_stage_gate_refused_at_execution(tmp_path):
+    """Stage gate refuses when manifest.stage == EXECUTION."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-exec", stage="EXECUTION")
+    r = _ctl("record-snapshot", str(task_dir), "--head-sha", "e" * 40, "--branch", "x")
+    assert r.returncode == 1
+    assert "EXECUTION" in r.stderr
+    # Manifest's stage stays EXECUTION; no snapshot key added
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["stage"] == "EXECUTION"
+    assert "snapshot" not in manifest or manifest.get("snapshot") is None
+
+
+def test_stage_gate_refused_at_done(tmp_path):
+    """Stage gate refuses when manifest.stage == DONE."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-done", stage="DONE")
+    r = _ctl("record-snapshot", str(task_dir), "--head-sha", "f" * 40, "--branch", "x")
+    assert r.returncode == 1
+    assert "DONE" in r.stderr
+
+
+def test_stage_gate_allowed_at_pre_execution_snapshot(tmp_path):
+    """Stage gate allows when manifest.stage == PRE_EXECUTION_SNAPSHOT."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-pre", stage="PRE_EXECUTION_SNAPSHOT")
+    r = _ctl("record-snapshot", str(task_dir), "--head-sha", "0" * 40, "--branch", "x")
+    assert r.returncode == 0
+
+
+def test_invalid_head_sha_format(tmp_path):
+    """head_sha format validation rejects uppercase, short, long."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-bad")
+    # Uppercase
+    r1 = _ctl("record-snapshot", str(task_dir), "--head-sha", "A" * 40, "--branch", "x")
+    assert r1.returncode == 1
+    assert "head_sha" in r1.stderr.lower()
+    # Too short
+    r2 = _ctl("record-snapshot", str(task_dir), "--head-sha", "a" * 39, "--branch", "x")
+    assert r2.returncode == 1
+    # Too long
+    r3 = _ctl("record-snapshot", str(task_dir), "--head-sha", "a" * 41, "--branch", "x")
+    assert r3.returncode == 1
+
+
+def test_no_git_no_flag_hard_errors(tmp_path):
+    """When --head-sha omitted and no git repo, command exits 1."""
+    # Don't init git in tmp_path
+    task_dir = _make_task_dir(tmp_path, task_id="task-nogit")
+    r = _ctl("record-snapshot", str(task_dir))
+    assert r.returncode == 1
+    # Stderr must hint at the remedy
+    assert "head-sha" in r.stderr.lower() or "git" in r.stderr.lower()
+
+
+def test_detached_head_branch_fallback(tmp_path):
+    """Detached HEAD with no --branch falls back to dynos/{task_id}-snapshot."""
+    real_sha = _init_git(tmp_path, detached=True)
+    task_dir = _make_task_dir(tmp_path, task_id="task-detached")
+    r = _ctl("record-snapshot", str(task_dir))
+    assert r.returncode == 0, f"stderr={r.stderr}"
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["snapshot"]["head_sha"] == real_sha
+    assert manifest["snapshot"]["branch"] == "dynos/task-detached-snapshot"
+
+
+def test_invalid_branch_empty(tmp_path):
+    """Empty branch (after strip) is rejected."""
+    _init_git(tmp_path)
+    task_dir = _make_task_dir(tmp_path, task_id="task-emptybranch")
+    r = _ctl("record-snapshot", str(task_dir), "--head-sha", "0" * 40, "--branch", "   ")
+    assert r.returncode == 1
+    assert "branch" in r.stderr.lower()


### PR DESCRIPTION
## Summary

- Adds `python3 hooks/ctl.py record-snapshot <task_dir> [--head-sha SHA] [--branch NAME]` — an audited entry point for recording the pre-execution snapshot SHA into `manifest.snapshot`. Replaces the `lib_core.write_ctl_json` bypass that every `/dynos-work:execute` run in the prior conversation used to populate this field.
- Auto-detects `head_sha` from `git rev-parse HEAD` and `branch` from `git symbolic-ref --short HEAD`. Detached HEAD falls back to `dynos/{task_id}-snapshot`. `head_sha` validated against `/^[0-9a-f]{40}$/`; branch must be non-empty (≤200 chars after strip).
- Stage gate: 10-stage allowlist (`FOUNDRY_INITIALIZED` through `EXECUTION_GRAPH_BUILD`). Refused at or beyond `EXECUTION` with `cannot record snapshot: task is already at stage {stage}`.
- Idempotent on `head_sha`: same SHA → no-op (`status: already_recorded`); different SHA → refused (no `--force` flag).
- Manifest write goes through `_write_ctl_json` (the audited write boundary) followed by `_try_extend_chain_for_artifact(manifest_path)` for receipt-chain integrity.
- `skills/execute/SKILL.md` Step 2 updated to call `record-snapshot` instead of describing the bypass pattern.

## Test plan

- [x] 11 subprocess tests in `tests/test_record_snapshot.py`: happy path auto-detect, explicit args, idempotent same SHA, refusal on different SHA, stage gate refused at `EXECUTION` + `DONE`, allowed at `PRE_EXECUTION_SNAPSHOT`, invalid `head_sha` format (uppercase / short / long), no-git hard error, detached HEAD branch fallback, empty branch rejection.
- [x] Broader regression: 1712 passed, 6 skipped, 0 failed.
- [ ] After merge, every `/dynos-work:execute` calls `record-snapshot` instead of the Python `lib_core.write_ctl_json` shortcut.

## Known follow-ups (non-blocking, surfaced by audit)

- `sec-001`: TOCTOU between manifest read and write — a concurrent `transition` between `_load_manifest` (line 2160) and `_write_ctl_json` (line 2193) could silently roll back the newer stage. Systemic ctl-wide concern (every command shares this race); not introduced by this diff.
- `sec-002`: Idempotency check is permissive when `manifest.snapshot` is malformed (non-dict, missing `head_sha`). Falls through to overwrite without warning. Robustness issue, not exploit (requires a separate write-policy bypass to seed the malformed value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
