### PR TITLE
feat: PRO-001 strengthening — capability-key forge resistance

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -41,7 +41,7 @@ from lib_receipts import (
     receipt_executor_routing,
 )
 from lib_validate import apply_fast_track, check_segment_ownership, require_nonblank, validate_task_artifacts
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 # task-20260504-007: residuals queue producer + run-next consumer.
 # Imported as a module (not `from lib_residuals import ...`) so tests
@@ -251,7 +251,7 @@ def _write_ctl_json(task_dir: Path, path: Path, payload: dict) -> None:
             operation="modify" if path.exists() else "create",
             source=_WRITE_ROLE,
         ),
-        capability_key=get_capability_key(_WRITE_ROLE),
+        capability_key=_get_capability_key(_WRITE_ROLE),
     )
     write_json(path, payload)
 
@@ -898,7 +898,7 @@ def cmd_amend_artifact(args: argparse.Namespace) -> int:
                 operation="create",
                 source="amend-artifact",
             ),
-            capability_key=get_capability_key("receipt-writer"),
+            capability_key=_get_capability_key("receipt-writer"),
         )
     except Exception as exc:
         print(f"amend-artifact: write denied for amendment receipt: {exc}", file=sys.stderr)
@@ -935,7 +935,7 @@ def cmd_amend_artifact(args: argparse.Namespace) -> int:
                     operation="modify",
                     source="amend-artifact",
                 ),
-                capability_key=get_capability_key("receipt-writer"),
+                capability_key=_get_capability_key("receipt-writer"),
             )
         except Exception as exc:
             print(f"amend-artifact: write denied for canonical receipt update: {exc}", file=sys.stderr)

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +177,7 @@ def write_ctl_json(task_dir: Path, path: Path, data: Any) -> None:
             operation="modify" if path.exists() else "create",
             source="ctl",
         ),
-        capability_key=get_capability_key("ctl"),
+        capability_key=_get_capability_key("ctl"),
     )
     write_json(path, data)
 

--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from lib_core import _persistent_project_dir, now_iso
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 
 # Event names whose sole purpose is operator visibility / forensic trace.
@@ -422,7 +422,7 @@ def verify_signed_events(
                             operation="modify",
                             source=_WRITE_ROLE,
                         ),
-                        capability_key=get_capability_key(_WRITE_ROLE),
+                        capability_key=_get_capability_key(_WRITE_ROLE),
                         emit_event=False,
                     )
                 except Exception as exc:
@@ -526,11 +526,11 @@ def verify_signed_events(
     return verified
 
 
-def _append_jsonl(path: Path, line: str, *, attempt: WriteAttempt) -> None:
+def _append_jsonl(path: Path, line: str, *, attempt: WriteAttempt, capability_key: object) -> None:
     """Thread-safe append a single line to a JSONL file."""
     require_write_allowed(
         attempt,
-        capability_key=get_capability_key(attempt.role),
+        capability_key=capability_key,
         emit_event=False,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -587,6 +587,7 @@ def log_event(root: Path, event_type: str, *, task: str | None = None, **payload
                         operation="modify" if (task_dir / "events.jsonl").exists() else "create",
                         source=_WRITE_ROLE,
                     ),
+                    capability_key=_get_capability_key(_WRITE_ROLE),
                 )
                 return
 
@@ -602,6 +603,7 @@ def log_event(root: Path, event_type: str, *, task: str | None = None, **payload
                 operation="modify" if global_path.exists() else "create",
                 source="system",
             ),
+            capability_key=_get_capability_key("system"),
         )
     except Exception as exc:
         print(f"[dynos-log] WARNING: log_event failed: {exc}", file=sys.stderr)

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -18,7 +18,7 @@ from typing import Any
 from lib_core import now_iso, append_execution_log, _persistent_project_dir
 from lib_log import log_event, verify_signed_events
 from lib_validate import require_nonblank, require_nonblank_str
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 
 # Receipt contract version. Receipts written by this module embed
@@ -362,7 +362,7 @@ def write_receipt(task_dir: Path, step_name: str, **payload: Any) -> Path:
             operation="modify" if receipt_path.exists() else "create",
             source=_WRITE_ROLE,
         ),
-        capability_key=get_capability_key(_WRITE_ROLE),
+        capability_key=_get_capability_key(_WRITE_ROLE),
     )
     _atomic_write_text(receipt_path, json.dumps(receipt, indent=2, default=str))
 

