### PR TITLE
refactor: extract require_nonblank_str helper, migrate 16 inline raises

### DIFF
--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from lib_core import now_iso, append_execution_log, _persistent_project_dir
 from lib_log import log_event, verify_signed_events
-from lib_validate import require_nonblank
+from lib_validate import require_nonblank, require_nonblank_str
 from write_policy import WriteAttempt, get_capability_key, require_write_allowed
 
 
@@ -715,8 +715,7 @@ def receipt_search_conducted(task_dir: Path, *, query: str, search_used: bool = 
     so a caller cannot write a vacuous "search conducted" receipt without having
     done any search.
     """
-    if not isinstance(query, str) or not query.strip():
-        raise ValueError("receipt_search_conducted: query must be a non-empty string")
+    require_nonblank_str(query, field_name="receipt_search_conducted: query")
     if not search_used:
         raise ValueError(
             "receipt_search_conducted: search_used must be True — "
@@ -987,8 +986,7 @@ def receipt_executor_done(
     determined the segment was legitimately a no-op. Must be a bool; raises
     ``ValueError`` on type violation.
     """
-    if not isinstance(injected_prompt_sha256, str) or not injected_prompt_sha256:
-        raise ValueError("injected_prompt_sha256 must be a non-empty string")
+    require_nonblank_str(injected_prompt_sha256, field_name="injected_prompt_sha256")
 
     if not isinstance(diff_verified_files, list) or not all(
         isinstance(f, str) for f in diff_verified_files
@@ -1124,8 +1122,7 @@ def _validate_audit_done_args(
     "no report -> default to zero" rule). Raises ValueError or TypeError
     with identical existing messages on any violation.
     """
-    if not isinstance(route_mode, str) or not route_mode:
-        raise ValueError("route_mode must be a non-empty string")
+    require_nonblank_str(route_mode, field_name="route_mode")
     if injected_agent_sha256 is None and route_mode != "generic":
         raise ValueError(
             f"injected_agent_sha256 may be None only when route_mode=='generic' "
@@ -1788,11 +1785,10 @@ def receipt_planner_spawn(  # called dynamically from skills/start/SKILL.md
 
     # Sidecar assertion — unconditional now. Every caller must first run
     # `hooks/router.py planner-inject-prompt` and pass the captured digest.
-    if not isinstance(injected_prompt_sha256, str) or not injected_prompt_sha256:
-        raise ValueError(
-            "receipt_planner_spawn: injected_prompt_sha256 must be a "
-            "non-empty string"
-        )
+    require_nonblank_str(
+        injected_prompt_sha256,
+        field_name="receipt_planner_spawn: injected_prompt_sha256",
+    )
     sidecar_file = (
         task_dir / "receipts" / INJECTED_PLANNER_PROMPTS_DIR
         / f"{phase}.sha256"
@@ -1926,12 +1922,10 @@ def receipt_tdd_tests(
         isinstance(p, str) for p in test_file_paths
     ):
         raise ValueError("test_file_paths must be a list[str]")
-    if not isinstance(tests_evidence_sha256, str) or not tests_evidence_sha256:
-        raise ValueError("tests_evidence_sha256 must be a non-empty string")
+    require_nonblank_str(tests_evidence_sha256, field_name="tests_evidence_sha256")
     if not isinstance(tokens_used, int) or tokens_used < 0:
         raise ValueError("tokens_used must be a non-negative int")
-    if not isinstance(model_used, str) or not model_used:
-        raise ValueError("model_used must be a non-empty string")
+    require_nonblank_str(model_used, field_name="model_used")
 
     if tokens_used > 0:
         _record_tokens(task_dir, "tdd-tests", model_used, tokens_used)
@@ -1965,12 +1959,10 @@ def receipt_human_approval(
     (no path separators), `artifact_sha256` must be a non-empty string,
     `approver` defaults to "human".
     """
-    if not isinstance(stage, str) or not stage:
-        raise ValueError("stage must be a non-empty string")
+    require_nonblank_str(stage, field_name="stage")
     if "/" in stage or "\\" in stage or stage.startswith("."):
         raise ValueError(f"stage must not contain path separators: {stage!r}")
-    if not isinstance(artifact_sha256, str) or not artifact_sha256:
-        raise ValueError("artifact_sha256 must be a non-empty string")
+    require_nonblank_str(artifact_sha256, field_name="artifact_sha256")
     try:
         require_nonblank(approver, field_name="approver")
     except (TypeError, ValueError):
@@ -2133,8 +2125,7 @@ def receipt_postmortem_skipped(
             f"invalid postmortem skip reason: {reason!r} "
             f"(allowed: {', '.join(sorted(_POSTMORTEM_SKIP_REASONS))})"
         )
-    if not isinstance(retrospective_sha256, str) or not retrospective_sha256:
-        raise ValueError("retrospective_sha256 must be a non-empty string")
+    require_nonblank_str(retrospective_sha256, field_name="retrospective_sha256")
 
     # Rule (a): subsumed_by must be a list. `isinstance(..., list)`
     # rejects tuples, sets, dicts, strings, None, ints, etc. — the
@@ -2221,10 +2212,8 @@ def receipt_calibration_applied(
         raise ValueError("retros_consumed must be a non-negative int")
     if not isinstance(scores_updated, int) or scores_updated < 0:
         raise ValueError("scores_updated must be a non-negative int")
-    if not isinstance(policy_sha256_before, str) or not policy_sha256_before:
-        raise ValueError("policy_sha256_before must be a non-empty string")
-    if not isinstance(policy_sha256_after, str) or not policy_sha256_after:
-        raise ValueError("policy_sha256_after must be a non-empty string")
+    require_nonblank_str(policy_sha256_before, field_name="policy_sha256_before")
+    require_nonblank_str(policy_sha256_after, field_name="policy_sha256_after")
     if retros_consumed > 0 and policy_sha256_before == policy_sha256_after:
         raise ValueError(
             f"receipt_calibration_applied REFUSES to write: retros_consumed="
@@ -2263,8 +2252,7 @@ def receipt_calibration_noop(
             f"invalid calibration-noop reason: {reason!r} "
             f"(allowed: {sorted(_CALIBRATION_NOOP_REASONS)})"
         )
-    if not isinstance(policy_sha256, str) or not policy_sha256:
-        raise ValueError("policy_sha256 must be a non-empty string")
+    require_nonblank_str(policy_sha256, field_name="policy_sha256")
     return write_receipt(
         task_dir,
         "calibration-noop",
@@ -2401,10 +2389,8 @@ def receipt_force_override(
         encode human intent (break-glass rationale + operator identity)
         that is not derivable from on-disk state.
     """
-    if not isinstance(from_stage, str) or not from_stage:
-        raise ValueError("from_stage must be a non-empty string")
-    if not isinstance(to_stage, str) or not to_stage:
-        raise ValueError("to_stage must be a non-empty string")
+    require_nonblank_str(from_stage, field_name="from_stage")
+    require_nonblank_str(to_stage, field_name="to_stage")
     # SEC-002 hardening: stage names MUST be strict uppercase identifier
     # slugs. Prevents path traversal via crafted manifest["stage"] values
     # like "../../etc/x" reaching the receipt filename.
@@ -2488,10 +2474,8 @@ def receipt_scheduler_refused(
         entry MUST be a string. Any other container type or non-string
         entry raises ``ValueError``.
     """
-    if not isinstance(current_stage, str) or not current_stage:
-        raise ValueError("current_stage must be a non-empty string")
-    if not isinstance(proposed_stage, str) or not proposed_stage:
-        raise ValueError("proposed_stage must be a non-empty string")
+    require_nonblank_str(current_stage, field_name="current_stage")
+    require_nonblank_str(proposed_stage, field_name="proposed_stage")
     # SEC-002 hardening: stage names MUST be strict uppercase identifier
     # slugs. Prevents path traversal / event-payload injection via crafted
     # manifest stage values reaching the receipt/event surface.

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -39,6 +39,26 @@ def require_nonblank(value: str, *, field_name: str) -> str:
     return stripped
 
 
+def require_nonblank_str(value, *, field_name: str) -> str:
+    """Raise ValueError if value is not a non-empty string. Returns stripped value.
+
+    Use this when migrating inline raise patterns of the form
+    `if not isinstance(X, str) or not X: raise ValueError("X must be a non-empty string")`.
+
+    Differs from require_nonblank() in that non-string inputs raise ValueError
+    (not TypeError), preserving compatibility with code paths that use
+    `pytest.raises(ValueError)` on the original inline pattern.
+
+    Raises:
+        ValueError: if value is not a str OR is empty/whitespace-only.
+    Returns:
+        The stripped string.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
 REQUIRED_SPEC_HEADINGS: list[str] = [
     "Task Summary",
     "User Context",

--- a/tests/test_lib_receipts_inline_pattern_sentinel.py
+++ b/tests/test_lib_receipts_inline_pattern_sentinel.py
@@ -1,0 +1,117 @@
+"""Sentinel test: AST-walk hooks/lib_receipts.py for inline raise patterns.
+
+Covers AC 12 of task-20260504-006.
+
+After seg-2 migrates all 13 inline sites to require_nonblank_str, this test
+must pass.  Before migration it will fail (reporting matched line numbers) —
+that is the expected TDD-First failure.
+
+Pattern detected (exactly 2-operand BoolOp):
+
+    if not isinstance(X, str) or not X[.strip()]:
+        raise ValueError("... must be a non-empty string")
+
+Allowlist: BoolOp nodes with 3+ operands are skipped (those carry an
+additional None guard and are out of scope for this migration).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_RECEIPTS = REPO_ROOT / "hooks" / "lib_receipts.py"
+
+
+def _is_target_pattern(node: ast.If) -> bool:
+    """Return True if *node* matches the inline isinstance+raise pattern.
+
+    Pattern (2-operand Or only):
+      test  : BoolOp(Or, [UnaryOp(Not, Call(isinstance, ..., Name('str'))),
+                          UnaryOp(Not, <anything>)])
+      body[0]: Raise(Call(ValueError, [Constant(<contains "must be a non-empty string">)]))
+
+    3+-operand BoolOp nodes are allowlisted (additional None checks).
+    """
+    test = node.test
+
+    # Must be a BoolOp(Or) with EXACTLY 2 operands.
+    if not isinstance(test, ast.BoolOp):
+        return False
+    if not isinstance(test.op, ast.Or):
+        return False
+    if len(test.values) != 2:
+        # 3+ operands → allowlisted (None-guard pattern)
+        return False
+
+    op0, op1 = test.values
+
+    # operand[0]: UnaryOp(Not, Call(isinstance, ..., Name('str')))
+    if not isinstance(op0, ast.UnaryOp):
+        return False
+    if not isinstance(op0.op, ast.Not):
+        return False
+    call0 = op0.operand
+    if not isinstance(call0, ast.Call):
+        return False
+    func0 = call0.func
+    if not (isinstance(func0, ast.Name) and func0.id == "isinstance"):
+        return False
+    # isinstance must have at least 2 args; second must be Name('str')
+    if len(call0.args) < 2:
+        return False
+    second_arg = call0.args[1]
+    if not (isinstance(second_arg, ast.Name) and second_arg.id == "str"):
+        return False
+
+    # operand[1]: UnaryOp(Not, <anything>)
+    if not isinstance(op1, ast.UnaryOp):
+        return False
+    if not isinstance(op1.op, ast.Not):
+        return False
+
+    # body[0] must be a Raise of ValueError with "must be a non-empty string"
+    if not node.body:
+        return False
+    stmt = node.body[0]
+    if not isinstance(stmt, ast.Raise):
+        return False
+    exc = stmt.exc
+    if not isinstance(exc, ast.Call):
+        return False
+    exc_func = exc.func
+    if not (isinstance(exc_func, ast.Name) and exc_func.id == "ValueError"):
+        return False
+    if not exc.args:
+        return False
+    first_arg = exc.args[0]
+    if not isinstance(first_arg, ast.Constant):
+        return False
+    if not isinstance(first_arg.value, str):
+        return False
+    if "must be a non-empty string" not in first_arg.value:
+        return False
+
+    return True
+
+
+def test_no_inline_isinstance_str_raise_valueerror_pattern_in_lib_receipts() -> None:
+    """No two-operand inline isinstance+ValueError pattern remains in lib_receipts.py (AC 12).
+
+    Walks every If node in hooks/lib_receipts.py.  Fails with the matched
+    line number(s) if any matching pattern is found.  3+-operand BoolOp
+    nodes are excluded (allowlisted None-guard patterns).
+    """
+    source = LIB_RECEIPTS.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(LIB_RECEIPTS))
+
+    matched_lines: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If) and _is_target_pattern(node):
+            matched_lines.append(node.lineno)
+
+    assert not matched_lines, (
+        f"hooks/lib_receipts.py still contains {len(matched_lines)} inline "
+        f"isinstance+ValueError pattern(s) that should be migrated to "
+        f"require_nonblank_str. Matched line(s): {matched_lines}"
+    )

--- a/tests/test_require_nonblank_str.py
+++ b/tests/test_require_nonblank_str.py
@@ -1,0 +1,69 @@
+"""Unit tests for require_nonblank_str in hooks/lib_validate.py.
+
+Covers ACs 4, 5, 6, 7, 11 of task-20260504-006.
+
+TDD contract: these tests FAIL until seg-1 adds require_nonblank_str to
+hooks/lib_validate.py.  Do not implement the helper before these tests
+are committed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+from lib_validate import require_nonblank_str  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# AC 4: non-str input raises ValueError (not TypeError)
+# ---------------------------------------------------------------------------
+
+def test_non_str_raises_valueerror() -> None:
+    """require_nonblank_str(123) raises ValueError, NOT TypeError (AC 4)."""
+    with pytest.raises(ValueError, match="x must be a non-empty string"):
+        require_nonblank_str(123, field_name="x")
+
+
+# ---------------------------------------------------------------------------
+# AC 5: empty string raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_empty_str_raises_valueerror() -> None:
+    """require_nonblank_str('') raises ValueError with expected message (AC 5)."""
+    with pytest.raises(ValueError, match="x must be a non-empty string"):
+        require_nonblank_str("", field_name="x")
+
+
+# ---------------------------------------------------------------------------
+# AC 6: whitespace-only string raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_whitespace_only_raises_valueerror() -> None:
+    """require_nonblank_str('   ') raises ValueError with expected message (AC 6)."""
+    with pytest.raises(ValueError, match="x must be a non-empty string"):
+        require_nonblank_str("   ", field_name="x")
+
+
+# ---------------------------------------------------------------------------
+# AC 7a: valid string with no surrounding whitespace returns same (stripped) value
+# ---------------------------------------------------------------------------
+
+def test_valid_str_returns_stripped() -> None:
+    """require_nonblank_str('hello') returns 'hello' unchanged (AC 7)."""
+    result = require_nonblank_str("hello", field_name="x")
+    assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# AC 7b: valid string with surrounding whitespace returns stripped value
+# ---------------------------------------------------------------------------
+
+def test_valid_str_with_padding_returns_stripped() -> None:
+    """require_nonblank_str('  hello  ') returns 'hello' stripped (AC 7)."""
+    result = require_nonblank_str("  hello  ", field_name="x")
+    assert result == "hello"


### PR DESCRIPTION
## Summary

Closes the last residual from `project_open_trust_residuals.md` item 2 (inline validation-pattern duplication). The original 7 sites flagged in 2026-04-19 were already migrated to `require_nonblank` in PR #143 (TypeError/ValueError split). This PR addresses the **16 NEW inline raise patterns** that accumulated in `hooks/lib_receipts.py` since then — all using a `ValueError`-only contract that's incompatible with `require_nonblank`'s TypeError-on-non-str split.

**hooks/lib_validate.py** — Add `require_nonblank_str(value, *, field_name) -> str` helper. Raises `ValueError` (NOT TypeError) for both non-str and blank/whitespace cases. Returns the stripped string. Preserves compatibility with `pytest.raises(ValueError)` sites.

**hooks/lib_receipts.py** — Extend `lib_validate` import to include `require_nonblank_str`. Migrate 16 inline raise patterns of the form `if not isinstance(X, str) or not X: raise ValueError("X must be a non-empty string")` to `require_nonblank_str(X, field_name="X")`. Field names match original error-message prefixes verbatim.

## Discovered during TDD

Initial scoping found 13 sites; the TDD-First AST sentinel test discovered **3 additional sites** (lines 1791, 2224, 2226) that the manual grep missed. All 16 migrated.

## Whitespace tightening

Helper uses `not value.strip()` while the inline pattern used `not X`. For sha256 hashes / stage names / model names / route modes — all caller-supplied internal values — whitespace-only input is impossible in practice. Strict improvement.

## Tests

- `tests/test_require_nonblank_str.py` — 5 unit tests (TDD-First).
- `tests/test_lib_receipts_inline_pattern_sentinel.py` — AST-walk sentinel fails on any 2-operand `BoolOp(Or)` + `isinstance(str)` + `ValueError` raise pattern. 3+ operand BoolOps allowlisted (those have additional None checks beyond the helper's contract).

## Test plan

- [x] `pytest tests/test_require_nonblank_str.py tests/test_lib_receipts_inline_pattern_sentinel.py -v` — 6 pass
- [x] `pytest tests/test_receipt_audit_done_selfverify.py tests/test_receipt_audit_spawn_log_crosscheck.py tests/test_receipts_exports.py -v` — 18 pass (no regression)
- [x] Full suite: 1770 passed, 7 skipped, 2 deselected (pre-existing claude_md_auditor flakes), 2 pre-existing hygiene flakes from PR #152/#153 (not regressions)
- [x] Audit: all 6 auditors PASS. Security haiku-L1 flagged 2 false-positive blockers; opus binding verdict downgraded all. Code-quality haiku-L1 flagged 1 docstring nitpick; opus downgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
