### PR TITLE
fix: defense-in-depth + dead-branch cleanup bundle (6 items)

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2471,6 +2471,8 @@ def _collect_latest_audit_reports(audit_dir: Path) -> dict[str, Path]:
     # Group files by auditor key.
     groups: dict[str, list[tuple[int, int, str, float, str, Path]]] = {}
     for p in audit_dir.glob("*.json"):
+        if p.is_symlink():
+            continue
         name = p.name
         stem = p.stem  # filename without .json
 
@@ -4060,7 +4062,7 @@ def cmd_verify_audit_summary_text(args: argparse.Namespace) -> int:
     diff_first_line = None
     for i, (s, d) in enumerate(zip(stored_lines, derived_lines)):
         if s != d:
-            diff_first_line = stored_lines[i] if i < len(stored_lines) else None
+            diff_first_line = stored_lines[i]
             break
     else:
         # All shared lines match; the longer one diverges at its tail.

--- a/hooks/lib_chain.py
+++ b/hooks/lib_chain.py
@@ -51,16 +51,27 @@ _CHAIN_FILENAME = "task-receipt-chain.jsonl"
 class ChainValidationResult:
     """Structured result of `validate_chain()`.
 
-    Fields:
-        status: One of {"valid", "content_mismatch", "chain_corrupt",
-                "chain_missing", "chain_truncated"}.
-        first_failed_index: 0-based index of the first failing entry, or
-                None when status == "valid" or "chain_missing".
-        first_failed_field: Which field broke ("sha256", "prev_sha256",
-                "_sig"), or None when status is "valid"/"chain_missing".
-        error_reason: Human-readable detail for the CLI/logs.
-        first_failed_file_path: file_path of the failing entry, or None
-                when status == "valid"/"chain_missing".
+Field invariants by status:
+
+| status              | first_failed_index | first_failed_field | error_reason | first_failed_file_path |
+|---------------------|--------------------|--------------------|--------------|------------------------|
+| "valid"             | None               | None               | None         | None                   |
+| "chain_missing"     | None               | None               | None         | None                   |
+| "content_mismatch"  | int >= 0           | "sha256"           | str          | str                    |
+| "chain_corrupt"     | int >= 0           | "_sig" or "prev_sha256" | str    | str or None            |
+| "chain_truncated"   | int >= 0           | "_sig"             | str          | str or None            |
+
+Fields:
+    status: One of {"valid", "content_mismatch", "chain_corrupt",
+            "chain_missing", "chain_truncated"}.
+    first_failed_index: 0-based index of the first failing entry, or
+            None when status is "valid" or "chain_missing".
+    first_failed_field: Which field broke ("sha256", "prev_sha256",
+            "_sig"), or None when status is "valid" or "chain_missing".
+    error_reason: Human-readable detail for the CLI/logs, or None
+            when status is "valid" or "chain_missing".
+    first_failed_file_path: file_path of the failing entry, or None
+            when status is "valid" or "chain_missing".
     """
     status: str
     first_failed_index: int | None
@@ -139,7 +150,7 @@ def _task_relative(task_dir: Path, file_path: Path) -> str:
     except ValueError:
         # File lives outside task_dir — store an absolute path. validate_chain
         # will recompute against the same path on validate.
-        return str(file_path)
+        return str(file_path.resolve())
 
 
 def _append_entry_unlocked(task_dir: Path, step: str, kind: str, file_path: Path) -> None:

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -175,6 +175,10 @@ def allowed_globs_for_role(role: str, task_dir: Path | None) -> list[str]:
 
 def decide_write(attempt: WriteAttempt) -> WriteDecision:
     path = attempt.path.resolve()
+    if path.name == ".rules_corrupt" and path.parent.name == ".dynos":
+        if attempt.role == "daemon":
+            return WriteDecision(True, ".dynos/.rules_corrupt allowed for daemon role", "direct")
+        return WriteDecision(False, ".dynos/.rules_corrupt is daemon-owned kill-switch state; agent writes denied", "deny")
     rel = _task_relative(path, attempt.task_dir)
     rel_posix = rel.as_posix() if rel is not None else None
 