--- a/hooks/lib_tokens.py
+++ b/hooks/lib_tokens.py
@@ -79,7 +79,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from lib_core import load_json, write_json
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 
 EMPTY_USAGE: dict = {
@@ -127,7 +127,7 @@ def _write_usage(task_dir: Path, data: dict) -> None:
             operation="modify" if usage_path.exists() else "create",
             source="system",
         ),
-        capability_key=get_capability_key("system"),
+        capability_key=_get_capability_key("system"),
     )
     write_json(usage_path, data)
 

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -43,7 +43,7 @@ from lib_receipts import (
     INJECTED_PROMPTS_DIR,
 )
 from lib_registry import ensure_learned_registry
-from write_policy import WriteAttempt, get_capability_key, require_write_allowed
+from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
 
 
 # ---------------------------------------------------------------------------
@@ -1483,7 +1483,19 @@ def _atomic_write_bytes(path: Path, data: bytes, *, attempt: WriteAttempt | None
     if attempt is not None:
         require_write_allowed(
             attempt,
-            capability_key=get_capability_key(attempt.role),
+            capability_key=_get_capability_key("receipt-writer"),
+        )
+    else:
+        _system_attempt = WriteAttempt(
+            role="system",
+            task_dir=None,
+            path=path,
+            operation="modify",
+            source="system",
+        )
+        require_write_allowed(
+            _system_attempt,
+            capability_key=_get_capability_key("system"),
         )
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -38,15 +38,21 @@ _PRIVILEGED_ROLE_MODULE_MAP: dict[str, frozenset[str]] = {
 # Each privileged role gets a distinct object() identity that callers must
 # import and pass explicitly. Forge-resistance equals Python object identity:
 # without importing this module's private symbol, no caller can construct a
-# matching token. The role-to-module mapping in _PRIVILEGED_ROLE_MODULE_MAP
-# remains the policy source of truth for write permissions; the capability
-# key only proves caller identity.
+# matching token. The capability key proves caller identity at runtime.
+#
+# _PRIVILEGED_ROLE_MODULE_MAP is NOT consulted at runtime by this module —
+# it is a static allowlist enforced at lint/test time by
+# tests/test_write_policy_module_allowlist.py, which scans imports of the
+# capability-key helper across the codebase and fails CI if a module outside
+# the allowlist imports a privileged role's key. Runtime enforcement is the
+# capability-key identity check in require_write_allowed; the module map is
+# the static counterpart that catches drift before code lands.
 _CAPABILITY_KEYS: dict[str, object] = {
     role: object() for role in _PRIVILEGED_ROLE_MODULE_MAP
 }
 
 
-def get_capability_key(role: str) -> object:
+def _get_capability_key(role: str) -> object:
     """Return the capability-key sentinel for a privileged role.
 
     Raises KeyError if role is not in _CAPABILITY_KEYS. Privileged callers

--- a/tests/test_role_frame_check.py
+++ b/tests/test_role_frame_check.py
@@ -10,6 +10,9 @@ AC 9: hooks/write_policy.py defines _PRIVILEGED_ROLE_MODULE_MAP: dict[str, froze
       require_write_allowed identity-checks a per-role capability_key sentinel;
       a call without the matching key raises ValueError containing
       'capability_key mismatch'. (Replaces former sys._getframe stack-walking.)
+
+task-20260504-008 hardening: post-rename, the import is `_get_capability_key`
+(private-by-convention). See AC 5 in spec.md.
 """
 from __future__ import annotations
 

--- a/tests/test_role_frame_check.py
+++ b/tests/test_role_frame_check.py
@@ -36,7 +36,7 @@ from write_policy import (
     WriteAttempt,
     _CAPABILITY_KEYS,
     _PRIVILEGED_ROLE_MODULE_MAP,
-    get_capability_key,
+    _get_capability_key,
     require_write_allowed,
 )
 

--- a/tests/test_write_policy_capability_key.py
+++ b/tests/test_write_policy_capability_key.py
@@ -50,7 +50,7 @@ def test_require_write_allowed_missing_capability_key_raises_typeerror(tmp_path:
     After segment-A, capability_key is a required keyword-only argument with no
     default. Python must raise TypeError for missing required kwarg.
     """
-    from write_policy import require_write_allowed, get_capability_key  # noqa: F401 — import both per plan
+    from write_policy import require_write_allowed, _get_capability_key  # noqa: F401 — import both per plan
 
     task_dir = tmp_path / ".dynos" / "task-test-ctl"
     task_dir.mkdir(parents=True)
@@ -66,7 +66,7 @@ def test_require_write_allowed_wrong_capability_key_raises_valueerror(tmp_path: 
     attempt.role is 'receipt-writer' but the key supplied is for 'ctl'.
     The identity check must catch this and raise ValueError.
     """
-    from write_policy import require_write_allowed, get_capability_key
+    from write_policy import require_write_allowed, _get_capability_key
 
     task_dir = tmp_path / ".dynos" / "task-test-rw"
     task_dir.mkdir(parents=True)
@@ -74,7 +74,7 @@ def test_require_write_allowed_wrong_capability_key_raises_valueerror(tmp_path: 
     attempt = _make_receipt_writer_attempt(task_dir)
 
     with pytest.raises(ValueError) as exc_info:
-        require_write_allowed(attempt, capability_key=get_capability_key("ctl"))
+        require_write_allowed(attempt, capability_key=_get_capability_key("ctl"))
 
     assert "capability_key mismatch" in str(exc_info.value)
 
@@ -86,7 +86,7 @@ def test_require_write_allowed_correct_capability_key_passes(tmp_path: Path):
     and the path is manifest.json which decide_write permits for ctl.
     No exception should be raised.
     """
-    from write_policy import require_write_allowed, get_capability_key
+    from write_policy import require_write_allowed, _get_capability_key
 
     task_dir = tmp_path / ".dynos" / "task-test-pass"
     task_dir.mkdir(parents=True)
@@ -95,7 +95,101 @@ def test_require_write_allowed_correct_capability_key_passes(tmp_path: Path):
     # Must not raise; capture raised exception explicitly to produce a useful failure message
     raised = None
     try:
-        require_write_allowed(attempt, capability_key=get_capability_key("ctl"), emit_event=False)
+        require_write_allowed(attempt, capability_key=_get_capability_key("ctl"), emit_event=False)
     except Exception as exc:
         raised = exc
     assert raised is None, f"Expected no exception but got {type(raised).__name__}: {raised}"
+
+
+# AC-13
+def test_forge_via_tautological_path(tmp_path: Path) -> None:
+    """AC 13: Adversarial forge via tautological path — _append_jsonl rejects mismatched key.
+
+    An attacker controls WriteAttempt(role="ctl", ...) and routes it through
+    _append_jsonl. The _append_jsonl caller (simulated here as an eventbus caller)
+    supplies _get_capability_key("eventbus") — its own role's key, not the attacker's
+    claimed role's key.
+
+    After segment-D, _append_jsonl requires a caller-supplied capability_key and
+    forwards it directly to require_write_allowed, which checks identity against
+    _CAPABILITY_KEYS.get(attempt.role). Since the eventbus key does not equal the
+    ctl key, require_write_allowed raises ValueError containing 'capability_key mismatch'.
+
+    This test will be RED on main (segment-D not yet applied) because:
+      (a) _append_jsonl still derives the key from attempt.role (tautological),
+          making the mismatch check impossible, AND
+      (b) _get_capability_key does not yet exist (segment-B not yet applied).
+    """
+    from lib_log import _append_jsonl  # noqa: PLC0415
+    from write_policy import WriteAttempt, _get_capability_key  # noqa: PLC0415
+
+    # Attacker constructs a WriteAttempt claiming the high-privilege 'ctl' role
+    task_dir = tmp_path / ".dynos" / "task-x"
+    task_dir.mkdir(parents=True)
+    manifest_path = task_dir / "manifest.json"
+
+    attacker_attempt = WriteAttempt(
+        role="ctl",
+        task_dir=task_dir,
+        path=manifest_path,
+        operation="modify",
+        source="ctl",
+    )
+
+    # Simulate an eventbus caller passing its own role's key — NOT the attacker's key.
+    # After segment-D this must raise ValueError with "capability_key mismatch" because
+    # the eventbus key is not the ctl key.
+    with pytest.raises(ValueError, match="capability_key mismatch"):
+        _append_jsonl(
+            manifest_path,
+            '{"event": "forge_attempt"}\n',
+            attempt=attacker_attempt,
+            capability_key=_get_capability_key("eventbus"),
+        )
+
+
+# AC-14
+def test_attempt_none_safety_role(tmp_path: Path) -> None:
+    """AC 14: _atomic_write_bytes(path, data, attempt=None) closes the dormant bypass.
+
+    After segment-E, when attempt is None, _atomic_write_bytes constructs a
+    WriteAttempt(role='system', task_dir=None, ...) and calls require_write_allowed
+    with _get_capability_key('system'). Because task_dir=None, _emit_policy_event
+    returns early without any file I/O, so no stub is needed.
+
+    Assertions:
+      1. No exception is raised.
+      2. The output file exists after the call.
+      3. The output file contains exactly the bytes that were written.
+      4. _get_capability_key('system') is importable from write_policy — confirming
+         the private-name rename has landed (segment-B).
+
+    This test will be RED on main (segment-E not yet applied) because:
+      (a) _get_capability_key does not yet exist in write_policy (segment-B not yet applied),
+          so the import below raises ImportError; AND
+      (b) after segment-B lands but before segment-E, _atomic_write_bytes still skips
+          the policy check entirely when attempt=None — the bypass is still open.
+          The file write succeeds via bypass; the test passes for the wrong reason
+          until segment-E lands and closes the bypass with the system-role policy check.
+    """
+    import router  # noqa: PLC0415
+    from write_policy import _get_capability_key  # noqa: PLC0415 — RED on main until segment-B
+
+    out_path = tmp_path / "out.bin"
+    data = b"data"
+
+    # Verify _get_capability_key("system") is callable and returns an object
+    # (the system sentinel). This is the key _atomic_write_bytes must use internally
+    # when constructing the safety-role attempt (segment-E post-condition).
+    system_key = _get_capability_key("system")
+    assert system_key is not None, "_get_capability_key('system') must return a non-None sentinel"
+
+    # Must not raise — the system safety role permits non-task writes (task_dir=None)
+    router._atomic_write_bytes(out_path, data, attempt=None)
+
+    assert out_path.exists(), (
+        "_atomic_write_bytes(attempt=None) did not create the output file"
+    )
+    assert out_path.read_bytes() == data, (
+        f"Output file content mismatch: expected {data!r}, got {out_path.read_bytes()!r}"
+    )

--- a/tests/test_write_policy_capability_key.py
+++ b/tests/test_write_policy_capability_key.py
@@ -1,10 +1,9 @@
-"""TDD-first tests for PRO-001 CapabilityKey enforcement.
+"""TDD-first tests for PRO-001 CapabilityKey enforcement and forge-resistance hardening.
 
-ACs covered: 9, 10, 11.
-
-These tests will FAIL with ImportError or TypeError until segment-A-write-policy
-adds _CAPABILITY_KEYS, get_capability_key, and the new require_write_allowed
-signature with required capability_key kwarg. That is the expected TDD-first state.
+Original ACs: 9, 10, 11 (capability_key kwarg machinery).
+task-20260504-008 hardening ACs: 4, 5, 13, 14 (rename to private name + adversarial tests).
+Segment owners: TDD-First gate authored adversarial tests; segment-F-update-tests
+finalized the rename + adversarial-test suite for the post-rename code paths.
 """
 from __future__ import annotations
 

--- a/tests/test_write_policy_module_allowlist.py
+++ b/tests/test_write_policy_module_allowlist.py
@@ -1,0 +1,208 @@
+"""Static-allowlist and invariant tests for the capability-key forge boundary.
+
+ACs covered: 2 (public name gone), 11 (module allowlist grep enforcement).
+PRO-001 hard constraint: sc-001 (no sys._getframe reintroduction), sc-002 (public name removed).
+
+TDD ordering: these tests are INITIALLY RED on main because:
+  - test_module_allowlist_grep: _get_capability_key does not yet exist in write_policy.py
+    (the function is still the public get_capability_key), so importing
+    _PRIVILEGED_ROLE_MODULE_MAP will succeed but the grep will find zero import lines
+    for the post-rename name, meaning the test will pass trivially — UNTIL the
+    rename lands (segment-B) and then the test properly validates all six importing files.
+    NOTE: on the current main the test passes trivially because no hooks file yet
+    imports _get_capability_key (they all import get_capability_key). The meaningful
+    RED state for this test is triggered by test_public_get_capability_key_is_gone.
+  - test_public_get_capability_key_is_gone: FAILS RED because get_capability_key
+    still exists in write_policy (hasattr returns True).
+  - test_no_sys_getframe_reintroduction: passes GREEN on main (no violations).
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = ROOT / "hooks"
+
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# AC 11 — Module allowlist grep enforcement
+# ---------------------------------------------------------------------------
+
+
+# AC-11
+def test_module_allowlist_grep() -> None:
+    """AC 11: Every hooks/*.py module that imports _get_capability_key must appear
+    in at least one value-set of _PRIVILEGED_ROLE_MODULE_MAP.
+
+    Greps hooks/*.py (excluding write_policy.py) for:
+      - lines matching: from write_policy import ... _get_capability_key
+      - lines matching: write_policy._get_capability_key
+
+    For each file found, asserts its stem is present in at least one frozenset
+    value of _PRIVILEGED_ROLE_MODULE_MAP. Fails explicitly (never silently skips)
+    when any importing module's stem is missing from all value-sets.
+    """
+    from write_policy import _PRIVILEGED_ROLE_MODULE_MAP  # noqa: PLC0415
+
+    # Build set of all allowlisted stems (union of all frozenset values)
+    allowlisted_stems: set[str] = set()
+    for value_set in _PRIVILEGED_ROLE_MODULE_MAP.values():
+        allowlisted_stems.update(value_set)
+
+    # Patterns that detect an import of _get_capability_key from write_policy
+    import_pattern = re.compile(r"from write_policy import[^#\n]*_get_capability_key")
+    dotaccess_pattern = re.compile(r"write_policy\._get_capability_key")
+
+    importing_files: list[Path] = []
+    for hooks_file in sorted(HOOKS_DIR.glob("*.py")):
+        if hooks_file.name == "write_policy.py":
+            continue
+        source = hooks_file.read_text(encoding="utf-8")
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            # Skip comment-only lines
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if import_pattern.search(line) or dotaccess_pattern.search(line):
+                importing_files.append(hooks_file)
+                break  # one match per file is sufficient
+
+    violations: list[str] = []
+    for hooks_file in importing_files:
+        stem = hooks_file.stem
+        if stem not in allowlisted_stems:
+            violations.append(
+                f"Module '{stem}' (file: {hooks_file.relative_to(ROOT)}) imports "
+                f"_get_capability_key but its stem is absent from all value-sets of "
+                f"_PRIVILEGED_ROLE_MODULE_MAP. Add '{stem}' to the appropriate "
+                f"frozenset in write_policy.py or remove the import."
+            )
+
+    assert not violations, "\n".join(violations)
+
+
+# ---------------------------------------------------------------------------
+# PRO-001 hard constraint sc-001 — no sys._getframe reintroduction
+# ---------------------------------------------------------------------------
+
+
+# AC covers PRO-001 prohibition (audit finding sc-001)
+def test_no_sys_getframe_reintroduction() -> None:
+    """Greps the seven in-scope hooks files for sys._getframe or caller_module.
+
+    Excludes comment-only lines (first non-whitespace character is '#').
+    Asserts zero non-comment matches. The single existing comment-only mention
+    in hooks/write_policy.py line 37 is tolerated by this exclusion.
+
+    In-scope files:
+      hooks/write_policy.py, hooks/lib_log.py, hooks/router.py,
+      hooks/lib_tokens.py, hooks/lib_receipts.py, hooks/ctl.py, hooks/lib_core.py
+    """
+    in_scope_files = [
+        HOOKS_DIR / "write_policy.py",
+        HOOKS_DIR / "lib_log.py",
+        HOOKS_DIR / "router.py",
+        HOOKS_DIR / "lib_tokens.py",
+        HOOKS_DIR / "lib_receipts.py",
+        HOOKS_DIR / "ctl.py",
+        HOOKS_DIR / "lib_core.py",
+    ]
+
+    forbidden_patterns = [
+        re.compile(r"sys\._getframe"),
+        re.compile(r"caller_module"),
+    ]
+
+    violations: list[str] = []
+    for hooks_file in in_scope_files:
+        if not hooks_file.exists():
+            # File missing is itself a structural problem; report it
+            violations.append(f"In-scope file not found: {hooks_file}")
+            continue
+        source = hooks_file.read_text(encoding="utf-8")
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            stripped = line.lstrip()
+            # Skip comment-only lines (first non-whitespace char is '#')
+            if stripped.startswith("#"):
+                continue
+            for pattern in forbidden_patterns:
+                if pattern.search(line):
+                    violations.append(
+                        f"{hooks_file.relative_to(ROOT)}:{lineno}: "
+                        f"forbidden pattern {pattern.pattern!r} found in non-comment line: "
+                        f"{line.rstrip()!r}"
+                    )
+
+    assert not violations, (
+        "PRO-001 prohibition violated — sys._getframe or caller_module found in "
+        f"non-comment code:\n" + "\n".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — Public get_capability_key name is gone
+# ---------------------------------------------------------------------------
+
+
+# AC-2
+def test_public_get_capability_key_is_gone() -> None:
+    """AC 2: The public name 'get_capability_key' must not exist in write_policy.
+
+    Two assertions:
+    1. hasattr(write_policy_module, 'get_capability_key') is False — the attribute
+       must not be present at all on the imported module.
+    2. A subprocess attempting 'from write_policy import get_capability_key' must
+       exit with a non-zero return code AND 'ImportError' must appear in its
+       combined stdout+stderr output.
+
+    The private name '_get_capability_key' (underscore-prefixed) is expected to
+    exist after segment-B; this test only verifies the public name is absent.
+    """
+    import importlib  # noqa: PLC0415
+
+    # Force a fresh import (the module may already be in sys.modules from other tests)
+    if "write_policy" in sys.modules:
+        write_policy_module = sys.modules["write_policy"]
+    else:
+        write_policy_module = importlib.import_module("write_policy")
+
+    assert not hasattr(write_policy_module, "get_capability_key"), (
+        "write_policy still exposes the public 'get_capability_key' attribute. "
+        "Rename it to '_get_capability_key' per AC 1 and AC 2."
+    )
+
+    # Subprocess check: importing the public name must raise ImportError
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.path.insert(0, 'hooks'); from write_policy import get_capability_key",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, (
+        "Expected subprocess to exit non-zero when importing the removed public name "
+        "'get_capability_key' from write_policy, but it exited 0. "
+        "The public name has not been removed."
+    )
+
+    combined_output = result.stdout + result.stderr
+    assert "ImportError" in combined_output, (
+        "Expected 'ImportError' in subprocess output when importing the removed "
+        f"public name 'get_capability_key', but got:\n{combined_output!r}"
+    )

--- a/tests/test_write_policy_module_allowlist.py
+++ b/tests/test_write_policy_module_allowlist.py
@@ -1,5 +1,6 @@
 """Static-allowlist and invariant tests for the capability-key forge boundary.
 
+Segment owner: segment-A-tdd-allowlist (task-20260504-008).
 ACs covered: 2 (public name gone), 11 (module allowlist grep enforcement).
 PRO-001 hard constraint: sc-001 (no sys._getframe reintroduction), sc-002 (public name removed).
 


### PR DESCRIPTION
## Summary

Hardens the capability-token write boundary in `hooks/write_policy.py` against forge attempts. Drains residual PRO-001.

- **Rename** `get_capability_key` → `_get_capability_key` (private-by-convention) across 6 hooks/ modules and 2 test files. Public name is gone (asserted via `hasattr` + subprocess `ImportError`).
- **Close two tautological-key callsites**:
  - `lib_log._append_jsonl` gains a required `capability_key` parameter; each caller passes the key matching its own role.
  - `router._atomic_write_bytes` hard-codes `_get_capability_key("receipt-writer")` for non-None attempts and runs the policy check under a system safety role for the previously-bypassed `attempt=None` path.
- **Static enforcement**: new `tests/test_write_policy_module_allowlist.py` makes `_PRIVILEGED_ROLE_MODULE_MAP` load-bearing at lint time (grep-based allowlist, `sys._getframe` non-reintroduction invariant, public-name-gone assertion).
- **Adversarial tests** in `test_write_policy_capability_key.py` cover the forge-via-tautological-path and `attempt=None` safety-role properties.
- Hard constraint preserved: zero `sys._getframe` / frame-name inspection in any in-scope file.

## Test plan

- [x] `pytest`: 1827 passed, 0 failed, 7 skipped (pre-existing). Confirmed.
- [x] Targeted ACs: 35 tests pass directly covering ACs 2/4/5/11/13/14 + sc-001 invariant.
- [x] `grep -rn "get_capability_key" hooks/ --include="*.py" | grep -v "_get_capability_key" | grep -v "write_policy.py"` returns zero hits.
- [x] `python3 -c "from write_policy import get_capability_key"` raises `ImportError`.
- [x] `_atomic_write_bytes(path, b"data", attempt=None)` succeeds and writes under the system safety role (test_attempt_none_safety_role).
- [ ] Reviewer: confirm `_PRIVILEGED_ROLE_MODULE_MAP` value-sets remain accurate for the existing 6 callers.
- [ ] Reviewer: confirm no out-of-tree caller of `_append_jsonl` was missed (the signature change is breaking by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)