### PR TITLE
test: allowlist 5 ghost/tautological tests with justifications

### DIFF
--- a/tests/test_test_suite_hygiene.py
+++ b/tests/test_test_suite_hygiene.py
@@ -29,6 +29,29 @@ _GHOST_TEST_ALLOWLIST: dict[str, str] = {
         "Facade re-export contract: verifies lib.is_pid_running is callable after import. "
         "Meaningful because the facade could accidentally export a non-callable alias."
     ),
+    "test_source_filter_downstream.py::test_policy_engine_never_calls_with_include_unverified_true": (
+        "Static AST guard delegating to _assert_no_include_unverified_true helper. The helper "
+        "asserts internally; the wrapping test's job is to bind module path → guard. "
+        "Hygiene check counts asserts in the test function only and cannot follow the helper call."
+    ),
+    "test_source_filter_downstream.py::test_agent_generator_never_calls_with_include_unverified_true": (
+        "Static AST guard delegating to _assert_no_include_unverified_true helper. Same justification "
+        "as the policy_engine variant — wrapper binds module path → guard, helper holds the assert."
+    ),
+    "test_source_filter_downstream.py::test_postmortem_improve_never_calls_with_include_unverified_true": (
+        "Static AST guard delegating to _assert_no_include_unverified_true helper. Same justification "
+        "as the policy_engine variant — wrapper binds module path → guard, helper holds the assert."
+    ),
+    "test_lib_chain_perf.py::test_append_entry_function_exists": (
+        "Crash-guard precondition for the perf-001 / perf-002 sibling tests in TestPerf001And002. "
+        "Asserts _append_entry is found by _find_function; if the function is renamed or removed, "
+        "this test fails fast with a clear message rather than letting the sibling tests fail "
+        "with confusing AST-walk errors. Tautological-looking but load-bearing as a rename canary."
+    ),
+    "test_lib_chain_perf.py::test_cmd_function_exists": (
+        "Crash-guard precondition for the perf-002 sibling tests. Same justification as "
+        "test_append_entry_function_exists — rename canary for cmd_run_task_receipt_chain."
+    ),
 }
 
 _BANNED_SNIPPETS = (


### PR DESCRIPTION
## Summary

After PR #152 (lib_chain perf) and PR #153 (_source filter) landed, two `test_test_suite_hygiene.py` checks started failing on main:

1. `test_no_zero_assertion_test_functions` flagged 3 tests in `tests/test_source_filter_downstream.py` that delegate their assertion to a shared `_assert_no_include_unverified_true` helper. The hygiene check counts asserts in the test function only and cannot follow the helper call.

2. `test_no_tautological_only_assertions` flagged 2 tests in `tests/test_lib_chain_perf.py` that assert function existence (`isinstance(node, ast.FunctionDef)`). They're load-bearing rename canaries — the sibling perf-001/002 AST tests fail confusingly when `_append_entry` / `cmd_run_task_receipt_chain` is renamed; these existence checks fail-fast with a clear message instead.

Added all 5 to `_GHOST_TEST_ALLOWLIST` with justifications matching the existing entries' style.

## Test plan

- [x] `pytest tests/test_test_suite_hygiene.py -v` — 3 pass (was 2 fails + 1 pass before)
- [x] No production code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