--- a/tests/test_collect_latest_symlink.py
+++ b/tests/test_collect_latest_symlink.py
@@ -1,0 +1,121 @@
+"""Tests for symlink exclusion in _collect_latest_audit_reports (task-20260504-003).
+
+Covers AC 7 (sec-r2-002):
+  _collect_latest_audit_reports must skip any .json entry that is a symlink.
+  A symlink with a .json extension inside audit-reports/ must not appear in
+  the return value, preventing path-injection via crafted symlink names.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+from ctl import _collect_latest_audit_reports  # noqa: E402
+
+
+def _write_real_report(audit_dir: Path, filename: str, auditor_name: str) -> Path:
+    """Write a real JSON audit report and return its path."""
+    p = audit_dir / filename
+    p.write_text(json.dumps({"auditor_name": auditor_name, "findings": []}))
+    return p
+
+
+def test_symlink_excluded_from_collection(tmp_path: Path) -> None:
+    """A symlink .json file in audit-reports/ must not appear in the collected dict (AC 7).
+
+    The real file is collected; the symlink is silently skipped.
+    """
+    audit_dir = tmp_path / "audit-reports"
+    audit_dir.mkdir()
+
+    # Real checkpoint file for security-auditor
+    real_file = _write_real_report(
+        audit_dir,
+        "security-auditor-checkpoint-2026-05-01T00:00:00.json",
+        auditor_name="security-auditor",
+    )
+
+    # Symlink with a .json extension — injection attempt
+    symlink_target = tmp_path / "fake-injected-report.json"
+    symlink_target.write_text(
+        json.dumps({"auditor_name": "spec-completion-auditor", "findings": []})
+    )
+    symlink_path = audit_dir / "spec-completion-auditor-checkpoint-2026-05-02T00:00:00.json"
+    symlink_path.symlink_to(symlink_target)
+
+    result = _collect_latest_audit_reports(audit_dir)
+
+    # The symlink must not be among the winning paths.
+    collected_paths = set(result.values())
+    assert symlink_path not in collected_paths, (
+        "symlink must be excluded from _collect_latest_audit_reports result; "
+        f"collected paths: {collected_paths}"
+    )
+    assert symlink_path.resolve() not in collected_paths, (
+        "resolved symlink target must also not appear in result via indirect collection"
+    )
+
+    # The real file must still be collected.
+    assert real_file in collected_paths or real_file.resolve() in collected_paths, (
+        "real (non-symlink) report must still be collected; "
+        f"collected paths: {collected_paths}"
+    )
+
+    # Exactly one auditor key returned (the real file's auditor only).
+    assert len(result) == 1, (
+        f"expected exactly 1 auditor in result, got {len(result)}: {list(result.keys())}"
+    )
+    assert "security-auditor" in result, (
+        f"security-auditor key must be present; keys: {list(result.keys())}"
+    )
+
+
+def test_symlink_only_dir_returns_empty(tmp_path: Path) -> None:
+    """When audit-reports/ contains only symlinks, the result is empty.
+
+    This is the all-symlink edge case: no real reports → empty dict.
+    """
+    audit_dir = tmp_path / "audit-reports"
+    audit_dir.mkdir()
+
+    symlink_target = tmp_path / "external.json"
+    symlink_target.write_text(
+        json.dumps({"auditor_name": "security-auditor", "findings": []})
+    )
+    symlink_path = audit_dir / "security-auditor-checkpoint-2026-05-01T00:00:00.json"
+    symlink_path.symlink_to(symlink_target)
+
+    result = _collect_latest_audit_reports(audit_dir)
+
+    assert result == {}, (
+        "all-symlink audit-reports/ must yield empty dict; "
+        f"got: {result}"
+    )
+
+
+def test_real_files_collected_normally_without_symlinks(tmp_path: Path) -> None:
+    """Baseline: real files continue to be collected correctly when no symlinks are present."""
+    audit_dir = tmp_path / "audit-reports"
+    audit_dir.mkdir()
+
+    _write_real_report(
+        audit_dir,
+        "security-auditor-checkpoint-2026-05-01T00:00:00.json",
+        auditor_name="security-auditor",
+    )
+    _write_real_report(
+        audit_dir,
+        "code-quality-auditor-checkpoint-2026-05-01T00:00:00.json",
+        auditor_name="code-quality-auditor",
+    )
+
+    result = _collect_latest_audit_reports(audit_dir)
+
+    assert len(result) == 2, f"expected 2 auditors; got {len(result)}: {list(result.keys())}"
+    assert "security-auditor" in result
+    assert "code-quality-auditor" in result

--- a/tests/test_user_summary.py
+++ b/tests/test_user_summary.py
@@ -176,6 +176,7 @@ def test_derive_em_dash_codepoint():
     result = derive_user_summary(summary)
     # The em-dash codepoint is —
     assert "—" in result, "em-dash U+2014 must be present in header"
+    assert any(ord(c) == 0x2014 for c in result), "codepoint must be U+2014 specifically"
     # Not the en-dash
     assert "–" not in result
 

--- a/tests/test_write_policy_sentinel.py
+++ b/tests/test_write_policy_sentinel.py
@@ -1,0 +1,135 @@
+"""Tests for .dynos/.rules_corrupt sentinel gate in write_policy (task-20260504-003).
+
+Covers ACs 4 and 5 (sec-r2-001):
+  AC 4 — decide_write with path resolving to .dynos/.rules_corrupt and
+          role='execute-inline' must be refused.
+  AC 5 — same path with role='daemon' must NOT be refused by the sentinel.
+
+The sentinel check must operate on the already-resolved absolute path so a
+symlink pointing at .dynos/.rules_corrupt cannot bypass it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+
+def _make_dynos_dir(tmp_path: Path) -> Path:
+    """Return tmp_path/.dynos, created on disk."""
+    dynos_dir = tmp_path / ".dynos"
+    dynos_dir.mkdir(parents=True, exist_ok=True)
+    return dynos_dir
+
+
+def test_sentinel_refused_for_non_daemon_role(tmp_path: Path) -> None:
+    """execute-inline must be refused when writing .dynos/.rules_corrupt (AC 4)."""
+    dynos_dir = _make_dynos_dir(tmp_path)
+    sentinel_path = dynos_dir / ".rules_corrupt"
+
+    decision = decide_write(
+        WriteAttempt(
+            role="execute-inline",
+            task_dir=None,
+            path=sentinel_path,
+            operation="create",
+            source="agent",
+        )
+    )
+
+    assert decision.allowed is False, (
+        "sentinel gate must refuse non-daemon role writing .dynos/.rules_corrupt"
+    )
+    # Reason must identify what is being protected — any of these substrings suffice.
+    reason_lower = decision.reason.lower()
+    assert (
+        "rules_corrupt" in reason_lower
+        or "kill-switch" in reason_lower
+        or "kill switch" in reason_lower
+        or "daemon-owned" in reason_lower
+        or "daemon" in reason_lower
+    ), f"reason should reference the sentinel or daemon ownership; got: {decision.reason!r}"
+
+
+def test_sentinel_refused_for_backend_executor_role(tmp_path: Path) -> None:
+    """backend-executor must also be refused (AC 4 — any non-daemon role)."""
+    dynos_dir = _make_dynos_dir(tmp_path)
+    sentinel_path = dynos_dir / ".rules_corrupt"
+
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=None,
+            path=sentinel_path,
+            operation="modify",
+            source="agent",
+        )
+    )
+
+    assert decision.allowed is False, (
+        "backend-executor must not be allowed to write .dynos/.rules_corrupt"
+    )
+
+
+def test_sentinel_allowed_for_daemon_role(tmp_path: Path) -> None:
+    """daemon role must not be refused by the sentinel check (AC 5)."""
+    dynos_dir = _make_dynos_dir(tmp_path)
+    sentinel_path = dynos_dir / ".rules_corrupt"
+
+    decision = decide_write(
+        WriteAttempt(
+            role="daemon",
+            task_dir=None,
+            path=sentinel_path,
+            operation="create",
+            source="system",
+        )
+    )
+
+    assert decision.allowed is True, (
+        "daemon role must be permitted to write .dynos/.rules_corrupt; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )
+
+
+def test_sentinel_via_symlink_still_blocked(tmp_path: Path) -> None:
+    """A symlink whose resolve() lands on .dynos/.rules_corrupt must still be blocked.
+
+    This verifies that the check operates on the resolved absolute path, not the
+    raw caller-supplied path — closing the symlink bypass vector described in AC 1
+    and the implicit requirements section.
+    """
+    dynos_dir = _make_dynos_dir(tmp_path)
+    # The symlink target does not need to exist for resolve() on POSIX; Path.resolve()
+    # resolves symlinks in the prefix and returns the real path of the target name.
+    # Create the target so resolve() can fully canonicalize it.
+    target = dynos_dir / ".rules_corrupt"
+    target.touch()
+
+    symlink_path = dynos_dir / "sneaky"
+    symlink_path.symlink_to(target)
+
+    # Confirm the symlink resolves to .rules_corrupt
+    assert symlink_path.resolve().name == ".rules_corrupt", (
+        "test setup error: symlink should resolve to .rules_corrupt"
+    )
+
+    decision = decide_write(
+        WriteAttempt(
+            role="execute-inline",
+            task_dir=None,
+            path=symlink_path,  # caller passes the symlink path
+            operation="modify",
+            source="agent",
+        )
+    )
+
+    assert decision.allowed is False, (
+        "symlink whose resolved path is .dynos/.rules_corrupt must be blocked; "
+        f"got allowed={decision.allowed}, reason={decision.reason!r}"
+    )


### PR DESCRIPTION
## Summary

Six small surgical changes deferred from prior PR audits as non-blocking findings, bundled.

**write_policy.py** — `decide_write` sentinel gate for `.dynos/.rules_corrupt`. Allows only `role == "daemon"`; refuses everything else as defense-in-depth (the daemon process bypasses write_policy entirely; this gate refuses any agent attempting to flip the kill-switch). Operates on the already-resolved path so symlink redirection cannot bypass it.

**ctl.py** —
- `_collect_latest_audit_reports`: skip symlinks via `if p.is_symlink(): continue` as the first statement in the glob loop. Hardens the helper introduced in PR #150 against TOCTOU on `stat()`/`load_json` via attacker-placed symlinks.
- `cmd_verify_audit_summary_text`: remove dead `i < len(stored_lines)` ternary (zip truncates → guard always True).

**lib_chain.py** —
- `_task_relative`: fallback returns `str(file_path.resolve())` instead of `str(file_path)` so chain entries are always absolute when outside task_dir.
- `ChainValidationResult`: docstring rewritten with explicit invariant table covering all 5 status values and their None/non-None field pairings.

## Tests (TDD-First, committed pre-impl)

- `tests/test_write_policy_sentinel.py` — 4 tests (refused-for-non-daemon, refused-for-backend-executor, allowed-for-daemon, blocked-via-symlink)
- `tests/test_collect_latest_symlink.py` — 3 tests (symlink-excluded, all-symlink-dir-empty, real-files-baseline)
- `tests/test_user_summary.py` — added `assert any(ord(c) == 0x2014 for c in result)` alongside the existing literal substring check (hardens against character-substitution drift in source)

## Test plan

- [x] `pytest tests/test_write_policy_sentinel.py tests/test_collect_latest_symlink.py tests/test_user_summary.py -v` — 21 pass
- [x] Full suite: 1729 passed, 7 skipped, 0 regressions
- [x] Audit pipeline dogfooded again: spec-completion + code-quality reaudits superseded their failing checkpoints via the latest-supersedes-prior helper from PR #150

## Origin of items

- sec-r2-001 sentinel write_policy gate (deferred from PR #145)
- sec-r2-002 symlink re-check (deferred from PR #150 — flagged by haiku-L1 security, downgraded to advisory by opus binding verdict)
- sec-003 U+2014 codepoint assertion (deferred from PR #148)
- cq-002 dead branch in cmd_verify_audit_summary_text (deferred from PR #148)
- cq-004 _task_relative absolute path fallback (deferred from PR #147)
- cq-001 ChainValidationResult docstring (deferred from PR #147)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
