### PR TITLE
feat: broaden residual producer + postmortem-rule ingestion (v7.4.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.4.0] - 2026-05-05
+### "Wider Drain": Residual Queue Captures More Sources
+
+The 7.3.0 producer admitted only `claude-md-auditor` and `dead-code-auditor` non-blocking findings — narrow on purpose, but narrow enough that running the queue against itself excluded most of the actionable follow-ups it surfaced. 7.4.0 broadens the producer to three more auditors and adds a second source surface so postmortem prevention rules with concrete enforcement (test, lint, static-check, ci-gate, runtime-guard) land in the same queue rather than only `prevention-rules.json`.
+
+### Added
+- Producer now admits non-blocking findings from `security-auditor`, `performance-auditor`, and `code-quality-auditor` (in addition to `claude-md-auditor` and `dead-code-auditor`). Severity-`info` and category skip-list rules still apply.
+- New `lib_residuals.ingest_prevention_rules(root, rules)` helper that ingests postmortem prevention rules with actionable enforcement (test / lint / static-check / ci-gate / runtime-guard) into the residual queue. Advisory and review-checklist rules are deliberately excluded.
+- `postmortem_analysis.apply_analysis` now calls the new helper after writing prevention rules, so engineering-actionable rules surface as queue items alongside their write to `prevention-rules.json`.
+
+### Plugin / Distribution
+- Bump `package.json` and `.claude-plugin/plugin.json` to `7.4.0`.
+
+---
+
 ## [7.3.0] - 2026-05-04
 ### "Residual Drain": Non-Blocking Findings Become an Overnight Backlog
 

--- a/hooks/lib_residuals.py
+++ b/hooks/lib_residuals.py
@@ -41,7 +41,22 @@ from lib_core import load_json
 
 ALLOWED_AUDITORS: frozenset[str] = frozenset({
     "claude-md-auditor",
+    "code-quality-auditor",
     "dead-code-auditor",
+    "performance-auditor",
+    "security-auditor",
+})
+
+# Postmortem prevention-rule enforcement values that are actionable
+# engineering work (worth queuing). Values like "review-checklist",
+# "prompt-constraint", and "advisory" are deliberately excluded — they
+# describe judgment-based gates, not buildable items.
+ACTIONABLE_ENFORCEMENTS: frozenset[str] = frozenset({
+    "test",
+    "lint",
+    "static-check",
+    "ci-gate",
+    "runtime-guard",
 })
 
 REJECTED_CATEGORIES: frozenset[str] = frozenset({
@@ -309,6 +324,120 @@ def ingest_findings(task_dir: Path, root: Path, summary: dict) -> int:
             os.close(fd)
 
 
+def ingest_prevention_rules(root: Path, rules: list) -> int:
+    """Ingest postmortem prevention rules with actionable enforcement.
+
+    Filters to rules whose ``enforcement`` is in ``ACTIONABLE_ENFORCEMENTS``
+    (test, lint, static-check, ci-gate, runtime-guard). Rules with
+    ``review-checklist``, ``prompt-constraint``, or ``advisory`` enforcement
+    are NOT ingested — they describe judgment-based gates, not buildable
+    items.
+
+    Each accepted rule becomes a queue row with ``kind = "residual"`` and
+    ``source_auditor = "postmortem-analysis"``. Fingerprint is
+    ``sha256("postmortem-analysis:" + rule.rule + ":" + rule.rationale)`` —
+    intentionally NOT keyed on enforcement, so a rule that gets escalated
+    from advisory→ci-gate later does not produce a duplicate row.
+
+    Returns the count actually appended (after filter and dedup).
+    Concurrency-safe via the same ``fcntl.LOCK_EX`` pattern as
+    ``ingest_findings``. Never raises on a malformed rule entry — those
+    are silently skipped. May raise on irrecoverable IO; the caller in
+    ``postmortem_analysis.apply_analysis`` is expected to catch and log.
+    """
+    if not isinstance(rules, list):
+        return 0
+
+    candidates: list[dict] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        enforcement = rule.get("enforcement")
+        if not isinstance(enforcement, str) or enforcement not in ACTIONABLE_ENFORCEMENTS:
+            continue
+        rule_text = rule.get("rule")
+        rationale = rule.get("rationale")
+        if not isinstance(rule_text, str) or not rule_text:
+            continue
+        if not isinstance(rationale, str):
+            rationale = ""
+
+        title = rule_text[:120]
+        source_finding = rule.get("source_finding", "")
+        if not isinstance(source_finding, str):
+            source_finding = ""
+        category = rule.get("category", "")
+        if not isinstance(category, str):
+            category = ""
+
+        description_parts = [
+            f"Rule: {rule_text}",
+            f"Rationale: {rationale}" if rationale else "",
+            f"Enforcement: {enforcement}",
+            f"Category: {category}" if category else "",
+            f"Source finding: {source_finding}" if source_finding else "",
+        ]
+        description = "\n".join(p for p in description_parts if p)
+
+        fp = compute_fingerprint("postmortem-analysis", rule_text, rationale)
+
+        candidates.append({
+            "id": str(uuid.uuid4()),
+            "kind": "residual",
+            "fingerprint": fp,
+            "created_at": _now_iso_z(),
+            "source_task_id": "",
+            "source_auditor": "postmortem-analysis",
+            "title": title,
+            "description": description,
+            "location": "",
+            "status": "pending",
+            "attempts": 0,
+            "last_attempt_at": None,
+        })
+
+    if not candidates:
+        return 0
+
+    qp = queue_path(root)
+    qp.parent.mkdir(parents=True, exist_ok=True)
+    fd: int = -1
+    try:
+        fd = os.open(str(qp), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            current = _read_locked_queue(fd)
+            existing = current.get("findings", [])
+
+            blocking_fps: set[str] = set()
+            for row in existing:
+                if not isinstance(row, dict):
+                    continue
+                if row.get("status") in DEDUP_BLOCKING_STATUSES:
+                    f = row.get("fingerprint")
+                    if isinstance(f, str):
+                        blocking_fps.add(f)
+
+            appended = 0
+            for cand in candidates:
+                fp = cand["fingerprint"]
+                if fp in blocking_fps:
+                    continue
+                existing.append(cand)
+                blocking_fps.add(fp)
+                appended += 1
+
+            if appended > 0:
+                _atomic_write_under_lock(qp, {"findings": existing})
+
+            return appended
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -450,6 +579,7 @@ __all__ = [
     "queue_path",
     "load_queue",
     "ingest_findings",
+    "ingest_prevention_rules",
     "select_next_pending",
     "update_row_status",
     "extract_residual_id",

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -784,6 +784,7 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
     # category — the same chain-of-custody PR #131 established for
     # the drop path but cut off before the promote path.
     promoted_records: list[dict] = []
+    just_merged_rules: list[dict] = []
     lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
     with os.fdopen(lock_fd, "w") as lock_fh:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
@@ -822,6 +823,7 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
                 current_rules.append(merged)
                 existing_rule_texts.add(text.lower())
                 added += 1
+                just_merged_rules.append(merged)
                 promoted_records.append({
                     "category": merged["category"],
                     "executor": merged["executor"],
@@ -867,6 +869,24 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
     except (FileNotFoundError, OSError, ValueError) as exc:
         log_event(root, "postmortem_analysis_receipt_failed", task=task_id, error=str(exc))
 
+    # v7.4.0: ingest rules with actionable enforcement (test/lint/static-check/
+    # ci-gate/runtime-guard) into the residual queue so they surface as
+    # buildable follow-ups, not just policy entries. Defensive — a queue
+    # write failure must NOT abort the postmortem.
+    queue_ingested = 0
+    if just_merged_rules:
+        try:
+            from lib_residuals import ingest_prevention_rules
+            queue_ingested = ingest_prevention_rules(root, just_merged_rules)
+        except Exception as _exc:  # noqa: BLE001 — defensive
+            log_event(
+                root,
+                "postmortem_residual_ingest_failed",
+                task=task_id,
+                task_id=task_id,
+                error=str(_exc),
+            )
+
     return {
         "task_id": task_id,
         "rules_added": added,
@@ -874,6 +894,7 @@ def apply_analysis(task_dir: Path, analysis: dict) -> dict:
         "input_rule_count": _input_rule_count,
         "rejected_count": rejected_count,
         "normalization_drops": len(_normalization_drops),
+        "residual_queue_ingested": queue_ingested,
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/tests/test_lib_residuals.py
+++ b/tests/test_lib_residuals.py
@@ -52,9 +52,11 @@ ALLOWED_ROW_KEYS = frozenset({
 
 
 def _make_root(tmp_path: Path) -> Path:
-    """Create a minimal project root with a .dynos directory."""
+    """Create a minimal project root with a .dynos directory.
+    Idempotent so a single test can call this multiple times against
+    distinct sub-tmp_paths without colliding."""
     root = tmp_path / "project"
-    (root / ".dynos").mkdir(parents=True)
+    (root / ".dynos").mkdir(parents=True, exist_ok=True)
     return root
 
 
@@ -317,19 +319,21 @@ def test_filter_accepts_correct_findings(tmp_path: Path):
     dead_code_findings = [
         _make_finding(id="F-accept-2", severity="error", category="unused-import", blocking=False),
     ]
-    # Findings for disallowed auditor: all rejected
-    security_findings = [
+    # Findings for disallowed auditor: all rejected. v7.4.0 broadened the
+    # allowlist (now includes security/performance/code-quality), so use a
+    # name NOT in the v7.4.0 set.
+    disallowed_findings = [
         _make_finding(id="F-disallowed", severity="warning", category="xss", blocking=False),
     ]
 
     claude_path = _write_auditor_report(task_dir, "claude-md-auditor", claude_findings)
     dead_path = _write_auditor_report(task_dir, "dead-code-auditor", dead_code_findings)
-    sec_path = _write_auditor_report(task_dir, "security-auditor", security_findings)
+    disallowed_path = _write_auditor_report(task_dir, "ml-executor-auditor", disallowed_findings)
 
     summary = _make_summary(task_dir, [
         {"auditor_name": "claude-md-auditor", "report_path": str(claude_path)},
         {"auditor_name": "dead-code-auditor", "report_path": str(dead_path)},
-        {"auditor_name": "security-auditor", "report_path": str(sec_path)},
+        {"auditor_name": "ml-executor-auditor", "report_path": str(disallowed_path)},
     ])
 
     count = ingest_findings(task_dir, root, summary)
@@ -399,15 +403,17 @@ def test_filter_rejects_bad_category(tmp_path: Path):
 
 
 def test_filter_rejects_disallowed_auditor(tmp_path: Path):
-    """auditor_name='security-auditor' is not appended."""
+    """An auditor_name that is NOT in the v7.4.0 allowlist is not appended."""
     root = _make_root(tmp_path)
     task_dir = tmp_path / "task-dir"
     task_dir.mkdir()
 
     finding = _make_finding(severity="warning", category="xss", blocking=False)
-    report_path = _write_auditor_report(task_dir, "security-auditor", [finding])
+    # v7.4.0 allowlist: claude-md, dead-code, security, performance, code-quality.
+    # Use a name not in that set.
+    report_path = _write_auditor_report(task_dir, "ml-executor-auditor", [finding])
     summary = _make_summary(task_dir, [
-        {"auditor_name": "security-auditor", "report_path": str(report_path)}
+        {"auditor_name": "ml-executor-auditor", "report_path": str(report_path)}
     ])
 
     count = ingest_findings(task_dir, root, summary)
@@ -761,3 +767,151 @@ def test_ingest_findings_missing_task_id_uses_empty_string(tmp_path: Path):
 
     q = load_queue(queue_path(root))
     assert q["findings"][0]["source_task_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# v7.4.0 — broadened auditor allowlist
+# ---------------------------------------------------------------------------
+
+
+def _ingest_one(tmp_path: Path, auditor_name: str, severity: str = "warning",
+                category: str = "perf", blocking: bool = False) -> int:
+    root = _make_root(tmp_path)
+    task_dir = tmp_path / f"task-{auditor_name}"
+    task_dir.mkdir()
+    finding = _make_finding(
+        severity=severity, category=category, blocking=blocking, id=f"F-{auditor_name}",
+    )
+    report_path = _write_auditor_report(task_dir, auditor_name, [finding])
+    summary = _make_summary(
+        task_dir,
+        [{"auditor_name": auditor_name, "report_path": str(report_path)}],
+    )
+    return ingest_findings(task_dir, root, summary)
+
+
+def test_filter_accepts_security_auditor(tmp_path: Path):
+    """v7.4.0: non-blocking security finding is admitted."""
+    assert _ingest_one(tmp_path, "security-auditor",
+                       severity="warning", category="security") == 1
+
+
+def test_filter_accepts_performance_auditor(tmp_path: Path):
+    """v7.4.0: non-blocking performance finding is admitted."""
+    assert _ingest_one(tmp_path, "performance-auditor",
+                       severity="minor", category="performance") == 1
+
+
+def test_filter_accepts_code_quality_auditor(tmp_path: Path):
+    """v7.4.0: non-blocking code-quality finding is admitted."""
+    assert _ingest_one(tmp_path, "code-quality-auditor",
+                       severity="warning", category="quality") == 1
+
+
+def test_filter_still_rejects_severity_info_for_new_auditors(tmp_path: Path):
+    """v7.4.0: severity=info is still rejected even for newly-allowed auditors."""
+    assert _ingest_one(tmp_path, "security-auditor",
+                       severity="info", category="security") == 0
+    assert _ingest_one(tmp_path, "performance-auditor",
+                       severity="info", category="performance") == 0
+    assert _ingest_one(tmp_path, "code-quality-auditor",
+                       severity="info", category="quality") == 0
+
+
+# ---------------------------------------------------------------------------
+# v7.4.0 — ingest_prevention_rules
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(
+    *,
+    rule: str = "Reject os.open(... 0o644) in hooks/",
+    rationale: str = "Blocks the world-readable queue literal",
+    enforcement: str = "lint",
+    category: str = "sec",
+    source_finding: str = "SEC-002",
+) -> dict:
+    return {
+        "rule": rule,
+        "rationale": rationale,
+        "enforcement": enforcement,
+        "category": category,
+        "source_finding": source_finding,
+        "executor": "backend-executor",
+        "template": "pattern_must_not_appear",
+        "params": {"regex": "0o644", "scope": "hooks/**/*.py"},
+    }
+
+
+def test_ingest_prevention_rules_filters_by_enforcement(tmp_path: Path):
+    """v7.4.0: rules with actionable enforcement land in queue; advisory rules don't."""
+    root = _make_root(tmp_path)
+    rules = [
+        _make_rule(rule="Test rule 1", enforcement="lint"),
+        _make_rule(rule="Test rule 2", enforcement="static-check"),
+        _make_rule(rule="Test rule 3", enforcement="ci-gate"),
+        _make_rule(rule="Test rule 4", enforcement="test"),
+        _make_rule(rule="Test rule 5", enforcement="runtime-guard"),
+        _make_rule(rule="Skipped 1", enforcement="advisory"),
+        _make_rule(rule="Skipped 2", enforcement="review-checklist"),
+        _make_rule(rule="Skipped 3", enforcement="prompt-constraint"),
+    ]
+    count = lib_residuals.ingest_prevention_rules(root, rules)
+    assert count == 5
+
+    q = load_queue(queue_path(root))
+    titles = {r["title"] for r in q["findings"]}
+    assert "Test rule 1" in titles
+    assert "Test rule 5" in titles
+    assert "Skipped 1" not in titles
+    assert "Skipped 2" not in titles
+    assert "Skipped 3" not in titles
+
+
+def test_ingest_prevention_rules_dedup(tmp_path: Path):
+    """v7.4.0: calling twice with the same rule produces one row."""
+    root = _make_root(tmp_path)
+    rules = [_make_rule(rule="Same rule", rationale="Same rationale")]
+    assert lib_residuals.ingest_prevention_rules(root, rules) == 1
+    assert lib_residuals.ingest_prevention_rules(root, rules) == 0
+    q = load_queue(queue_path(root))
+    assert len(q["findings"]) == 1
+
+
+def test_ingest_prevention_rules_row_shape(tmp_path: Path):
+    """v7.4.0: appended rows have correct kind, source_auditor, and AC-2 fields."""
+    root = _make_root(tmp_path)
+    rules = [_make_rule(rule="Shape test", rationale="Shape rationale",
+                        enforcement="lint", category="sec",
+                        source_finding="SEC-002")]
+    assert lib_residuals.ingest_prevention_rules(root, rules) == 1
+    q = load_queue(queue_path(root))
+    row = q["findings"][0]
+    assert set(row.keys()) == ALLOWED_ROW_KEYS
+    assert row["kind"] == "residual"
+    assert row["source_auditor"] == "postmortem-analysis"
+    assert row["title"] == "Shape test"
+    assert "Shape rationale" in row["description"]
+    assert "lint" in row["description"]
+    assert "SEC-002" in row["description"]
+    assert row["status"] == "pending"
+    assert row["attempts"] == 0
+    assert row["last_attempt_at"] is None
+    assert row["source_task_id"] == ""
+    assert row["location"] == ""
+    # Fingerprint is sha256("postmortem-analysis:" + rule + ":" + rationale)
+    expected_fp = compute_fingerprint("postmortem-analysis", "Shape test", "Shape rationale")
+    assert row["fingerprint"] == expected_fp
+
+
+def test_ingest_prevention_rules_skips_malformed(tmp_path: Path):
+    """v7.4.0: malformed rule entries are silently skipped, not raised."""
+    root = _make_root(tmp_path)
+    rules = [
+        "not a dict",
+        {},  # no rule field
+        {"rule": "", "enforcement": "lint"},  # empty rule
+        {"rule": "missing enforcement"},  # no enforcement
+        _make_rule(rule="Valid rule", enforcement="lint"),
+    ]
+    assert lib_residuals.ingest_prevention_rules(root, rules) == 1


### PR DESCRIPTION
## Summary

Closes two design gaps in v7.3.0's residual queue producer that surfaced when the queue ran against the task that built it.

## What changed

### 1. Broadened producer auditor allowlist

`hooks/lib_residuals.py:ALLOWED_AUDITORS` extended from 2 → 5 auditors:

- claude-md-auditor (existing)
- dead-code-auditor (existing)
- security-auditor (new)
- performance-auditor (new)
- code-quality-auditor (new)

Severity-`info` and the category skip-list (`tool-error`, `no-rules-found`, `no-files-changed`) still apply, so info-level chatter is still rejected.

### 2. New postmortem-rule ingestion surface

New `lib_residuals.ingest_prevention_rules(root, rules)` helper. Filters to rules with `enforcement` in `{test, lint, static-check, ci-gate, runtime-guard}`. Rules with `advisory`, `review-checklist`, or `prompt-constraint` enforcement are deliberately excluded (those are judgment-based, not buildable).

Each ingested rule becomes a queue row with:
- `kind: "residual"` (matches v7.3.0 discriminator)
- `source_auditor: "postmortem-analysis"`
- `fingerprint = sha256("postmortem-analysis:" + rule + ":" + rationale)` — intentionally not keyed on enforcement, so rules escalated from advisory → ci-gate later don't duplicate

### 3. Wired into postmortem_analysis.apply_analysis

`memory/postmortem_analysis.py:apply_analysis` calls the new helper after writing prevention rules, in a try/except so a queue write failure cannot abort the postmortem. Local import at the call site avoids any circular-dep risk. Return dict gains a `residual_queue_ingested` counter.

## Tests

- `tests/test_lib_residuals.py`: 8 new tests covering the broadened filter (3 newly-allowed auditors + info-rejection check) and `ingest_prevention_rules` (filter by enforcement, dedup, row shape, malformed-input safety).
- All 54 tests pass (46 prior from v7.3.0 + 8 new).
- `_make_root` test helper made idempotent so tests can call it multiple times against distinct sub-paths.

## Out of scope

- Building the linters that the prevention rules describe — separate task.
- UI/dashboard differentiation by `kind` — still post-7.3.0 follow-up.
- Token-budget enforcement — still deferred from 7.3.0.

## Test plan
- [x] `python3 -m pytest tests/test_lib_residuals.py tests/test_residual_round_trip.py -q` → 54/54 pass
- [ ] Reviewer: confirm CHANGELOG voice matches the existing 7.3.0 / 7.2.0 entries
- [ ] Reviewer: spot-check the local import of `lib_residuals` in `postmortem_analysis.apply_analysis` (no circular dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)