### PR TITLE
feat: opt-in auto_approve_gates for low-risk residual draining

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -31,6 +31,7 @@ from lib_receipts import (
     plan_validated_receipt_matches,
     read_receipt,
     receipt_audit_done,
+    receipt_auto_approval,
     receipt_executor_done,
     receipt_human_approval,
     receipt_plan_audit,
@@ -706,28 +707,25 @@ def cmd_transition(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_approve_stage(args: argparse.Namespace) -> int:
-    """Record a human approval receipt and atomically advance the manifest stage.
+def _do_approve_stage(task_dir: Path, stage: str, *, approver_type: str) -> int:
+    """Shared core for cmd_approve_stage. ``approver_type`` is "human" or "auto".
 
-    stage must be one of SPEC_NORMALIZATION / SPEC_REVIEW / PLAN_REVIEW /
-    TDD_REVIEW. Exits 1 on any failure that prevents the receipt write or the
-    stage transition (unknown stage, missing artifact, receipt-write refusal,
-    illegal transition). Exits 0 only after both the receipt is durably on disk
-    AND manifest.json reflects the new stage.
+    Behavior is byte-identical to the legacy ``cmd_approve_stage`` for
+    ``approver_type == "human"`` (same receipt stem, same stdout line, same
+    error semantics). For ``approver_type == "auto"`` the function instead
+    writes ``auto-approval-{stage}.json`` via ``receipt_auto_approval`` and
+    emits a stdout line that names ``auto-approved`` rather than ``approved``.
 
-    The manifest stage is guaranteed to be advanced before this function
-    returns; callers do not depend on the daemon to observe the receipt and
-    issue the transition. The daemon may still observe receipts for telemetry
-    purposes but is not required for correctness. stderr carries error text;
-    stdout is reserved for a success line.
+    Both paths refuse the corrupt-rules sentinel, validate the stage, hash
+    the artifact, write the receipt, and ensure the manifest stage is
+    advanced before returning 0. stderr carries error text; stdout is
+    reserved for a single success line.
     """
-    task_dir = Path(args.task_dir).resolve()
     root = _root_for_task_dir(task_dir)
     blocked = _refuse_if_rules_corrupt(root)
     if blocked is not None:
         return blocked
 
-    stage = args.stage
     mapping = _APPROVE_STAGE_MAP.get(stage)
     if mapping is None:
         allowed = ", ".join(sorted(_APPROVE_STAGE_MAP))
@@ -753,7 +751,10 @@ def cmd_approve_stage(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        receipt_human_approval(task_dir, stage, sha256_hex, approver="human")
+        if approver_type == "auto":
+            receipt_auto_approval(task_dir, stage, sha256_hex)
+        else:
+            receipt_human_approval(task_dir, stage, sha256_hex, approver="human")
     except Exception as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -777,8 +778,50 @@ def cmd_approve_stage(args: argparse.Namespace) -> int:
             print(str(exc), file=sys.stderr)
             return 1
 
-    print(f"{task_dir.name}: approved {stage} ({sha256_hex[:12]}) — stage advanced to {next_stage}")
+    verb = "auto-approved" if approver_type == "auto" else "approved"
+    print(f"{task_dir.name}: {verb} {stage} ({sha256_hex[:12]}) — stage advanced to {next_stage}")
     return 0
+
+
+def cmd_approve_stage(args: argparse.Namespace) -> int:
+    """Record an approval receipt and atomically advance the manifest stage.
+
+    stage must be one of SPEC_NORMALIZATION / SPEC_REVIEW / PLAN_REVIEW /
+    TDD_REVIEW. Exits 1 on any failure that prevents the receipt write or the
+    stage transition (unknown stage, missing artifact, receipt-write refusal,
+    illegal transition). Exits 0 only after both the receipt is durably on disk
+    AND manifest.json reflects the new stage.
+
+    Without ``--auto-approved`` the behavior is byte-identical to the legacy
+    human-approval flow (writes ``human-approval-{stage}.json`` via
+    ``receipt_human_approval`` and prints ``approved`` in the success line).
+
+    With ``--auto-approved`` the command refuses with exit 1 unless
+    ``manifest.auto_approve_gates`` is true, then writes
+    ``auto-approval-{stage}.json`` via ``receipt_auto_approval`` and prints
+    ``auto-approved`` in the success line.
+
+    The manifest stage is guaranteed to be advanced before this function
+    returns; callers do not depend on the daemon to observe the receipt and
+    issue the transition.
+    """
+    task_dir = Path(args.task_dir).resolve()
+    auto_approved = bool(getattr(args, "auto_approved", False))
+    if auto_approved:
+        # Gate the auto path on manifest.auto_approve_gates being explicitly
+        # true. Refuse fast (before any receipt write or stage advance) so a
+        # caller cannot circumvent the residual-pick-time ceiling check by
+        # invoking ``approve-stage --auto-approved`` directly.
+        try:
+            manifest = load_json(task_dir / "manifest.json")
+        except Exception as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        if not isinstance(manifest, dict) or manifest.get("auto_approve_gates") is not True:
+            print("auto_approve_gates is not true", file=sys.stderr)
+            return 1
+        return _do_approve_stage(task_dir, args.stage, approver_type="auto")
+    return _do_approve_stage(task_dir, args.stage, approver_type="human")
 
 
 # Artifact name → (relative file path within task_dir, canonical receipt stem)
@@ -970,6 +1013,540 @@ def cmd_amend_artifact(args: argparse.Namespace) -> int:
 
     print(f"amended {artifact_name}: sha256={sha256_after}")
     print(f"amendment receipt: {amend_receipt_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Auto-approve gates (task-20260505-001)
+#
+# manifest.auto_approve_gates: bool
+#   Default false (enforced by absence — readers use
+#   ``manifest.get("auto_approve_gates", False)``). The flag is written to
+#   ``true`` ONLY by ``cmd_set_auto_approve_gates`` (residual-pick-time)
+#   below. ``cmd_apply_auto_approve_veto`` may downgrade ``true -> false``
+#   at classification-time but MUST NEVER raise ``false -> true``.
+# ---------------------------------------------------------------------------
+
+# Auditors permitted to seed an auto-approval flow at residual-pick time.
+# Anything outside this set fails the AC-21b "source_auditor_allowlist"
+# ceiling. ``security-auditor`` is intentionally excluded — it has its own
+# AC-21a "source_auditor_security" ceiling that fires earlier with a more
+# specific message, so a security-auditor row is rejected even though the
+# enclosing allowlist set would also reject it.
+_AUTO_APPROVE_ALLOWED_AUDITORS: frozenset[str] = frozenset({
+    "code-quality-auditor",
+    "dead-code-auditor",
+    "performance-auditor",
+    "ui-auditor",
+})
+
+
+def _check_external_surface_path(location: str) -> bool:
+    """Return True when ``location`` matches an external-surface ceiling pattern.
+
+    Patterns (any single match returns True):
+      * empty string -> True (an empty location is a fail-closed signal that
+        the producer could not localize the change; treat as external).
+      * exact match: ``hooks/ctl.py``
+      * recursive glob: ``skills/**/SKILL.md`` — any ``SKILL.md`` file at
+        any depth under ``skills/``.
+      * recursive glob: ``agents/**/*.md`` — any ``.md`` file at any depth
+        under ``agents/``.
+      * substring: ``router`` anywhere in the path (component or filename).
+      * prefix: ``api/``.
+
+    The recursive ``**`` patterns are NOT delegated to ``fnmatch.fnmatch``
+    (which does not implement recursive globbing). They are decomposed into
+    explicit ``Path.parts`` checks so behavior matches the spec on inputs
+    such as ``skills/foo/bar/SKILL.md`` and ``agents/x/y/z.md``.
+    """
+    if not isinstance(location, str) or location == "":
+        return True
+    # Normalize backslashes — accept Windows-style separators and route them
+    # through the same logic as POSIX paths.
+    norm = location.replace("\\", "/")
+    if norm == "hooks/ctl.py":
+        return True
+    if norm.startswith("api/"):
+        return True
+    if "router" in norm:
+        return True
+    parts = [p for p in norm.split("/") if p]
+    # skills/**/SKILL.md  (any depth >= 2 under skills/, basename SKILL.md)
+    if len(parts) >= 2 and parts[0] == "skills" and parts[-1] == "SKILL.md":
+        return True
+    # agents/**/*.md  (any depth >= 2 under agents/, .md suffix)
+    if len(parts) >= 2 and parts[0] == "agents" and parts[-1].endswith(".md"):
+        return True
+    return False
+
+
+def _read_auto_approve_gates_disabled(root: Path) -> bool:
+    """Return ``policy.auto_approve_gates_disabled`` (default False).
+
+    Reads ``_persistent_project_dir(root) / "policy.json"``. Missing file,
+    unreadable file, malformed JSON, missing key, or non-bool value all
+    fall through to ``False`` — the feature is enabled by default
+    (fail-open consistent with ``is_learning_enabled``).
+    """
+    try:
+        from lib_core import _persistent_project_dir  # noqa: PLC0415
+        policy_path = _persistent_project_dir(root) / "policy.json"
+        data = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    val = data.get("auto_approve_gates_disabled", False)
+    return val is True
+
+
+def _atomic_set_auto_approve_gates_true(task_dir: Path) -> None:
+    """Atomically set ``manifest.auto_approve_gates = True`` under LOCK_EX.
+
+    Holds an exclusive lock on the manifest file FD across read+modify+write
+    so two concurrent ``set-auto-approve-gates`` invocations cannot race and
+    corrupt the JSON. The write goes through ``_write_ctl_json`` so the
+    write-policy boundary is enforced exactly once.
+
+    Also re-checks the AC-4 post-classification refusal under the lock: the
+    pre-lock check in ``cmd_set_auto_approve_gates`` reads from a stale
+    snapshot, so a concurrent ``apply-auto-approve-veto`` can settle
+    classification between the snapshot read and the atomic write. Without
+    an in-lock re-check the writer would silently raise ``false -> true``
+    after classification has settled. Raises ``RuntimeError`` with the
+    sentinel substring ``"classification already settled"`` when the
+    in-lock manifest carries a non-null classification.
+    """
+    import fcntl as _fcntl  # noqa: PLC0415
+
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"manifest.json missing: {manifest_path}")
+    fd = -1
+    try:
+        fd = os.open(str(manifest_path), os.O_RDWR)
+        _fcntl.flock(fd, _fcntl.LOCK_EX)
+        try:
+            with os.fdopen(os.dup(fd), "r", encoding="utf-8") as fh:
+                fh.seek(0)
+                raw = fh.read()
+            try:
+                manifest = json.loads(raw) if raw.strip() else {}
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"manifest.json is not valid JSON: {exc}") from exc
+            if not isinstance(manifest, dict):
+                raise ValueError("manifest.json must be a JSON object")
+            # AC-4 in-lock re-check: the pre-lock check in cmd_set_auto_approve_gates
+            # operates on a stale snapshot. Re-evaluate classification-settled
+            # under the lock to close the TOCTOU window between
+            # cmd_apply_auto_approve_veto and this writer (sec-Re-001).
+            if manifest.get("classification") is not None:
+                raise RuntimeError(
+                    "set-auto-approve-gates: classification already settled "
+                    "(in-lock check)"
+                )
+            manifest["auto_approve_gates"] = True
+            _write_ctl_json(task_dir, manifest_path, manifest)
+        finally:
+            _fcntl.flock(fd, _fcntl.LOCK_UN)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def cmd_set_auto_approve_gates(args: argparse.Namespace) -> int:
+    """Mark a task eligible for auto-approval gates at residual-pick time.
+
+    Walks the residual-pick-time ceilings (security-auditor, allowlist,
+    empty-location, external-surface path-glob, global policy) and, on
+    success, atomically writes ``manifest.auto_approve_gates = true``.
+
+    Refusal cases (each exits 1):
+      * --task-dir missing or manifest.json absent
+      * residual-id not present in proactive-findings.json
+      * any pick-time ceiling tripped (stderr names the ceiling)
+      * manifest.classification already settled (post-classification false
+        -> true is forbidden by AC-4)
+
+    Idempotent: when ``manifest.auto_approve_gates`` is already true the
+    command exits 0 without re-evaluating any ceiling.
+    """
+    task_dir_raw = getattr(args, "task_dir", None)
+    if not task_dir_raw:
+        print("set-auto-approve-gates: --task-dir is required", file=sys.stderr)
+        return 1
+    task_dir = Path(task_dir_raw).resolve()
+    # The residual queue and project-policy file are anchored at the project
+    # root (cwd), NOT at task_dir.parent.parent. Tests and orchestrators may
+    # place ``task_dir`` outside the project tree (e.g. shared scratch dir),
+    # while always running ``ctl.py`` from the project root. Manifest reads
+    # remain relative to ``task_dir`` (per-task), independent of ``root``.
+    # task_dir non-existence is reported via the manifest-missing check below
+    # (more specific error message).
+    root = Path.cwd().resolve()
+    blocked = _refuse_if_rules_corrupt(root)
+    if blocked is not None:
+        return blocked
+
+    # Read manifest first — we need it to short-circuit on already-true and
+    # to reject if classification is settled. A missing manifest is a hard
+    # failure regardless of the residual-id.
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        print(
+            f"set-auto-approve-gates: manifest.json missing at {manifest_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        manifest = load_json(manifest_path)
+    except Exception as exc:
+        print(
+            f"set-auto-approve-gates: failed to read manifest.json: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    if not isinstance(manifest, dict):
+        print(
+            "set-auto-approve-gates: manifest.json must be a JSON object",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-4 idempotency: already-true exits 0 without re-checking ceilings.
+    if manifest.get("auto_approve_gates") is True:
+        print(json.dumps({
+            "auto_approve_gates": True,
+            "task_id": manifest.get("task_id", task_dir.name),
+            "ceiling_checked": ["already_true"],
+        }))
+        return 0
+
+    residual_id = getattr(args, "from_residual_id", None)
+    if not isinstance(residual_id, str) or not residual_id.strip():
+        print(
+            "set-auto-approve-gates: --from-residual-id is required",
+            file=sys.stderr,
+        )
+        return 1
+    residual_id = residual_id.strip()
+
+    # Look up the residual row by id.
+    try:
+        queue = lib_residuals.load_queue(lib_residuals.queue_path(root))
+    except Exception as exc:
+        print(
+            f"set-auto-approve-gates: failed to load residual queue: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    findings = queue.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
+    row = None
+    for entry in findings:
+        if isinstance(entry, dict) and entry.get("id") == residual_id:
+            row = entry
+            break
+    if row is None:
+        print(
+            f"set-auto-approve-gates: residual id not found in queue: {residual_id!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Pick-time ceilings (fail closed, in order). The order is significant —
+    # tests assert specific stderr substrings for the FIRST tripped ceiling.
+    source_auditor = row.get("source_auditor")
+    location = row.get("location")
+    if not isinstance(location, str):
+        location = ""
+
+    # AC-21a: security-auditor row -> blocked_by="source_auditor_security".
+    if source_auditor == "security-auditor":
+        print(
+            "set-auto-approve-gates: blocked by ceiling source_auditor_security "
+            "(row.source_auditor=security-auditor)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-21b: source_auditor not in allowlist -> blocked_by="source_auditor_allowlist".
+    if source_auditor not in _AUTO_APPROVE_ALLOWED_AUDITORS:
+        print(
+            "set-auto-approve-gates: blocked by ceiling source_auditor_allowlist "
+            f"(row.source_auditor={source_auditor!r} not in "
+            f"{sorted(_AUTO_APPROVE_ALLOWED_AUDITORS)})",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-21c: empty/missing location -> blocked_by="external_surface_empty_location".
+    if not location.strip():
+        print(
+            "set-auto-approve-gates: blocked by ceiling external_surface_empty_location "
+            "(row.location is empty)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-21d: global policy disabled -> blocked_by="global_policy".
+    if _read_auto_approve_gates_disabled(root):
+        print(
+            "set-auto-approve-gates: blocked by ceiling global_policy "
+            "(policy.auto_approve_gates_disabled=true)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-22: external-surface path glob -> blocked_by="external_surface_path".
+    if _check_external_surface_path(location):
+        print(
+            "set-auto-approve-gates: blocked by ceiling external_surface_path "
+            f"(row.location={location!r} matches a protected surface)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-4 post-classification refusal: NEVER raise false -> true once
+    # classification is settled. The flag-set is residual-pick-time only.
+    # Evaluated AFTER ceilings so a ceiling-blocked row still names its ceiling
+    # in stderr (instead of being shadowed by classification settled).
+    if manifest.get("classification") is not None:
+        print("set-auto-approve-gates: classification already settled", file=sys.stderr)
+        return 1
+
+    # All ceilings pass — atomically flip the flag to true.
+    try:
+        _atomic_set_auto_approve_gates_true(task_dir)
+    except Exception as exc:
+        print(
+            f"set-auto-approve-gates: failed to update manifest.json: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps({
+        "auto_approve_gates": True,
+        "task_id": manifest.get("task_id", task_dir.name),
+        "ceiling_checked": [
+            "source_auditor_security",
+            "source_auditor_allowlist",
+            "external_surface_empty_location",
+            "external_surface_path",
+            "global_policy",
+        ],
+    }))
+    return 0
+
+
+def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
+    """Apply classification-time veto ceilings to ``manifest.auto_approve_gates``.
+
+    Reads ``manifest.classification`` (must be settled — non-null), evaluates
+    six ceilings in order, and:
+      * if any ceiling trips, sets ``policy.decision = "blocked"`` and
+        downgrades ``manifest.auto_approve_gates`` to false (cannot raise
+        false -> true);
+      * otherwise sets ``policy.decision = "auto"`` and leaves
+        ``manifest.auto_approve_gates`` unchanged (the residual-pick-time
+        flag, if present, is preserved).
+
+    The ``classification.auto_approval_policy`` schema is exactly the shape
+    documented in AC-6:
+
+      {
+        "decision": "auto" | "blocked",
+        "basis": {
+          "risk_level": <str|None>,
+          "domains": [<str>],
+          "source_auditor": <str|None>,
+          "external_surface_path_match": <bool>,
+          "global_policy_disabled": <bool>,
+          "no_residual_row": <bool>,    # only when row is missing (sc-003)
+        },
+        "ceilings_checked": [
+          "risk_level", "domain_security", "source_auditor_security",
+          "external_surface_path", "source_auditor_allowlist",
+          "global_policy",
+        ],
+        "blocked_by": null | <ceiling-name>,
+      }
+    """
+    task_dir_raw = getattr(args, "task_dir", None)
+    if not task_dir_raw:
+        print("apply-auto-approve-veto: --task-dir is required", file=sys.stderr)
+        return 1
+    task_dir = Path(task_dir_raw).resolve()
+    if not task_dir.exists():
+        print(
+            f"apply-auto-approve-veto: task-dir does not exist: {task_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # See cmd_set_auto_approve_gates: residual queue + project policy live at
+    # cwd, manifest lives at task_dir. The two roots are independent.
+    root = Path.cwd().resolve()
+    blocked = _refuse_if_rules_corrupt(root)
+    if blocked is not None:
+        return blocked
+
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        print(
+            f"apply-auto-approve-veto: manifest.json missing at {manifest_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        manifest = load_json(manifest_path)
+    except Exception as exc:
+        print(
+            f"apply-auto-approve-veto: failed to read manifest.json: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    if not isinstance(manifest, dict):
+        print(
+            "apply-auto-approve-veto: manifest.json must be a JSON object",
+            file=sys.stderr,
+        )
+        return 1
+
+    classification = manifest.get("classification")
+    if not isinstance(classification, dict):
+        print(
+            "apply-auto-approve-veto: classification not settled",
+            file=sys.stderr,
+        )
+        return 1
+
+    risk_level = classification.get("risk_level")
+    domains_raw = classification.get("domains")
+    domains: list[str] = []
+    if isinstance(domains_raw, list):
+        domains = [str(d) for d in domains_raw if isinstance(d, str)]
+
+    # Locate the residual row by extracting the residual-id from raw-input.md.
+    residual_id: str | None = None
+    raw_input_path = task_dir / "raw-input.md"
+    if raw_input_path.is_file():
+        try:
+            raw_text = raw_input_path.read_text(encoding="utf-8")
+            residual_id = lib_residuals.extract_residual_id(raw_text)
+        except OSError:
+            residual_id = None
+
+    row: dict | None = None
+    if residual_id:
+        try:
+            queue = lib_residuals.load_queue(lib_residuals.queue_path(root))
+            for entry in queue.get("findings", []):
+                if isinstance(entry, dict) and entry.get("id") == residual_id:
+                    row = entry
+                    break
+        except Exception:
+            row = None
+
+    row_source_auditor: str | None = None
+    row_location: str = ""
+    if row is not None:
+        sa = row.get("source_auditor")
+        row_source_auditor = sa if isinstance(sa, str) else None
+        loc = row.get("location")
+        row_location = loc if isinstance(loc, str) else ""
+
+    surface_match = _check_external_surface_path(row_location) if row is not None else False
+    global_disabled = _read_auto_approve_gates_disabled(root)
+
+    ceilings_checked = [
+        "risk_level",
+        "domain_security",
+        "source_auditor_security",
+        "external_surface_path",
+        "source_auditor_allowlist",
+        "global_policy",
+    ]
+
+    basis: dict = {
+        "risk_level": risk_level,
+        "domains": list(domains),
+        "source_auditor": row_source_auditor,
+        "external_surface_path_match": bool(surface_match),
+        "global_policy_disabled": bool(global_disabled),
+    }
+    if row is None:
+        # sc-003: when no row is found basis is still fully populated, with
+        # an explicit no_residual_row=true disambiguator. Downstream consumers
+        # can distinguish "row exists but auditor was null" from "no row".
+        basis["no_residual_row"] = True
+
+    blocked_by: str | None = None
+
+    # AC-5a: missing risk level -> blocked (fail-closed). AC-5a (continued):
+    # explicit high/critical -> blocked.
+    if not isinstance(risk_level, str) or not risk_level.strip():
+        blocked_by = "risk_level"
+    elif risk_level in {"high", "critical"}:
+        blocked_by = "risk_level"
+    elif "security" in domains:
+        blocked_by = "domain_security"
+    elif row is not None and row_source_auditor == "security-auditor":
+        blocked_by = "source_auditor_security"
+    elif row is not None and surface_match:
+        blocked_by = "external_surface_path"
+    elif global_disabled:
+        blocked_by = "global_policy"
+
+    decision = "blocked" if blocked_by is not None else "auto"
+
+    policy = {
+        "decision": decision,
+        "basis": basis,
+        "ceilings_checked": ceilings_checked,
+        "blocked_by": blocked_by,
+    }
+
+    # If blocked, downgrade manifest.auto_approve_gates to false (can never
+    # raise false -> true here — this is the AC-5 invariant).
+    if blocked_by is not None:
+        manifest["auto_approve_gates"] = False
+    # Update classification.auto_approval_policy in-place.
+    classification["auto_approval_policy"] = policy
+    manifest["classification"] = classification
+
+    # Persist to manifest.json AND mirror classification to classification.json
+    # via the canonical helper. ``_persist_classification`` validates type/risk/
+    # domains; if validation fails (e.g. risk_level=None on a malformed
+    # classification — AC-5e), this veto path still needs to record the
+    # blocked decision so callers see the policy. Fall back to a direct
+    # manifest write + classification.json mirror without re-running the
+    # type/risk/domains validator: the malformed classification is the
+    # *reason* the veto blocked, not a reason to refuse the decision.
+    try:
+        _persist_classification(task_dir, classification)
+    except Exception as _persist_exc:
+        try:
+            write_json(manifest_path, manifest)
+            cls_path = task_dir / "classification.json"
+            write_json(cls_path, classification)
+        except Exception as _fallback_exc:
+            print(
+                f"apply-auto-approve-veto: failed to persist classification: {_fallback_exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    final_flag = bool(manifest.get("auto_approve_gates", False))
+    print(json.dumps({
+        "auto_approve_gates": final_flag,
+        "decision": decision,
+        "blocked_by": blocked_by,
+    }))
     return 0
 
 
@@ -1914,6 +2491,48 @@ def cmd_run_start_classification(args: argparse.Namespace) -> int:
             return 1
 
         fast_track = apply_fast_track(task_dir)
+
+        # AC-24: apply the auto-approve veto post-classification. Both
+        # exception path AND non-zero return path are logged to stderr but
+        # NEITHER aborts run-start-classification (sc-002 from plan audit).
+        # Calling via the module-level name so tests can monkeypatch the
+        # symbol on this module to exercise crash/non-zero scenarios.
+        # Fail-closed: if the veto could not run cleanly, force
+        # auto_approve_gates=False in the manifest so the trust substrate
+        # never trusts an unverified flag (the veto is what proves the
+        # ceilings were checked).
+        try:
+            veto_args = argparse.Namespace(task_dir=str(task_dir))
+            veto_rc = cmd_apply_auto_approve_veto(veto_args)
+        except Exception as _veto_exc:
+            print(
+                f"[warn] apply-auto-approve-veto raised: {_veto_exc}",
+                file=sys.stderr,
+            )
+            veto_rc = 1
+        if veto_rc != 0:
+            print(
+                f"[warn] apply-auto-approve-veto returned non-zero: rc={veto_rc}",
+                file=sys.stderr,
+            )
+            # Force-downgrade the flag to false on veto failure (fail-closed
+            # security posture; the flag is only trustworthy after the veto
+            # has affirmed the ceilings).
+            try:
+                manifest_path = task_dir / "manifest.json"
+                if manifest_path.is_file():
+                    fail_closed_manifest = load_json(manifest_path)
+                    if isinstance(fail_closed_manifest, dict) and (
+                        fail_closed_manifest.get("auto_approve_gates") is True
+                    ):
+                        fail_closed_manifest["auto_approve_gates"] = False
+                        write_json(manifest_path, fail_closed_manifest)
+            except Exception as _force_exc:
+                print(
+                    f"[warn] apply-auto-approve-veto fail-closed write failed: {_force_exc}",
+                    file=sys.stderr,
+                )
+
         manifest = _load_manifest(task_dir)
         current_stage = manifest.get("stage")
         transitioned_to = None
@@ -4671,7 +5290,53 @@ def register_task_lifecycle_parsers(subparsers: argparse._SubParsersAction) -> N
         "stage",
         help="Review stage: SPEC_REVIEW, PLAN_REVIEW, or TDD_REVIEW",
     )
+    approve_stage_parser.add_argument(
+        "--auto-approved",
+        dest="auto_approved",
+        action="store_true",
+        default=False,
+        help=(
+            "Write auto-approval-{stage}.json instead of human-approval-{stage}.json. "
+            "Refused with exit 1 unless manifest.auto_approve_gates is true."
+        ),
+    )
     approve_stage_parser.set_defaults(func=cmd_approve_stage)
+
+    set_auto_approve_gates_parser = subparsers.add_parser(
+        "set-auto-approve-gates",
+        help=(
+            "Mark a task eligible for auto-approval gates at residual-pick time. "
+            "Walks pick-time ceilings and atomically sets manifest.auto_approve_gates=true."
+        ),
+    )
+    set_auto_approve_gates_parser.add_argument(
+        "--task-dir",
+        dest="task_dir",
+        required=True,
+        help="Path to .dynos/task-<id> directory whose manifest will be updated.",
+    )
+    set_auto_approve_gates_parser.add_argument(
+        "--from-residual-id",
+        dest="from_residual_id",
+        required=True,
+        help="Residual id (lib_residuals row id) authorizing the auto-approve flag.",
+    )
+    set_auto_approve_gates_parser.set_defaults(func=cmd_set_auto_approve_gates)
+
+    apply_auto_approve_veto_parser = subparsers.add_parser(
+        "apply-auto-approve-veto",
+        help=(
+            "Apply classification-time veto ceilings; downgrades manifest.auto_approve_gates "
+            "to false when any ceiling trips. Cannot raise false -> true."
+        ),
+    )
+    apply_auto_approve_veto_parser.add_argument(
+        "--task-dir",
+        dest="task_dir",
+        required=True,
+        help="Path to .dynos/task-<id> directory whose classification will receive the veto.",
+    )
+    apply_auto_approve_veto_parser.set_defaults(func=cmd_apply_auto_approve_veto)
 
     amend_artifact_parser = subparsers.add_parser(
         "amend-artifact",

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -772,41 +772,78 @@ def _human_approval_err(
     stage_label: str,
     artifact_path: Path,
 ) -> str | None:
-    """Mirror of ``_check_human_approval`` (nested in
-    ``_replay_gates_for_transition``) — returns an error string on
-    failure rather than raising. Promoted from a closure in
-    ``_compute_bypassed_gates_for_force`` so the captured variables
-    (``task_dir``, ``current_stage``, ``next_stage``) become explicit
-    parameters. Never raises: any internal exception → return None
-    (treat as no-error so the forced transition still proceeds).
+    """Mirror of ``_check_any_approval`` (closure in
+    ``_replay_gates_for_transition``); both paths must accept either
+    human-approval-{stage} or auto-approval-{stage} receipts. Drift
+    between this function and the closure causes
+    ``_compute_bypassed_gates_for_force`` to misreport auto-approved
+    tasks.
+
+    Returns an error string on failure rather than raising. Promoted
+    from a closure in ``_compute_bypassed_gates_for_force`` so the
+    captured variables (``task_dir``, ``current_stage``,
+    ``next_stage``) become explicit parameters. Never raises: any
+    internal exception → return None (treat as no-error so the forced
+    transition still proceeds).
+
+    Behavioural mirror of ``_check_any_approval``:
+      1. Try human-approval-{stage_label} first; if the receipt exists,
+         it is the chosen receipt for the gate.
+      2. Otherwise try auto-approval-{stage_label}; if it exists, it is
+         the chosen receipt.
+      3. Otherwise return a "missing approval receipt" error string
+         that names BOTH possibilities so the caller knows either
+         receipt would have satisfied the gate.
+      4. With a chosen receipt, validate the live artifact's hash
+         against the receipt's ``artifact_sha256``; on mismatch return
+         a "hash mismatch" error string naming the chosen step.
     """
     try:
         from lib_receipts import read_receipt, hash_file, _receipts_dir
     except Exception:
         return None
     try:
-        receipt_step = f"human-approval-{stage_label}"
-        receipt_path = _receipts_dir(task_dir) / f"{receipt_step}.json"
-        receipt = read_receipt(task_dir, receipt_step)
-        if receipt is None:
+        human_step = f"human-approval-{stage_label}"
+        auto_step = f"auto-approval-{stage_label}"
+        receipts_dir = _receipts_dir(task_dir)
+        receipt_path_human = receipts_dir / f"{human_step}.json"
+        receipt_path_auto = receipts_dir / f"{auto_step}.json"
+
+        human_receipt = read_receipt(task_dir, human_step)
+        auto_receipt = (
+            read_receipt(task_dir, auto_step) if human_receipt is None else None
+        )
+
+        if human_receipt is not None:
+            chosen_step = human_step
+            chosen_path = receipt_path_human
+            chosen_receipt = human_receipt
+        elif auto_receipt is not None:
+            chosen_step = auto_step
+            chosen_path = receipt_path_auto
+            chosen_receipt = auto_receipt
+        else:
             return (
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"missing receipt {receipt_step} at {receipt_path} "
+                f"missing approval receipt — expected either "
+                f"{human_step} at {receipt_path_human} or "
+                f"{auto_step} at {receipt_path_auto} "
                 f"(artifact: {artifact_path})"
             )
+
         if not artifact_path.exists():
             return (
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"receipt {receipt_step} present at {receipt_path} but "
+                f"receipt {chosen_step} present at {chosen_path} but "
                 f"artifact missing at {artifact_path}"
             )
-        expected = receipt.get("artifact_sha256") or ""
+        expected = chosen_receipt.get("artifact_sha256") or ""
         actual = hash_file(artifact_path)
         if not isinstance(expected, str) or expected != actual:
             return (
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"hash mismatch for receipt {receipt_step} "
-                f"(receipt: {receipt_path}, artifact: {artifact_path}) "
+                f"hash mismatch for receipt {chosen_step} "
+                f"(receipt: {chosen_path}, artifact: {artifact_path}) "
                 f"expected={(expected or '')[:12]} actual={actual[:12]}"
             )
     except Exception:
@@ -1327,7 +1364,7 @@ def _replay_gates_for_transition(
     ``_refuse`` closure) on the first hard refusal, or aggregates
     ``gate_errors`` and raises one combined ``ValueError`` at the end.
 
-    The nested closures (``_refuse``, ``_check_human_approval``,
+    The nested closures (``_refuse``, ``_check_any_approval``,
     ``_check_tdd_tests``, ``_check_rules_check_passed``) intentionally
     stay nested — they share ``task_dir``, ``current_stage``,
     ``next_stage``, ``manifest_path`` via closure, and ``_refuse`` calls
@@ -1365,34 +1402,68 @@ def _replay_gates_for_transition(
             pass  # Logging must never block the refusal itself.
         raise ValueError(reason)
 
-    def _check_human_approval(stage_label: str, artifact_path: Path) -> None:
+    def _check_any_approval(stage_label: str, artifact_path: Path) -> None:
         """Refuse the current transition unless an approval receipt for
         ``stage_label`` exists and its ``artifact_sha256`` matches the
-        current hash of ``artifact_path``."""
+        current hash of ``artifact_path``.
+
+        Accepts EITHER ``human-approval-{stage_label}`` OR
+        ``auto-approval-{stage_label}``. Human-approval is checked
+        first; if absent, auto-approval is checked. When neither is
+        found the refusal message names BOTH possibilities so the
+        operator knows either receipt would have satisfied the gate.
+        Hash-mismatch refusal applies identically to both stems
+        (2026-04-30 forgery hardening invariant).
+
+        Mirrored by ``_human_approval_err`` (in this module) for the
+        force-override observability path; drift between this closure
+        and that helper causes ``_compute_bypassed_gates_for_force`` to
+        misreport auto-approved tasks as having human-bypassed gates.
+        """
         from lib_receipts import _receipts_dir  # type: ignore
 
-        receipt_step = f"human-approval-{stage_label}"
-        receipt_path = _receipts_dir(task_dir) / f"{receipt_step}.json"
-        receipt = read_receipt(task_dir, receipt_step)
-        if receipt is None:
+        human_step = f"human-approval-{stage_label}"
+        auto_step = f"auto-approval-{stage_label}"
+        receipts_dir = _receipts_dir(task_dir)
+        receipt_path_human = receipts_dir / f"{human_step}.json"
+        receipt_path_auto = receipts_dir / f"{auto_step}.json"
+
+        human_receipt = read_receipt(task_dir, human_step)
+        auto_receipt = (
+            read_receipt(task_dir, auto_step) if human_receipt is None else None
+        )
+
+        if human_receipt is not None:
+            chosen_step = human_step
+            chosen_path = receipt_path_human
+            chosen_receipt = human_receipt
+        elif auto_receipt is not None:
+            chosen_step = auto_step
+            chosen_path = receipt_path_auto
+            chosen_receipt = auto_receipt
+        else:
             _refuse(
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"missing receipt {receipt_step} at {receipt_path} "
+                f"missing approval receipt — expected either "
+                f"{human_step} at {receipt_path_human} or "
+                f"{auto_step} at {receipt_path_auto} "
                 f"(artifact: {artifact_path})"
             )
+            return  # _refuse raises; this satisfies type-narrowing
+
         if not artifact_path.exists():
             _refuse(
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"receipt {receipt_step} present at {receipt_path} but "
+                f"receipt {chosen_step} present at {chosen_path} but "
                 f"artifact missing at {artifact_path}"
             )
-        expected = receipt.get("artifact_sha256") or ""
+        expected = chosen_receipt.get("artifact_sha256") or ""
         actual = hash_file(artifact_path)
         if not isinstance(expected, str) or expected != actual:
             _refuse(
                 f"Cannot transition {current_stage} -> {next_stage}: "
-                f"hash mismatch for receipt {receipt_step} "
-                f"(receipt: {receipt_path}, artifact: {artifact_path}) "
+                f"hash mismatch for receipt {chosen_step} "
+                f"(receipt: {chosen_path}, artifact: {artifact_path}) "
                 f"expected={(expected or '')[:12]} actual={actual[:12]}"
             )
 
@@ -1528,15 +1599,17 @@ def _replay_gates_for_transition(
                 f"for risk_level={risk_level}; manifest={manifest_path}"
             )
 
-    # ---- AC 3: SPEC_REVIEW -> PLANNING requires human-approval-SPEC_REVIEW
-    # whose artifact_sha256 matches sha256(spec.md).
+    # ---- AC 3: SPEC_REVIEW -> PLANNING requires either
+    # human-approval-SPEC_REVIEW or auto-approval-SPEC_REVIEW whose
+    # artifact_sha256 matches sha256(spec.md).
     if current_stage == "SPEC_REVIEW" and next_stage == "PLANNING":
-        _check_human_approval("SPEC_REVIEW", task_dir / "spec.md")
+        _check_any_approval("SPEC_REVIEW", task_dir / "spec.md")
 
-    # ---- AC 4: PLAN_REVIEW -> PLAN_AUDIT requires human-approval-PLAN_REVIEW
-    # whose artifact_sha256 matches sha256(plan.md).
+    # ---- AC 4: PLAN_REVIEW -> PLAN_AUDIT requires either
+    # human-approval-PLAN_REVIEW or auto-approval-PLAN_REVIEW whose
+    # artifact_sha256 matches sha256(plan.md).
     if current_stage == "PLAN_REVIEW" and next_stage == "PLAN_AUDIT":
-        _check_human_approval("PLAN_REVIEW", task_dir / "plan.md")
+        _check_any_approval("PLAN_REVIEW", task_dir / "plan.md")
 
     # ---- F6: planner-spec receipt required at SPEC_NORMALIZATION ->
     # SPEC_REVIEW (skipped when manifest.fast_track is True — fast-track
@@ -1572,11 +1645,11 @@ def _replay_gates_for_transition(
                 "receipt: planner-plan (planner plan spawn was never recorded)"
             )
 
-    # ---- AC 6: TDD_REVIEW -> PRE_EXECUTION_SNAPSHOT requires
-    # human-approval-TDD_REVIEW whose artifact_sha256 matches
-    # sha256(evidence/tdd-tests.md).
+    # ---- AC 6: TDD_REVIEW -> PRE_EXECUTION_SNAPSHOT requires either
+    # human-approval-TDD_REVIEW or auto-approval-TDD_REVIEW whose
+    # artifact_sha256 matches sha256(evidence/tdd-tests.md).
     if current_stage == "TDD_REVIEW" and next_stage == "PRE_EXECUTION_SNAPSHOT":
-        _check_human_approval("TDD_REVIEW", task_dir / "evidence" / "tdd-tests.md")
+        _check_any_approval("TDD_REVIEW", task_dir / "evidence" / "tdd-tests.md")
 
     # ---- AC 11 + tdd_required gate: EXIT from PLAN_AUDIT.
     # (a) high/critical risk tasks MUST have a plan-audit-check receipt
@@ -3542,6 +3615,20 @@ def collect_retrospectives(root: Path, *, include_unverified: bool = False) -> l
         if not isinstance(data, dict):
             return
 
+        # AC-20: when the source retrospective JSON carries
+        # ``gates_auto_approved`` and/or ``auto_approved_stages`` (written
+        # by ``receipt_retrospective`` after seg-1), propagate them
+        # verbatim into the aggregated output dict for this task. The
+        # whole-dict ingestion below already preserves arbitrary keys,
+        # but we explicitly pin these two so a future refactor that
+        # narrows the kept keys cannot silently drop the auto-approval
+        # fields needed for grep-style audit.
+        _auto_approval_passthrough: dict[str, Any] = {}
+        if "gates_auto_approved" in data:
+            _auto_approval_passthrough["gates_auto_approved"] = data["gates_auto_approved"]
+        if "auto_approved_stages" in data:
+            _auto_approval_passthrough["auto_approved_stages"] = data["auto_approved_stages"]
+
         tid = data.get("task_id")
 
         # SEC-003: verify persistent retros against the flushed-event
@@ -3585,6 +3672,15 @@ def collect_retrospectives(root: Path, *, include_unverified: bool = False) -> l
             data["_source"] = "persistent"
         else:
             data["_source"] = "worktree"
+
+        # AC-20: re-pin the auto-approval pass-through so the aggregated
+        # entry always carries ``gates_auto_approved`` /
+        # ``auto_approved_stages`` verbatim when the source had them.
+        # Re-application is a no-op when the keys already round-tripped
+        # untouched, but it is a hard guarantee against any future code
+        # path that narrows ``data`` between ingestion and storage.
+        for _k, _v in _auto_approval_passthrough.items():
+            data[_k] = _v
 
         if isinstance(tid, str) and tid:
             key = tid

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -58,6 +58,7 @@ from receipts.planner import (
 )
 from receipts.approval import (
     receipt_human_approval,
+    receipt_auto_approval,
     receipt_postmortem_generated,
     receipt_postmortem_analysis,
     receipt_postmortem_skipped,
@@ -91,6 +92,7 @@ __all__ = [
     "receipt_plan_audit",
     "receipt_tdd_tests",
     "receipt_human_approval",
+    "receipt_auto_approval",
     "receipt_postmortem_generated",
     "receipt_postmortem_analysis",
     "receipt_postmortem_skipped",

--- a/hooks/receipts/__init__.py
+++ b/hooks/receipts/__init__.py
@@ -39,6 +39,7 @@ from .planner import (
 )
 from .approval import (
     receipt_human_approval,
+    receipt_auto_approval,
     receipt_postmortem_generated,
     receipt_postmortem_analysis,
     receipt_postmortem_skipped,
@@ -69,6 +70,7 @@ __all__ = [
     "receipt_plan_audit",
     "receipt_tdd_tests",
     "receipt_human_approval",
+    "receipt_auto_approval",
     "receipt_postmortem_generated",
     "receipt_postmortem_analysis",
     "receipt_postmortem_skipped",

--- a/hooks/receipts/approval.py
+++ b/hooks/receipts/approval.py
@@ -83,6 +83,47 @@ def receipt_human_approval(
     )
 
 
+def receipt_auto_approval(
+    task_dir: Path,
+    stage: str,
+    artifact_sha256: str,
+    *,
+    approver: str = "auto:residual-skill",
+) -> Path:
+    """Write receipt proving an auto-approval (low-risk residual drain) at `stage`.
+
+    Writes ``receipts/auto-approval-{stage}.json``. Identical validation
+    surface to ``receipt_human_approval`` so auto-approval receipts go
+    through the same hash-mismatch refusal at transition time (preserving
+    the 2026-04-30 audit-chain forgery hardening).
+
+    The ``kind="auto"`` payload field distinguishes auto-approval receipts
+    from human-approval receipts in greppable form for retrospectives and
+    audit trails.
+    """
+    require_nonblank_str(stage, field_name="stage")
+    if "/" in stage or "\\" in stage or stage.startswith("."):
+        raise ValueError(f"stage must not contain path separators: {stage!r}")
+    require_nonblank_str(artifact_sha256, field_name="artifact_sha256")
+    try:
+        require_nonblank(approver, field_name="approver")
+    except (TypeError, ValueError):
+        raise ValueError(
+            "approver must be a non-empty string "
+            "(whitespace-only values are rejected — whitespace carries no "
+            "approver identity)"
+        )
+
+    return write_receipt(
+        task_dir,
+        f"auto-approval-{stage}",
+        stage=stage,
+        artifact_sha256=artifact_sha256,
+        approver=approver,
+        kind="auto",
+    )
+
+
 def receipt_postmortem_generated(
     task_dir: Path,
     postmortem_json_path: Path | str,

--- a/hooks/receipts/core.py
+++ b/hooks/receipts/core.py
@@ -70,7 +70,7 @@ from write_policy import WriteAttempt, _get_capability_key, require_write_allowe
 #   * receipt_rules_check_passed derives counts internally from rules_engine
 # The bump signals "new semantics available"; it does NOT retroactively
 # invalidate v2 receipts (see MIN_VERSION_PER_STEP floors below).
-RECEIPT_CONTRACT_VERSION = 5
+RECEIPT_CONTRACT_VERSION = 6
 
 
 # Files that compose the calibration policy snapshot used by the
@@ -116,6 +116,12 @@ MIN_VERSION_PER_STEP: dict[str, int] = {
     # writes; existing pre-v5 force-override receipts remain readable
     # and are NOT retroactively invalidated.
     "force-override-*": 5,
+    # v5 -> v6 bump (task-20260505-001): auto-approval receipts allow
+    # /dynos-work:residual run-next to drain low-risk residuals overnight
+    # without human gates while preserving the same hash-mismatch refusal
+    # invariant as human-approval receipts. v5 receipts on disk remain
+    # readable; only new auto-approval-* writes carry contract_version=6.
+    "auto-approval-*": 6,
 }
 
 
@@ -216,6 +222,9 @@ _LOG_MESSAGES: dict[str, str] = {
     "human-approval-SPEC_REVIEW": "[DONE] human-approval SPEC_REVIEW — approver={approver}",
     "human-approval-PLAN_REVIEW": "[DONE] human-approval PLAN_REVIEW — approver={approver}",
     "human-approval-TDD_REVIEW": "[DONE] human-approval TDD_REVIEW — approver={approver}",
+    "auto-approval-SPEC_REVIEW": "[DONE] auto-approval SPEC_REVIEW — approver={approver}",
+    "auto-approval-PLAN_REVIEW": "[DONE] auto-approval PLAN_REVIEW — approver={approver}",
+    "auto-approval-TDD_REVIEW": "[DONE] auto-approval TDD_REVIEW — approver={approver}",
     "postmortem-generated": "[DONE] postmortem generated — anomalies={anomaly_count} patterns={pattern_count}",
     "postmortem-analysis": "[DONE] postmortem analysis — rules_added={rules_added}",
     "postmortem-skipped": "[DONE] postmortem skipped — reason={reason}",

--- a/hooks/receipts/stage.py
+++ b/hooks/receipts/stage.py
@@ -948,6 +948,33 @@ def receipt_retrospective(task_dir: Path, **_legacy: Any) -> Path:
     total_tokens = result.get("total_tokens")
     if total_tokens is None:
         total_tokens = result.get("total_token_usage", 0)
+
+    # task-20260505-001 AC-19: self-compute auto-approval gate counts by
+    # scanning the receipts directory at write time. Callers do NOT
+    # supply these fields (consistent with the v4 anti-falsification
+    # pattern). Counts only auto-approval receipts whose JSON parses and
+    # carries `valid: true`; the stage labels are extracted from the
+    # filename stem and sorted alphabetically.
+    receipts_dir = task_dir / "receipts"
+    gates_auto_approved = 0
+    auto_approved_stages: list[str] = []
+    if receipts_dir.is_dir():
+        for receipt_path in sorted(receipts_dir.glob("auto-approval-*.json")):
+            try:
+                payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("valid") is True:
+                gates_auto_approved += 1
+            stem = receipt_path.stem
+            if stem.startswith("auto-approval-"):
+                stage_label = stem[len("auto-approval-"):]
+                if stage_label and stage_label not in auto_approved_stages:
+                    auto_approved_stages.append(stage_label)
+    auto_approved_stages.sort()
+
     return write_receipt(
         task_dir,
         "retrospective",
@@ -956,6 +983,8 @@ def receipt_retrospective(task_dir: Path, **_legacy: Any) -> Path:
         efficiency_score=result.get("efficiency_score", 0.0),
         total_tokens=total_tokens,
         retrospective_path=str(task_dir / "task-retrospective.json"),
+        gates_auto_approved=gates_auto_approved,
+        auto_approved_stages=auto_approved_stages,
     )
 
 

--- a/skills/residual/SKILL.md
+++ b/skills/residual/SKILL.md
@@ -138,8 +138,8 @@ This is a LOCK_EX read-modify-write that:
 
 If the call raises an exception (filesystem error, race with another
 writer, etc.), print the error to stderr and exit non-zero. DO NOT
-proceed to step 4 — the queue is in an unknown state and a spawned
-task without a corresponding `in_progress` row would lose its
+proceed to step 4 or step 5 — the queue is in an unknown state and a
+spawned task without a corresponding `in_progress` row would lose its
 round-trip update.
 
 NOTE: `update_row_status` from the lib only changes `status` (and sets
@@ -175,7 +175,56 @@ print(json.dumps({"id": row["id"], "description": row.get("description","")}))
 PY
 ```
 
-### Step 4 — Invoke `/dynos-work:start` and POLL until terminal stage
+### Step 4 — Set auto-approve gates for the new task (best-effort)
+
+Before invoking `/dynos-work:start`, the new task directory does not
+yet exist. The auto-approve-gates ctl command requires the new task's
+`manifest.json` to be on disk because it is the sole writer of
+`manifest.auto_approve_gates`. There is therefore a sequencing
+constraint: `set-auto-approve-gates` MUST be called AFTER
+`/dynos-work:start` Step 0 has created `.dynos/task-{new_id}/manifest.json`
+but BEFORE classification has been settled (the gate refuses
+`false → true` once `manifest.classification` is non-null — this is
+the AC-4 enforcement in `cmd_set_auto_approve_gates`).
+
+In practice, call `set-auto-approve-gates` immediately after
+`/dynos-work:start` returns control with the new `task_id`. If the
+spawned start skill has already advanced past classification by the
+time you make the call, the gate will refuse with a non-zero exit; in
+that case fall through to the normal human-approval path (the gates
+were not enabled, but the residual still runs).
+
+```bash
+python3 hooks/ctl.py set-auto-approve-gates \
+  --task-dir .dynos/task-{new_id} \
+  --from-residual-id {row["id"]}
+```
+
+Fall-through behavior:
+
+- Exit code 0: `manifest.auto_approve_gates` was set to `true` on the
+  new task. Subsequent SPEC_REVIEW / PLAN_REVIEW / TDD_REVIEW gates in
+  `/dynos-work:start` will auto-approve via the receipt path. Continue
+  polling in Step 5.
+- Exit code 1: the gate refused (a pick-time ceiling tripped, the
+  classification was already settled, the manifest is missing, or the
+  global policy file disabled auto-approval). Log the stderr message
+  and continue with normal human-approval gates. DO NOT abort the
+  `run-next` flow — the residual must still run; it just runs with a
+  human in the loop.
+
+Recommended logging:
+
+```bash
+{timestamp} [GATE] set-auto-approve-gates residual={row.id} task={new_id} result={ok|refused: <reason>}
+```
+
+The auto-approval pathway is an opportunistic acceleration of
+operator-trusted residuals. A refusal is a normal outcome (e.g. for
+high-risk security findings) and never blocks the residual from
+running.
+
+### Step 5 — Invoke `/dynos-work:start` and POLL until terminal stage
 
 Build the input text for `/dynos-work:start`. The first line MUST be
 the residual-id sentinel comment, followed by a blank line, followed
@@ -195,7 +244,7 @@ Invoke `/dynos-work:start` with that text. The spawned task is a NEW
 dynos-work task with its own `task-{id}` directory under `.dynos/` and
 its own `manifest.json`.
 
-**WAIT — do NOT continue to step 5 until you have read the spawned
+**WAIT — do NOT continue to step 6 until you have read the spawned
 task's `manifest.json` and confirmed `stage` is exactly `"DONE"` or
 `"FAILED"`. Reading the manifest once and assuming the task completed
 is INCORRECT.** The `/dynos-work:start` skill returns control to you
@@ -213,14 +262,14 @@ REPAIR stages, which can take many minutes.
    ambiguity.)
 2. Read `.dynos/task-{id}/manifest.json`. Inspect the `stage` field.
 3. If `stage` is `"DONE"` or `"FAILED"`, polling is over — proceed to
-   step 5.
+   step 6.
 4. Otherwise, sleep approximately 30 seconds and re-read the manifest.
    Repeat. The lifecycle is monotonic; the manifest will eventually
    reach a terminal stage.
 5. If the manifest is missing or unreadable for more than a few
    consecutive polls (suggesting the spawned task crashed before
    writing the manifest), give up polling, treat this as a
-   round-trip-missing case, and fall through to step 5 — the fallback
+   round-trip-missing case, and fall through to step 6 — the fallback
    path will revert the row to `pending`.
 
 The skill prose deliberately uses 30-second polling rather than busy
@@ -229,7 +278,7 @@ than every few seconds wastes CPU and risks rate-limiting the
 filesystem. Polling looser than a minute slows feedback for the
 operator. 30 seconds is the recommended cadence.
 
-### Step 5 — Read the queue and report the round-trip outcome
+### Step 6 — Read the queue and report the round-trip outcome
 
 Once the spawned task is at a terminal stage (or polling has been
 abandoned because the manifest is permanently missing), re-read the
@@ -268,8 +317,9 @@ row was never updated. Possible causes include:
 
 In all these cases, the attempt is sacrificed — we do NOT increment
 `attempts` further on revert, because the original `update_row_status`
-in step 3 already incremented it once. Reverting `status` to
-`"pending"` lets the next `run-next` retry. After three sacrificed
+in step 3 already incremented it once. (Steps 4 and 5 do not touch
+`attempts`.) Reverting `status` to `"pending"` lets the next
+`run-next` retry. After three sacrificed
 attempts the row will not be eligible for selection (`attempts < 3`
 guard in `select_next_pending`), and an operator must inspect it
 manually.
@@ -315,7 +365,7 @@ fields).
 - Do NOT spawn auditor or executor agents directly to "fix" a
   residual. Only `/dynos-work:start` is the execution path; it
   enforces the full lifecycle and the audit gate.
-- Do NOT skip the polling loop in step 4. Reading `manifest.json`
+- Do NOT skip the polling loop in step 5. Reading `manifest.json`
   once and assuming completion is INCORRECT.
 - Do NOT mutate `proactive-findings.json` outside of
   `lib_residuals.update_row_status` (or an equivalent LOCK_EX atomic

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -354,6 +354,17 @@ python3 hooks/ctl.py run-spec-ready .dynos/task-{id}
 
 **Fast-track skip:** If `manifest.json` has `"fast_track": true`, skip this step. Spec is reviewed together with the plan in Step 6 (combined approval gate). Log: `{timestamp} [SKIP] spec-review — fast_track combined gate`.
 
+**Auto-approve path (precedes the human path):** If `manifest.json` has `"auto_approve_gates": true`, do NOT present `spec.md` to the user. Run the auto-approved variant of the approve-stage ctl command instead. This is the only sanctioned bypass — it still hashes the live `spec.md`, writes a `human-approval-SPEC_REVIEW` receipt with `approver_type="residual-auto"`, and advances SPEC_REVIEW → PLANNING through the same atomic gate that the human path uses. The receipt is forensically distinguishable from a human approval (the `approver_type` field), so the audit chain remains intact.
+
+```text
+python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
+```
+
+- Exit code 0: receipt was written and the stage advanced. Skip the rest of this step.
+- Exit code 1: the gate refused — the most common cause is `auto_approve_gates is not true` (the manifest flag was flipped off mid-flight) or a hash mismatch. Log the stderr message and fall through to the human-approval path below. Do NOT retry with `--auto-approved` if the manifest flag is no longer true; the gate is correct to refuse.
+
+In the auto path, the "if changes requested" and "if rejected" branches of the human path below are unreachable — the residual queue's classification has already filtered out tasks where human review is required. If you find yourself in those branches with `auto_approve_gates=true`, that is a bug in the pick-time ceilings, not a runtime decision to make here.
+
 **Normal path:** Present `spec.md` to the user and ask for approval.
 
 - If approved: run the `approve-stage` ctl command below. It hashes the current `spec.md`, writes the `human-approval-SPEC_REVIEW` receipt with that hash, the scheduler then observes the receipt write and advances the task to PLANNING asynchronously. Do NOT write a manual `[HUMAN]` log line — `approve-stage` is the only path that satisfies the receipt-gate in `transition_task` (which compares the receipt's `artifact_sha256` against the live `spec.md` at transition time and refuses with `human-approval-SPEC_REVIEW` / `hash mismatch` substrings on drift).
@@ -455,6 +466,30 @@ python3 hooks/ctl.py transition .dynos/task-{id} PLAN_REVIEW
 
 This gate always runs. For fast-track tasks it acts as the combined Spec + Plan approval (since Step 4 was skipped) — present BOTH `spec.md` AND `plan.md` together.
 
+**Auto-approve path (precedes the human path):** If `manifest.json` has `"auto_approve_gates": true`, do NOT present `plan.md` (or the combined `spec.md` + `plan.md`) to the user. Use the `--auto-approved` variant of approve-stage instead. Two cases:
+
+- Normal path (Step 4 already wrote the SPEC_REVIEW receipt — auto or human):
+
+  ```text
+  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
+  ```
+
+- Fast-track combined gate (Step 4 was skipped; the manifest is at SPEC_REVIEW after Step 5's stage walk and needs both receipts in order):
+
+  ```text
+  python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
+  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
+  ```
+
+  The state machine requires the SPEC_REVIEW receipt before the PLAN_REVIEW receipt — this ordering is unchanged by the auto-approval feature. Both calls must return exit 0; if either returns exit 1, log the stderr message and fall through to the human-approval path for that specific gate.
+
+Either auto path:
+
+- Exit code 0 on every call: receipts written, stages advanced, skip the rest of this step.
+- Exit code 1 on any call: the gate refused (most common: `auto_approve_gates is not true`, hash mismatch, or illegal transition). Log the stderr message and fall through to the human path below for the refused gate. Do not bypass with `transition --force`.
+
+In the auto path, "if changes requested" and "if rejected outright" branches below are unreachable — see the same note in Step 4.
+
 Present the artifact(s) to the user and ask for approval.
 
 - If approved (normal path): run `python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW`. This hashes the current `plan.md`, writes the `human-approval-PLAN_REVIEW` receipt with that hash, and atomically advances PLAN_REVIEW → PLAN_AUDIT. Exit code 0 means success; exit code 1 means the gate refused (stderr identifies the cause). Do not bypass with `transition --force`.
@@ -532,15 +567,26 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
    )
    ```
 
-6. When the user approves the test suite, transition out of TDD_REVIEW via the `approve-stage` ctl command. This hashes `evidence/tdd-tests.md`, writes the `human-approval-TDD_REVIEW` receipt with that hash, and advances TDD_REVIEW → PRE_EXECUTION_SNAPSHOT in one atomic step. Do NOT append a manual `[HUMAN]` log line — the receipt + approve-stage path is the only one the state machine accepts (the gate refuses with `human-approval-TDD_REVIEW` / `hash mismatch` substrings on drift):
+6. **Auto-approve path (precedes the human path):** If `manifest.json` has `"auto_approve_gates": true` AND `tdd_required: true` (which is the only condition under which Step 8 fires at all), do NOT present the test suite to the user. After the testing-executor spawn and the deterministic validation in step 2 above have both passed, run the auto-approved variant of approve-stage:
+
+   ```text
+   python3 hooks/ctl.py approve-stage .dynos/task-{id} TDD_REVIEW --auto-approved
+   ```
+
+   - Exit code 0: receipt written, stage advanced TDD_REVIEW → PRE_EXECUTION_SNAPSHOT. Proceed to step 7 (commit tests).
+   - Exit code 1: the gate refused. Log the stderr message and fall through to the human-approval path (step 7 below) for this gate. Do not bypass with `transition --force`.
+
+   This conditional does NOT change the `tdd_required == false` behavior. When `tdd_required` is `false`, Step 8 does not fire at all (existing condition unchanged); the auto-approval flag has no effect on a step that is not executed.
+
+7. When the user approves the test suite (or after step 6's auto-approval has run), transition out of TDD_REVIEW via the `approve-stage` ctl command. This hashes `evidence/tdd-tests.md`, writes the `human-approval-TDD_REVIEW` receipt with that hash, and advances TDD_REVIEW → PRE_EXECUTION_SNAPSHOT in one atomic step. Do NOT append a manual `[HUMAN]` log line — the receipt + approve-stage path is the only one the state machine accepts (the gate refuses with `human-approval-TDD_REVIEW` / `hash mismatch` substrings on drift):
 
    ```text
    python3 hooks/ctl.py approve-stage .dynos/task-{id} TDD_REVIEW
    ```
 
-   Exit code 0 means the receipt was written and the stage advanced. Exit code 1 means the gate refused — the stderr text identifies the cause. Do not bypass with `transition --force`.
+   Exit code 0 means the receipt was written and the stage advanced. Exit code 1 means the gate refused — the stderr text identifies the cause. Do not bypass with `transition --force`. (If step 6's auto-approval already advanced the stage, this human-path call is unreachable.)
 
-7. Commit the approved tests to the snapshot branch before any production code is written.
+8. Commit the approved tests to the snapshot branch before any production code is written.
 
 ---
 

--- a/tests/test_auto_approve_gates.py
+++ b/tests/test_auto_approve_gates.py
@@ -381,11 +381,21 @@ class TestSetAutoApproveGatesCeilings:
         assert "policy" in r.stderr
 
     def test_set_auto_approve_gates_success_stdout_json(self, tmp_path: Path):
-        """AC-3 happy path: all ceilings pass -> exits 0, stdout is parseable JSON."""
+        """AC-3 happy path: all ceilings pass -> exits 0, stdout is parseable JSON.
+
+        Uses pre-classification fixture (classification=None overridden after
+        _make_task because the fixture's `cls = classification or {...}` falls
+        through to a default dict on None — overwrite manifest post-creation
+        to genuinely null out classification, matching the residual-pick-time
+        precondition.
+        """
         root = tmp_path / "project"
         root.mkdir()
         (root / ".dynos").mkdir()
-        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        task_dir = _make_task(tmp_path / "td", stage="FOUNDRY_INITIALIZED")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest["classification"] = None
+        (task_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
         row = _default_row(source_auditor="code-quality-auditor", location="lib/utils.py")
         _make_queue(root, row)
         dynos_home = tmp_path / "home"
@@ -406,11 +416,21 @@ class TestSetAutoApproveGatesCeilings:
         assert "ceiling_checked" in out
 
     def test_set_auto_approve_gates_manifest_written(self, tmp_path: Path):
-        """AC-3 success: manifest.auto_approve_gates=true after command exits 0."""
+        """AC-3 success: manifest.auto_approve_gates=true after command exits 0.
+
+        Uses pre-classification fixture (classification=None overridden after
+        _make_task because the fixture's `cls = classification or {...}` falls
+        through to a default dict on None — overwrite manifest post-creation
+        to genuinely null out classification, matching the residual-pick-time
+        precondition.
+        """
         root = tmp_path / "project"
         root.mkdir()
         (root / ".dynos").mkdir()
-        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        task_dir = _make_task(tmp_path / "td", stage="FOUNDRY_INITIALIZED")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest["classification"] = None
+        (task_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
         row = _default_row(source_auditor="code-quality-auditor", location="lib/utils.py")
         _make_queue(root, row)
         dynos_home = tmp_path / "home"
@@ -1117,7 +1137,7 @@ class TestTransitionGateExtension:
         sys.path.insert(0, str(HOOKS))
         from lib_core import transition_task  # noqa: PLC0415
         task_dir = self._make_spec_review_task(tmp_path)
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="missing approval receipt") as exc_info:
             transition_task(task_dir, "PLANNING")
         msg = str(exc_info.value)
         assert "human-approval-SPEC_REVIEW" in msg
@@ -1524,3 +1544,207 @@ class TestValidateChainGapFree:
         # auto-approval receipts must not introduce spurious gap reports
         auto_gaps = [g for g in gaps if "auto-approval" in g]
         assert auto_gaps == [], f"validate_chain must not gap-report auto-approval receipts: {auto_gaps}"
+
+
+# ===========================================================================
+# AC-21i exact name: test_auto_approval_hash_mismatch_refused
+# AC-21m exact name: test_force_override_on_auto_approved_task
+# AC-21 integration: test_low_risk_residual_auto_drains_end_to_end
+# ===========================================================================
+
+class TestEndToEndDrain:
+    """AC-21 exact-name fixtures and end-to-end low-risk drain integration test."""
+
+    def test_auto_approval_hash_mismatch_refused(self, tmp_path: Path):
+        """AC-21i exact name: tampered artifact_sha256 in auto-approval receipt raises ValueError.
+
+        Writes auto-approval-SPEC_REVIEW.json with a known-wrong sha256 and
+        asserts transition_task raises ValueError whose message contains both
+        'auto-approval-SPEC_REVIEW' and 'hash mismatch'.
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        tampered_sha = "0" * 64
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": tampered_sha})
+        with pytest.raises(ValueError) as exc_info:
+            transition_task(task_dir, "PLANNING")
+        msg = str(exc_info.value)
+        assert "auto-approval-SPEC_REVIEW" in msg
+        assert "hash mismatch" in msg
+
+    def test_force_override_on_auto_approved_task(self, tmp_path: Path):
+        """AC-21m exact name: force-transition on an auto-approved task yields empty bypassed-gates.
+
+        A task where SPEC_REVIEW was auto-approved: transition_task(..., force=True)
+        must compute an empty bypassed-gates list because the auto-approval receipt
+        satisfies the gate even in force/dry-run mode.
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW", auto_approve_gates=True)
+        sha = hash_file(task_dir / "spec.md")
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": sha})
+        transition_task(
+            task_dir,
+            "PLANNING",
+            force=True,
+            force_reason="test override",
+            force_approver="test-operator",
+        )
+        override_receipts = list((task_dir / "receipts").glob("force-override-*.json"))
+        if override_receipts:
+            receipt_data = json.loads(override_receipts[0].read_text())
+            bypassed = receipt_data.get("bypassed_gates", [])
+            assert bypassed == [], (
+                f"bypassed_gates must be empty when auto-approval receipt satisfies the gate; got {bypassed}"
+            )
+        # Regardless of whether a force-override receipt exists, stage must advance
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest["stage"] == "PLANNING"
+
+    def test_low_risk_residual_auto_drains_end_to_end(self, tmp_path: Path):
+        """AC-21 integration (end-to-end): a low-risk residual drains through all auto-approve gates.
+
+        Setup:
+          - Queue row: source_auditor=code-quality-auditor, location=hooks/lib_receipts.py
+            (NOT in the surface-block path-glob list — this is a non-ctl.py hooks file).
+          - Task at SPEC_REVIEW, classification risk_level=low, domains=['backend'].
+
+        Sequence:
+          1. set-auto-approve-gates  → manifest.auto_approve_gates=true
+          2. apply-auto-approve-veto → decision='auto' (does NOT downgrade)
+          3. approve-stage SPEC_REVIEW --auto-approved  → auto-approval-SPEC_REVIEW.json written
+          4. approve-stage PLAN_REVIEW --auto-approved  → auto-approval-PLAN_REVIEW.json written
+          5. approve-stage TDD_REVIEW  --auto-approved  → auto-approval-TDD_REVIEW.json written
+          6. manifest stage advances through SPEC_REVIEW approval gate to PLANNING.
+
+        This test is intentionally RED until seg-3 (ctl.py commands) is implemented.
+        """
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+
+        # Task at SPEC_REVIEW, no pre-settled classification (set-auto-approve-gates needs pre-classification)
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            classification=None,  # not yet classified
+        )
+        # Overwrite manifest to remove the classification field entirely
+        manifest_data = json.loads((task_dir / "manifest.json").read_text())
+        manifest_data.pop("classification", None)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest_data, indent=2))
+
+        # Queue row: safe auditor, location NOT in surface-block list
+        row = _default_row(
+            rid="res-e2e-001",
+            source_auditor="code-quality-auditor",
+            location="hooks/lib_receipts.py",
+        )
+        _make_queue(root, row)
+
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=False)
+
+        # Step 1: set-auto-approve-gates must exit 0 and write manifest.auto_approve_gates=true
+        r_set = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r_set.returncode == 0, (
+            f"set-auto-approve-gates failed: {r_set.stderr!r}"
+        )
+        manifest_after_set = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest_after_set.get("auto_approve_gates") is True, (
+            "manifest.auto_approve_gates must be true after set-auto-approve-gates"
+        )
+
+        # Step 2: settle classification so apply-auto-approve-veto can run
+        manifest_after_set["classification"] = {
+            "type": "feature",
+            "domains": ["backend"],
+            "risk_level": "low",
+            "notes": "low-risk backend change",
+            "tdd_required": False,
+        }
+        (task_dir / "manifest.json").write_text(json.dumps(manifest_after_set, indent=2))
+        # Write raw-input.md sentinel for veto to locate the residual row
+        (task_dir / "raw-input.md").write_text(
+            f"<!-- residual-id: {row['id']} -->\nResidual input."
+        )
+
+        # Step 3: apply-auto-approve-veto must exit 0 and NOT downgrade (decision='auto')
+        r_veto = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r_veto.returncode == 0, (
+            f"apply-auto-approve-veto failed: {r_veto.stderr!r}"
+        )
+        veto_out = json.loads(r_veto.stdout)
+        assert veto_out.get("decision") == "auto", (
+            f"apply-auto-approve-veto must not downgrade low-risk task; got decision={veto_out.get('decision')!r}"
+        )
+        manifest_after_veto = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest_after_veto.get("auto_approve_gates") is True, (
+            "apply-auto-approve-veto must NOT downgrade auto_approve_gates for low-risk task"
+        )
+
+        # Step 4: approve-stage SPEC_REVIEW --auto-approved → writes auto-approval-SPEC_REVIEW.json
+        r_spec = _run("approve-stage", str(task_dir), "SPEC_REVIEW", "--auto-approved", cwd=root)
+        assert r_spec.returncode == 0, (
+            f"approve-stage SPEC_REVIEW --auto-approved failed: {r_spec.stderr!r}"
+        )
+        assert (task_dir / "receipts" / "auto-approval-SPEC_REVIEW.json").exists(), (
+            "auto-approval-SPEC_REVIEW.json must be written"
+        )
+
+        # Step 5: approve-stage PLAN_REVIEW --auto-approved → writes auto-approval-PLAN_REVIEW.json
+        #   (task must be at PLAN_REVIEW stage for this to work; advance the stage manually)
+        manifest_spec_approved = json.loads((task_dir / "manifest.json").read_text())
+        manifest_spec_approved["stage"] = "PLAN_REVIEW"
+        (task_dir / "plan.md").write_text(PLAN_CONTENT)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest_spec_approved, indent=2))
+        r_plan = _run("approve-stage", str(task_dir), "PLAN_REVIEW", "--auto-approved", cwd=root)
+        assert r_plan.returncode == 0, (
+            f"approve-stage PLAN_REVIEW --auto-approved failed: {r_plan.stderr!r}"
+        )
+        assert (task_dir / "receipts" / "auto-approval-PLAN_REVIEW.json").exists(), (
+            "auto-approval-PLAN_REVIEW.json must be written"
+        )
+
+        # Step 6: approve-stage TDD_REVIEW --auto-approved → writes auto-approval-TDD_REVIEW.json
+        manifest_plan_approved = json.loads((task_dir / "manifest.json").read_text())
+        manifest_plan_approved["stage"] = "TDD_REVIEW"
+        (task_dir / "evidence").mkdir(exist_ok=True)
+        (task_dir / "evidence" / "tdd-tests.md").write_text(TDD_EVIDENCE_CONTENT)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest_plan_approved, indent=2))
+        r_tdd = _run("approve-stage", str(task_dir), "TDD_REVIEW", "--auto-approved", cwd=root)
+        assert r_tdd.returncode == 0, (
+            f"approve-stage TDD_REVIEW --auto-approved failed: {r_tdd.stderr!r}"
+        )
+        assert (task_dir / "receipts" / "auto-approval-TDD_REVIEW.json").exists(), (
+            "auto-approval-TDD_REVIEW.json must be written"
+        )
+
+        # Step 7: manifest stage advances through SPEC_REVIEW gate
+        # (The stage transitions were driven by approve-stage above; verify final receipt state)
+        receipts_dir = task_dir / "receipts"
+        for stage_label in ("SPEC_REVIEW", "PLAN_REVIEW", "TDD_REVIEW"):
+            receipt_file = receipts_dir / f"auto-approval-{stage_label}.json"
+            assert receipt_file.exists(), f"auto-approval-{stage_label}.json must exist"
+            receipt_data = json.loads(receipt_file.read_text())
+            assert receipt_data.get("valid") is True, (
+                f"auto-approval-{stage_label}.json must have valid=true"
+            )

--- a/tests/test_auto_approve_gates.py
+++ b/tests/test_auto_approve_gates.py
@@ -1,0 +1,1526 @@
+"""TDD-First test suite for task-20260505-001: Auto-Approve Gates.
+
+Every acceptance criterion (AC-1 through AC-24) in
+.dynos/task-20260505-001/spec.md is covered here.  Tests are
+intentionally RED until the production code in seg-1 through seg-4 is
+implemented.  No production functions are stubbed; tests import real
+symbols and assert against real behaviour.
+
+Audit-finding fixes embedded:
+  sc-001 — three distinct _LOG_MESSAGES keys (test_log_messages_three_distinct_keys)
+  sc-002 — non-zero return path from veto also logged (test_apply_veto_crash_degrades_gracefully)
+  sc-003 — no-residual-row schema complete (test_apply_veto_no_residual_row_schema_complete)
+  sc-004 — receipt payload has no duplicate contract_version field
+           (test_receipt_auto_approval_no_duplicate_contract_version)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "hooks"
+
+# ---------------------------------------------------------------------------
+# Helpers shared across the suite
+# ---------------------------------------------------------------------------
+
+SPEC_CONTENT = (
+    "# Spec\n\n"
+    "## Task Summary\nTest.\n\n"
+    "## User Context\nU.\n\n"
+    "## Acceptance Criteria\n1. one\n\n"
+    "## Implicit Requirements Surfaced\nI.\n\n"
+    "## Out of Scope\nO.\n\n"
+    "## Assumptions\nsafe assumption: none\n\n"
+    "## Risk Notes\nR.\n"
+)
+
+PLAN_CONTENT = (
+    "# Plan\n\n"
+    "## Technical Approach\nA.\n\n"
+    "## Components / Modules\n### Component: Foo\n- **Purpose:** p\n- **Files:** `a.py`\n\n"
+    "## API Contracts\nNone.\n\n"
+    "## Data Flow\nNone.\n\n"
+    "## Error Handling Strategy\nNone.\n\n"
+    "## Test Strategy\nNone.\n\n"
+    "## Dependency Graph\n```\nnone\n```\n"
+)
+
+TDD_EVIDENCE_CONTENT = "# TDD Evidence\n\nAll tests pass.\n"
+
+
+def _env(dynos_home: Path | None = None) -> dict[str, str]:
+    e = {**os.environ, "PYTHONPATH": str(HOOKS)}
+    if dynos_home is not None:
+        e["DYNOS_HOME"] = str(dynos_home)
+    return e
+
+
+def _run(
+    *args: str,
+    dynos_home: Path | None = None,
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(HOOKS / "ctl.py"), *args],
+        cwd=str(cwd or ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=_env(dynos_home),
+    )
+
+
+def _make_task(
+    tmp_path: Path,
+    *,
+    task_id: str = "task-20260505-test",
+    stage: str = "SPEC_REVIEW",
+    auto_approve_gates: bool | None = None,
+    classification: dict | None = None,
+    fast_track: bool = False,
+    tdd_required: bool = False,
+) -> Path:
+    """Create a minimal task directory with manifest.json."""
+    task_dir = tmp_path / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    cls = classification or {
+        "type": "feature",
+        "domains": ["backend"],
+        "risk_level": "low",
+        "notes": "n",
+        "tdd_required": tdd_required,
+    }
+    manifest: dict = {
+        "task_id": task_id,
+        "created_at": "2026-05-05T00:00:00Z",
+        "title": "Auto-approve test",
+        "raw_input": "x",
+        "stage": stage,
+        "classification": cls,
+        "retry_counts": {},
+        "blocked_reason": None,
+        "completion_at": None,
+    }
+    if auto_approve_gates is not None:
+        manifest["auto_approve_gates"] = auto_approve_gates
+    if fast_track:
+        manifest["fast_track"] = True
+    (task_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    (task_dir / "spec.md").write_text(SPEC_CONTENT)
+    return task_dir
+
+
+def _make_queue(tmp_path: Path, row: dict) -> Path:
+    """Write a minimal proactive-findings.json with a single row."""
+    q_path = tmp_path / ".dynos" / "proactive-findings.json"
+    q_path.parent.mkdir(parents=True, exist_ok=True)
+    q_path.write_text(json.dumps({"findings": [row]}, indent=2))
+    return q_path
+
+
+def _default_row(
+    *,
+    rid: str = "res-001",
+    source_auditor: str = "code-quality-auditor",
+    location: str = "lib/utils.py",
+    status: str = "pending",
+) -> dict:
+    return {
+        "id": rid,
+        "source_auditor": source_auditor,
+        "location": location,
+        "description": "A test finding",
+        "status": status,
+        "attempts": 0,
+        "created_at": "2026-05-05T00:00:00Z",
+    }
+
+
+def _write_policy(persistent_dir: Path, *, disabled: bool = False) -> None:
+    persistent_dir.mkdir(parents=True, exist_ok=True)
+    (persistent_dir / "policy.json").write_text(
+        json.dumps({"auto_approve_gates_disabled": disabled})
+    )
+
+
+def _project_slug(root: Path) -> str:
+    return str(root.resolve()).strip("/").replace("/", "-")
+
+
+def _persistent_dir(dynos_home: Path, root: Path) -> Path:
+    slug = _project_slug(root)
+    return dynos_home / "projects" / slug
+
+
+def _write_receipt_file(task_dir: Path, step: str, payload: dict) -> Path:
+    """Write a receipt JSON file directly (bypasses write_receipt pipeline)."""
+    receipts = task_dir / "receipts"
+    receipts.mkdir(parents=True, exist_ok=True)
+    receipt = {
+        "step": step,
+        "ts": "2026-05-05T00:00:00Z",
+        "valid": True,
+        "contract_version": 6,  # post-bump version
+        **payload,
+    }
+    p = receipts / f"{step}.json"
+    p.write_text(json.dumps(receipt, indent=2))
+    return p
+
+
+# ===========================================================================
+# AC-1: manifest.auto_approve_gates field — defaults false, exclusive writer
+# ===========================================================================
+
+class TestManifestField:
+    """AC-1: auto_approve_gates field semantics."""
+
+    def test_manifest_field_default_false(self, tmp_path: Path):
+        """AC-1: absent auto_approve_gates in manifest is treated as false."""
+        task_dir = _make_task(tmp_path)
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        # The field should either be absent (defaulting to false) or explicitly false.
+        assert manifest.get("auto_approve_gates", False) is False
+
+    def test_manifest_field_writable_only_by_set_command(self, tmp_path: Path):
+        """AC-1: only set-auto-approve-gates can write auto_approve_gates=true.
+
+        This test documents the invariant: if the flag is set to true by any
+        path other than the canonical set-auto-approve-gates command, that is
+        a spec violation.  We verify the flag is absent from a freshly-created
+        task (so no other path is writing it).
+        """
+        task_dir = _make_task(tmp_path)
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert "auto_approve_gates" not in manifest or manifest["auto_approve_gates"] is False
+
+
+# ===========================================================================
+# AC-2: argparse registration for set-auto-approve-gates
+# ===========================================================================
+
+class TestArgparseRegistration:
+    """AC-2: set-auto-approve-gates CLI registration."""
+
+    def test_set_auto_approve_gates_argparse_registration(self, tmp_path: Path):
+        """AC-2: --help exits 0 and names both required flags."""
+        r = _run("set-auto-approve-gates", "--help")
+        assert r.returncode == 0, r.stderr
+        assert "--task-dir" in r.stdout
+        assert "--from-residual-id" in r.stdout
+
+    def test_apply_auto_approve_veto_argparse_registration(self, tmp_path: Path):
+        """AC-5/IR-1: apply-auto-approve-veto is registered as a top-level subcommand."""
+        r = _run("apply-auto-approve-veto", "--help")
+        assert r.returncode == 0, r.stderr
+        assert "--task-dir" in r.stdout
+
+    def test_approve_stage_auto_approved_flag_registered(self, tmp_path: Path):
+        """AC-7: --auto-approved flag appears in approve-stage --help."""
+        r = _run("approve-stage", "--help")
+        assert r.returncode == 0, r.stderr
+        assert "--auto-approved" in r.stdout
+
+
+# ===========================================================================
+# AC-3 / AC-21a-d: set-auto-approve-gates pick-time ceilings
+# ===========================================================================
+
+class TestSetAutoApproveGatesCeilings:
+    """AC-3: pick-time ceiling checks for set-auto-approve-gates."""
+
+    def test_security_auditor_row_blocked(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AC-3a / AC-21a: source_auditor=security-auditor -> exits 1, stderr contains 'security-auditor'."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="security-auditor")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "security-auditor" in r.stderr
+
+    def test_set_auto_approve_gates_security_auditor_blocked(self, tmp_path: Path):
+        """AC-21a exact name: security-auditor ceiling blocks and exits 1."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="security-auditor")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "security-auditor" in r.stderr
+
+    def test_high_risk_blocked(self, tmp_path: Path):
+        """AC-3b / AC-21b: source_auditor not in allowlist -> exits 1."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="spec-completion-auditor")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+
+    def test_set_auto_approve_gates_allowlist_blocked(self, tmp_path: Path):
+        """AC-21b exact name: non-allowlist auditor exits 1."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="spec-completion-auditor")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+
+    def test_set_auto_approve_gates_empty_location_blocked(self, tmp_path: Path):
+        """AC-3c / AC-21c: empty location -> exits 1, stderr contains 'location'."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(location="")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "location" in r.stderr
+
+    def test_global_policy_disable_blocked(self, tmp_path: Path):
+        """AC-3d / AC-21d: global policy disabled -> exits 1, stderr contains 'policy'."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=True)
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "policy" in r.stderr
+
+    def test_set_auto_approve_gates_global_policy_disabled(self, tmp_path: Path):
+        """AC-21d exact name: policy disabled blocks set-auto-approve-gates."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=True)
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "policy" in r.stderr
+
+    def test_set_auto_approve_gates_success_stdout_json(self, tmp_path: Path):
+        """AC-3 happy path: all ceilings pass -> exits 0, stdout is parseable JSON."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="code-quality-auditor", location="lib/utils.py")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=False)
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["auto_approve_gates"] is True
+        assert "task_id" in out
+        assert "ceiling_checked" in out
+
+    def test_set_auto_approve_gates_manifest_written(self, tmp_path: Path):
+        """AC-3 success: manifest.auto_approve_gates=true after command exits 0."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row(source_auditor="code-quality-auditor", location="lib/utils.py")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=False)
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest.get("auto_approve_gates") is True
+
+
+# ===========================================================================
+# AC-4: idempotency and post-classification refusal
+# ===========================================================================
+
+class TestSetAutoApproveGatesIdempotencyAndClassification:
+    """AC-4: idempotent when already true; refuses after classification."""
+
+    def test_set_auto_approve_gates_refuses_false_to_true_after_classification(
+        self, tmp_path: Path
+    ):
+        """AC-4: if manifest.classification is non-null, refuses with 'classification already settled'."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        # Task with classification already present
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        # Must exit 1 because classification is already settled
+        assert r.returncode == 1
+        assert "classification already settled" in r.stderr
+
+    def test_set_auto_approve_gates_idempotent_when_already_true(
+        self, tmp_path: Path
+    ):
+        """AC-4: if manifest.auto_approve_gates is already true, exits 0 without re-evaluating ceilings."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        # Manifest without classification (so set command can run), auto_approve_gates=true
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW", auto_approve_gates=True)
+        # Remove classification to simulate pre-classification state with flag already set
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest.pop("classification", None)
+        manifest["auto_approve_gates"] = True
+        (task_dir / "manifest.json").write_text(json.dumps(manifest))
+        row = _default_row(source_auditor="security-auditor")  # Would normally block
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        # Should exit 0 idempotently, not re-evaluate the security-auditor ceiling
+        assert r.returncode == 0, r.stderr
+
+    def test_set_auto_approve_gates_missing_manifest(self, tmp_path: Path):
+        """IR-5: missing manifest.json -> exits 1 with 'manifest.json missing'."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        nonexistent_dir = tmp_path / ".dynos" / "task-nonexistent"
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(nonexistent_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "manifest.json missing" in r.stderr
+
+
+# ===========================================================================
+# AC-5 / AC-21e-f, AC-21k: apply-auto-approve-veto classification ceilings
+# ===========================================================================
+
+class TestApplyAutoApproveVetoCeilings:
+    """AC-5: classification-time ceiling checks for apply-auto-approve-veto."""
+
+    def _make_classified_task(
+        self,
+        tmp_path: Path,
+        *,
+        risk_level: str = "low",
+        domains: list[str] | None = None,
+        auto_approve_gates: bool = True,
+        residual_id: str = "res-001",
+    ) -> tuple[Path, Path]:
+        """Build a task directory with a settled classification."""
+        domains = domains or ["backend"]
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            auto_approve_gates=auto_approve_gates,
+            classification={
+                "type": "feature",
+                "domains": domains,
+                "risk_level": risk_level,
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        # Write raw-input.md with residual-id sentinel
+        (task_dir / "raw-input.md").write_text(
+            f"<!-- residual-id: {residual_id} -->\nSome raw input."
+        )
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        return task_dir, root
+
+    def test_apply_auto_approve_veto_high_risk_blocks(self, tmp_path: Path):
+        """AC-5a / AC-21e: risk_level=high -> decision=blocked, auto_approve_gates=false."""
+        task_dir, root = self._make_classified_task(tmp_path, risk_level="high")
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["decision"] == "blocked"
+        assert out["auto_approve_gates"] is False
+
+    def test_apply_auto_approve_veto_critical_risk_blocks(self, tmp_path: Path):
+        """AC-5a: risk_level=critical -> decision=blocked."""
+        task_dir, root = self._make_classified_task(tmp_path, risk_level="critical")
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["decision"] == "blocked"
+        assert out["auto_approve_gates"] is False
+
+    def test_apply_auto_approve_veto_security_domain_blocks(self, tmp_path: Path):
+        """AC-5b / AC-21f: domains=['security'] -> decision=blocked."""
+        task_dir, root = self._make_classified_task(tmp_path, domains=["security"])
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["decision"] == "blocked"
+        assert out["auto_approve_gates"] is False
+
+    def test_global_policy_disable_veto(self, tmp_path: Path):
+        """AC-5d / AC-21k: global policy disabled -> apply-auto-approve-veto sets flag=false."""
+        task_dir, root = self._make_classified_task(tmp_path, risk_level="low")
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=True)
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["decision"] == "blocked"
+        assert out["auto_approve_gates"] is False
+
+    def test_apply_auto_approve_veto_missing_risk_level_blocked(self, tmp_path: Path):
+        """AC-5e: absent/null risk_level -> blocked (fail-closed)."""
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            auto_approve_gates=True,
+            classification={
+                "type": "feature",
+                "domains": ["backend"],
+                "risk_level": None,
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        (task_dir / "raw-input.md").write_text("<!-- residual-id: res-001 -->\nRaw.")
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["decision"] == "blocked"
+
+    def test_apply_auto_approve_veto_no_classification_refuses(self, tmp_path: Path):
+        """IR-6: classification not settled -> exits 1 with 'classification not settled'."""
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        # Remove classification
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest["classification"] = None
+        (task_dir / "manifest.json").write_text(json.dumps(manifest))
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 1
+        assert "classification not settled" in r.stderr
+
+    def test_apply_auto_approve_veto_downgrade_only(self, tmp_path: Path):
+        """AC-5: veto cannot raise false -> true; can only confirm or downgrade."""
+        task_dir, root = self._make_classified_task(
+            tmp_path, risk_level="low", auto_approve_gates=False
+        )
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        # Must remain false — veto cannot raise it
+        assert manifest.get("auto_approve_gates", False) is False
+
+
+# ===========================================================================
+# AC-6: auto_approval_policy schema completeness
+# ===========================================================================
+
+class TestAutoApprovalPolicySchema:
+    """AC-6: classification.auto_approval_policy exact JSON shape."""
+
+    def test_auto_approval_policy_schema_complete(self, tmp_path: Path):
+        """AC-6 / AC-21l (schema variant): apply-auto-approve-veto writes policy with all required fields."""
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            auto_approve_gates=True,
+            classification={
+                "type": "feature",
+                "domains": ["backend"],
+                "risk_level": "low",
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        (task_dir / "raw-input.md").write_text("<!-- residual-id: res-001 -->\nRaw.")
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        row = _default_row(rid="res-001", location="lib/utils.py")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        policy = manifest.get("classification", {}).get("auto_approval_policy")
+        assert policy is not None, "auto_approval_policy must be written to manifest"
+        assert "decision" in policy
+        assert policy["decision"] in {"auto", "blocked"}
+        basis = policy.get("basis", {})
+        assert "risk_level" in basis
+        assert "domains" in basis
+        assert "source_auditor" in basis
+        assert "external_surface_path_match" in basis
+        assert "global_policy_disabled" in basis
+        assert "ceilings_checked" in policy
+        assert "blocked_by" in policy
+        assert set(policy["ceilings_checked"]) == {
+            "risk_level",
+            "domain_security",
+            "source_auditor_security",
+            "external_surface_path",
+            "source_auditor_allowlist",
+            "global_policy",
+        }
+
+    def test_apply_veto_no_residual_row_schema_complete(self, tmp_path: Path):
+        """AC-6 / sc-003: when no residual row is found, policy.basis has all fields populated.
+
+        source_auditor=null, external_surface_path_match=false, no_residual_row=true.
+        The absence of a row must NOT produce a malformed policy object.
+        """
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            auto_approve_gates=True,
+            classification={
+                "type": "feature",
+                "domains": ["backend"],
+                "risk_level": "low",
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        # raw-input.md has no residual-id sentinel
+        (task_dir / "raw-input.md").write_text("No sentinel here.")
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        # Empty queue — no matching row
+        _make_queue(root, _default_row(rid="res-different"))
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        policy = manifest.get("classification", {}).get("auto_approval_policy")
+        assert policy is not None, "auto_approval_policy must be present even with no row"
+        basis = policy.get("basis", {})
+        # All required basis fields must be explicitly present
+        assert "risk_level" in basis
+        assert "domains" in basis
+        assert "source_auditor" in basis
+        assert basis["source_auditor"] is None
+        assert "external_surface_path_match" in basis
+        assert basis["external_surface_path_match"] is False
+        assert "global_policy_disabled" in basis
+        # The no_residual_row disambiguator
+        assert basis.get("no_residual_row") is True
+
+    def test_classification_json_receives_auto_approval_policy(self, tmp_path: Path):
+        """AC-6: classification.json gets auto_approval_policy at top level via _persist_classification."""
+        task_dir = _make_task(
+            tmp_path / "td",
+            stage="SPEC_REVIEW",
+            auto_approve_gates=True,
+            classification={
+                "type": "feature",
+                "domains": ["backend"],
+                "risk_level": "low",
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        (task_dir / "raw-input.md").write_text("<!-- residual-id: res-001 -->\nRaw.")
+        root = tmp_path / "project"
+        root.mkdir(exist_ok=True)
+        (root / ".dynos").mkdir(exist_ok=True)
+        row = _default_row(rid="res-001")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        r = _run(
+            "apply-auto-approve-veto",
+            "--task-dir", str(task_dir),
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+        cls_json_path = task_dir.parent.parent / ".dynos" / task_dir.name / "classification.json"
+        # Also check the standard path: .dynos/task-{id}/classification.json
+        cls_json_path2 = task_dir / "classification.json"
+        if cls_json_path2.exists():
+            cls_data = json.loads(cls_json_path2.read_text())
+            assert "auto_approval_policy" in cls_data
+
+
+# ===========================================================================
+# AC-7: approve-stage --auto-approved flag
+# ===========================================================================
+
+class TestApproveStageAutoApproved:
+    """AC-7: --auto-approved flag behaviour on approve-stage."""
+
+    def test_approve_stage_auto_writes_correct_receipt_stem(self, tmp_path: Path):
+        """AC-7 / AC-21f-proxy: --auto-approved writes auto-approval-{stage}.json, not human-approval."""
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW", auto_approve_gates=True)
+        r = _run("approve-stage", str(task_dir), "SPEC_REVIEW", "--auto-approved")
+        assert r.returncode == 0, r.stderr
+        auto_receipt = task_dir / "receipts" / "auto-approval-SPEC_REVIEW.json"
+        human_receipt = task_dir / "receipts" / "human-approval-SPEC_REVIEW.json"
+        assert auto_receipt.exists(), "auto-approval receipt must be written"
+        assert not human_receipt.exists(), "human-approval receipt must NOT be written with --auto-approved"
+
+    def test_approve_stage_auto_stdout_format(self, tmp_path: Path):
+        """AC-7 / IR-7: stdout line contains 'auto-approved', stage name, sha256 prefix, next stage."""
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW", auto_approve_gates=True)
+        r = _run("approve-stage", str(task_dir), "SPEC_REVIEW", "--auto-approved")
+        assert r.returncode == 0, r.stderr
+        assert "auto-approved" in r.stdout
+        assert "SPEC_REVIEW" in r.stdout
+        assert "PLANNING" in r.stdout
+
+    def test_approve_stage_auto_flag_false_in_manifest_exits_1(self, tmp_path: Path):
+        """AC-7: --auto-approved fails with 'auto_approve_gates is not true' when flag is false."""
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW", auto_approve_gates=False)
+        r = _run("approve-stage", str(task_dir), "SPEC_REVIEW", "--auto-approved")
+        assert r.returncode == 1
+        assert "auto_approve_gates is not true" in r.stderr
+
+    def test_approve_stage_human_path_unchanged(self, tmp_path: Path):
+        """AC-7: WITHOUT --auto-approved, behavior is byte-identical to pre-task (human path)."""
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        r = _run("approve-stage", str(task_dir), "SPEC_REVIEW")
+        assert r.returncode == 0, r.stderr
+        human_receipt = task_dir / "receipts" / "human-approval-SPEC_REVIEW.json"
+        assert human_receipt.exists()
+        assert "approved SPEC_REVIEW" in r.stdout
+        assert "PLANNING" in r.stdout
+
+
+# ===========================================================================
+# AC-8 / AC-9: receipt_auto_approval function
+# ===========================================================================
+
+class TestReceiptAutoApproval:
+    """AC-8: receipt_auto_approval function in lib_receipts.py."""
+
+    def test_receipt_auto_approval_writes_file(self, tmp_path: Path):
+        """AC-8: receipt_auto_approval writes receipts/auto-approval-{stage}.json."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import receipt_auto_approval  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        sha = "a" * 64
+        receipt_path = receipt_auto_approval(task_dir, "SPEC_REVIEW", sha)
+        assert receipt_path.name == "auto-approval-SPEC_REVIEW.json"
+        data = json.loads(receipt_path.read_text())
+        assert data["step"] == "auto-approval-SPEC_REVIEW"
+        assert data["artifact_sha256"] == sha
+        assert data["approver"] == "auto:residual-skill"
+        assert data["kind"] == "auto"
+
+    def test_receipt_auto_approval_contract_version_6(self, tmp_path: Path):
+        """AC-8 / AC-9: receipt carries contract_version=6."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import receipt_auto_approval  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        sha = "b" * 64
+        receipt_path = receipt_auto_approval(task_dir, "SPEC_REVIEW", sha)
+        data = json.loads(receipt_path.read_text())
+        assert data["contract_version"] == 6
+
+    def test_receipt_auto_approval_no_duplicate_contract_version(self, tmp_path: Path):
+        """AC-8 / sc-004: receipt payload must NOT have contract_version duplicated.
+
+        write_receipt injects contract_version at the top level. receipt_auto_approval
+        must NOT also pass contract_version=6 as a kwarg — doing so would create two
+        identical keys (silently collapsing to the last value, but semantically wrong).
+        We verify the receipt has exactly one contract_version key at the top level.
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import receipt_auto_approval  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        sha = "c" * 64
+        receipt_path = receipt_auto_approval(task_dir, "SPEC_REVIEW", sha)
+        raw = receipt_path.read_text()
+        data = json.loads(raw)
+        # JSON spec: a JSON object's keys should be unique. Verify no duplication
+        # by counting occurrences of the key string in the raw text.
+        assert raw.count('"contract_version"') == 1, (
+            "contract_version must appear exactly once in the receipt JSON"
+        )
+        assert data["contract_version"] == 6
+
+    def test_receipt_auto_approval_in_all(self, tmp_path: Path):
+        """AC-8: receipt_auto_approval is exported in __all__."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        import lib_receipts  # noqa: PLC0415
+        assert "receipt_auto_approval" in lib_receipts.__all__
+
+
+# ===========================================================================
+# AC-9: RECEIPT_CONTRACT_VERSION bumped to 6
+# ===========================================================================
+
+class TestContractVersionBump:
+    """AC-9: RECEIPT_CONTRACT_VERSION == 6."""
+
+    def test_receipt_contract_version_is_6(self):
+        """AC-9: RECEIPT_CONTRACT_VERSION must be 6 after the bump."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import RECEIPT_CONTRACT_VERSION  # noqa: PLC0415
+        assert RECEIPT_CONTRACT_VERSION == 6
+
+
+# ===========================================================================
+# AC-10: MIN_VERSION_PER_STEP has auto-approval-* entry
+# ===========================================================================
+
+class TestMinVersionPerStep:
+    """AC-10: auto-approval-* floor added to MIN_VERSION_PER_STEP."""
+
+    def test_min_version_auto_approval_wildcard_entry(self):
+        """AC-10: 'auto-approval-*': 6 exists in MIN_VERSION_PER_STEP."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import MIN_VERSION_PER_STEP  # noqa: PLC0415
+        assert "auto-approval-*" in MIN_VERSION_PER_STEP
+        assert MIN_VERSION_PER_STEP["auto-approval-*"] == 6
+
+    def test_min_version_human_approval_unchanged(self):
+        """AC-10: existing 'human-approval-*': 2 entry is unchanged."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import MIN_VERSION_PER_STEP  # noqa: PLC0415
+        assert MIN_VERSION_PER_STEP.get("human-approval-*") == 2
+
+    def test_resolve_min_version_auto_approval_spec_review(self):
+        """AC-10: _resolve_min_version('auto-approval-SPEC_REVIEW') returns 6."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import _resolve_min_version  # noqa: PLC0415
+        assert _resolve_min_version("auto-approval-SPEC_REVIEW") == 6
+
+    def test_resolve_min_version_auto_approval_plan_review(self):
+        """AC-10: _resolve_min_version('auto-approval-PLAN_REVIEW') returns 6."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import _resolve_min_version  # noqa: PLC0415
+        assert _resolve_min_version("auto-approval-PLAN_REVIEW") == 6
+
+    def test_resolve_min_version_auto_approval_tdd_review(self):
+        """AC-10: _resolve_min_version('auto-approval-TDD_REVIEW') returns 6."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import _resolve_min_version  # noqa: PLC0415
+        assert _resolve_min_version("auto-approval-TDD_REVIEW") == 6
+
+
+# ===========================================================================
+# AC-11: _LOG_MESSAGES has three exact auto-approval keys
+# ===========================================================================
+
+class TestLogMessages:
+    """AC-11: _LOG_MESSAGES three distinct auto-approval entries."""
+
+    def test_log_messages_three_distinct_keys(self):
+        """AC-11 / sc-001: _LOG_MESSAGES must have exactly three distinct auto-approval keys.
+
+        The audit found a duplicate-key bug where 'auto-approval-PLAN_REVIEW' was
+        used as a key twice instead of 'auto-approval-TDD_REVIEW' for the third entry.
+        This test asserts all three distinct keys are present.
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import _LOG_MESSAGES  # noqa: PLC0415
+        assert "auto-approval-SPEC_REVIEW" in _LOG_MESSAGES
+        assert "auto-approval-PLAN_REVIEW" in _LOG_MESSAGES
+        assert "auto-approval-TDD_REVIEW" in _LOG_MESSAGES
+        # Verify the values are distinct (each step has its own message)
+        assert _LOG_MESSAGES["auto-approval-SPEC_REVIEW"] != _LOG_MESSAGES["auto-approval-TDD_REVIEW"]
+        assert _LOG_MESSAGES["auto-approval-PLAN_REVIEW"] != _LOG_MESSAGES["auto-approval-TDD_REVIEW"]
+        # Confirm correct substring in each value
+        assert "SPEC_REVIEW" in _LOG_MESSAGES["auto-approval-SPEC_REVIEW"]
+        assert "PLAN_REVIEW" in _LOG_MESSAGES["auto-approval-PLAN_REVIEW"]
+        assert "TDD_REVIEW" in _LOG_MESSAGES["auto-approval-TDD_REVIEW"]
+
+    def test_log_messages_auto_approval_format_has_approver(self):
+        """AC-11: each auto-approval log message template has {approver} placeholder."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import _LOG_MESSAGES  # noqa: PLC0415
+        for key in ("auto-approval-SPEC_REVIEW", "auto-approval-PLAN_REVIEW", "auto-approval-TDD_REVIEW"):
+            assert "{approver}" in _LOG_MESSAGES[key], f"Missing {{approver}} in {key}"
+
+
+# ===========================================================================
+# AC-12 / AC-13 / AC-14: transition_task gate extension
+# ===========================================================================
+
+class TestTransitionGateExtension:
+    """AC-12/13/14: _check_any_approval closure and hash-mismatch hardening."""
+
+    def _make_spec_review_task(self, tmp_path: Path) -> Path:
+        """Task at SPEC_REVIEW stage with spec.md."""
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW")
+        return task_dir
+
+    def test_auto_approval_receipt_satisfies_gate(self, tmp_path: Path):
+        """AC-12 / AC-21g: auto-approval-SPEC_REVIEW.json with correct hash satisfies the gate."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = self._make_spec_review_task(tmp_path)
+        sha = hash_file(task_dir / "spec.md")
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": sha})
+        # Should not raise
+        transition_task(task_dir, "PLANNING")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest["stage"] == "PLANNING"
+
+    def test_human_approval_receipt_still_satisfies_gate(self, tmp_path: Path):
+        """AC-12 / AC-21h: human-approval-SPEC_REVIEW.json still works (human path unbroken)."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = self._make_spec_review_task(tmp_path)
+        sha = hash_file(task_dir / "spec.md")
+        _write_receipt_file(task_dir, "human-approval-SPEC_REVIEW", {"artifact_sha256": sha, "approver": "human"})
+        transition_task(task_dir, "PLANNING")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest["stage"] == "PLANNING"
+
+    def test_hash_mismatch_on_auto_approval_receipt_refused(self, tmp_path: Path):
+        """AC-14 / AC-21i: tampered artifact_sha256 in auto-approval receipt -> ValueError with correct substrings."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        task_dir = self._make_spec_review_task(tmp_path)
+        tampered_sha = "0" * 64  # wrong hash
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": tampered_sha})
+        with pytest.raises(ValueError) as exc_info:
+            transition_task(task_dir, "PLANNING")
+        msg = str(exc_info.value)
+        assert "auto-approval-SPEC_REVIEW" in msg
+        assert "hash mismatch" in msg
+
+    def test_transition_task_accepts_auto_approval_receipt(self, tmp_path: Path):
+        """AC-14: transition_task proceeds when auto-approval receipt has matching hash."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = self._make_spec_review_task(tmp_path)
+        sha = hash_file(task_dir / "spec.md")
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": sha})
+        result = transition_task(task_dir, "PLANNING")
+        # No exception = success; manifest updated
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest["stage"] == "PLANNING"
+
+    def test_neither_receipt_found_refuses_with_both_names(self, tmp_path: Path):
+        """AC-12: when neither human nor auto receipt exists, error message contains both names."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        task_dir = self._make_spec_review_task(tmp_path)
+        with pytest.raises(ValueError) as exc_info:
+            transition_task(task_dir, "PLANNING")
+        msg = str(exc_info.value)
+        assert "human-approval-SPEC_REVIEW" in msg
+        assert "auto-approval-SPEC_REVIEW" in msg
+
+    def test_plan_review_auto_approval_satisfies_gate(self, tmp_path: Path):
+        """AC-12: auto-approval-PLAN_REVIEW satisfies PLAN_REVIEW -> PLAN_AUDIT gate."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="PLAN_REVIEW")
+        (task_dir / "plan.md").write_text(PLAN_CONTENT)
+        sha = hash_file(task_dir / "plan.md")
+        _write_receipt_file(task_dir, "auto-approval-PLAN_REVIEW", {"artifact_sha256": sha})
+        transition_task(task_dir, "PLAN_AUDIT")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest["stage"] == "PLAN_AUDIT"
+
+
+# ===========================================================================
+# AC-13: _human_approval_err mirror
+# ===========================================================================
+
+class TestHumanApprovalErrMirror:
+    """AC-13: _human_approval_err mirrors _check_any_approval OR-logic."""
+
+    def test_force_override_observability_on_previously_auto_approved_task(
+        self, tmp_path: Path
+    ):
+        """AC-13 / AC-21m: force-transition on a task where SPEC_REVIEW was auto-approved.
+
+        _compute_bypassed_gates_for_force uses the updated _human_approval_err.
+        The returned bypassed-gates list must be empty (auto-approval satisfies the gate).
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_core import transition_task  # noqa: PLC0415
+        from lib_receipts import hash_file  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="SPEC_REVIEW", auto_approve_gates=True)
+        sha = hash_file(task_dir / "spec.md")
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": sha})
+        # Force-transition should compute 0 bypassed gates because the
+        # auto-approval receipt satisfies the SPEC_REVIEW gate
+        _, updated_manifest = transition_task(
+            task_dir,
+            "PLANNING",
+            force=True,
+            force_reason="test override",
+            force_approver="test-operator",
+        )
+        # Look for the force-override receipt which carries bypassed_gates
+        override_receipts = list((task_dir / "receipts").glob("force-override-*.json"))
+        if override_receipts:
+            receipt_data = json.loads(override_receipts[0].read_text())
+            bypassed = receipt_data.get("bypassed_gates", [])
+            assert bypassed == [], (
+                f"bypassed_gates must be empty when auto-approval receipt satisfies the gate; got {bypassed}"
+            )
+
+
+# ===========================================================================
+# AC-19 / AC-21j: receipt_retrospective auto-approval fields
+# ===========================================================================
+
+class TestRetrospectiveAutoApprovalFields:
+    """AC-19: receipt_retrospective self-computes gates_auto_approved and auto_approved_stages."""
+
+    def _make_done_task(self, tmp_path: Path) -> Path:
+        """Task at DONE stage with all required artifacts for retrospective."""
+        task_dir = _make_task(tmp_path, stage="DONE")
+        (task_dir / "plan.md").write_text(PLAN_CONTENT)
+        (task_dir / "evidence").mkdir(exist_ok=True)
+        (task_dir / "evidence" / "tdd-tests.md").write_text(TDD_EVIDENCE_CONTENT)
+        (task_dir / "task-retrospective.json").write_text(
+            json.dumps({"task_id": task_dir.name, "quality": 0.8})
+        )
+        return task_dir
+
+    def test_retrospective_gates_auto_approved_count(self, tmp_path: Path):
+        """AC-19 / AC-21j: two auto-approval receipts -> gates_auto_approved=2, auto_approved_stages sorted."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import receipt_retrospective  # noqa: PLC0415
+        task_dir = self._make_done_task(tmp_path)
+        # Write two auto-approval receipts
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": "a" * 64})
+        _write_receipt_file(task_dir, "auto-approval-PLAN_REVIEW", {"artifact_sha256": "b" * 64})
+        receipt_path = receipt_retrospective(task_dir)
+        retro = json.loads(receipt_path.read_text())
+        assert retro.get("gates_auto_approved") == 2
+        assert retro.get("auto_approved_stages") == ["PLAN_REVIEW", "SPEC_REVIEW"]
+
+    def test_retrospective_zero_auto_approved_stages(self, tmp_path: Path):
+        """AC-19: no auto-approval receipts -> gates_auto_approved=0, auto_approved_stages=[]."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import receipt_retrospective  # noqa: PLC0415
+        task_dir = self._make_done_task(tmp_path)
+        # No auto-approval receipts
+        receipt_path = receipt_retrospective(task_dir)
+        retro = json.loads(receipt_path.read_text())
+        assert retro.get("gates_auto_approved", 0) == 0
+        assert retro.get("auto_approved_stages", []) == []
+
+
+# ===========================================================================
+# AC-22: external surface path glob patterns
+# ===========================================================================
+
+@pytest.mark.parametrize(
+    "location,should_block",
+    [
+        ("hooks/ctl.py", True),               # exact match
+        ("skills/residual/SKILL.md", True),    # skills/**/SKILL.md
+        ("skills/start/SKILL.md", True),       # skills/**/SKILL.md
+        ("agents/planner/design.md", True),    # agents/**/*.md
+        ("some/router/config.py", True),       # *router*
+        ("api/v1/endpoint.py", True),          # api/**
+        ("", True),                            # empty location
+        ("lib/utils.py", False),               # safe — should not block
+        ("tests/test_core.py", False),         # safe
+    ],
+)
+def test_external_surface_path_glob_blocks_each_pattern(
+    tmp_path: Path, location: str, should_block: bool
+):
+    """AC-22 / AC-21e (parameterized): each path glob pattern triggers (or doesn't trigger) the ceiling.
+
+    Tests both set-auto-approve-gates and the internal _check_external_surface_path logic.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".dynos").mkdir()
+    task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+    # Remove classification so set-auto-approve-gates can run pre-classification
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    manifest.pop("classification", None)
+    (task_dir / "manifest.json").write_text(json.dumps(manifest))
+    row = _default_row(source_auditor="code-quality-auditor", location=location)
+    _make_queue(root, row)
+    dynos_home = tmp_path / "home"
+    dynos_home.mkdir()
+    persistent = _persistent_dir(dynos_home, root)
+    _write_policy(persistent, disabled=False)
+    r = _run(
+        "set-auto-approve-gates",
+        "--task-dir", str(task_dir),
+        "--from-residual-id", row["id"],
+        dynos_home=dynos_home,
+        cwd=root,
+    )
+    if should_block:
+        assert r.returncode == 1, (
+            f"Expected blocking for location={location!r}, got exit 0 with stdout={r.stdout!r}"
+        )
+    else:
+        assert r.returncode == 0, (
+            f"Expected pass for location={location!r}, got exit 1 with stderr={r.stderr!r}"
+        )
+
+
+# ===========================================================================
+# AC-23: policy file path and semantics
+# ===========================================================================
+
+class TestPolicyFilePath:
+    """AC-23: policy.json under ~/.dynos/projects/{slug}/; missing = false (fail-open)."""
+
+    def test_missing_policy_file_treated_as_enabled(self, tmp_path: Path):
+        """AC-23: absent policy.json -> feature enabled (fail-open for the disable key)."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest.pop("classification", None)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest))
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        # No policy.json created — should behave as if feature enabled
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        # Should succeed (feature is enabled by default)
+        assert r.returncode == 0, r.stderr
+
+    def test_missing_key_in_policy_treated_as_enabled(self, tmp_path: Path):
+        """AC-23: policy.json exists but lacks auto_approve_gates_disabled -> enabled."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest.pop("classification", None)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest))
+        row = _default_row()
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        persistent.mkdir(parents=True)
+        (persistent / "policy.json").write_text(json.dumps({"some_other_key": True}))
+        r = _run(
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+            dynos_home=dynos_home,
+            cwd=root,
+        )
+        assert r.returncode == 0, r.stderr
+
+
+# ===========================================================================
+# AC-24: apply-auto-approve-veto in cmd_run_start_classification
+# ===========================================================================
+
+class TestApplyVetoCrashDegradeGracefully:
+    """AC-24: veto crash/non-zero return in cmd_run_start_classification degrades gracefully."""
+
+    def _make_classifiable_task(self, tmp_path: Path) -> Path:
+        """Task ready for run-start-classification."""
+        task_dir = _make_task(
+            tmp_path,
+            task_id="task-20260505-cls",
+            stage="CLASSIFY_AND_SPEC",
+            auto_approve_gates=True,
+            classification={
+                "type": "feature",
+                "domains": ["backend"],
+                "risk_level": "low",
+                "notes": "n",
+                "tdd_required": False,
+            },
+        )
+        return task_dir
+
+    @pytest.mark.parametrize(
+        "veto_side_effect",
+        [
+            "raise",    # monkeypatch raises RuntimeError
+            "return_1", # monkeypatch returns 1 (non-zero without exception)
+        ],
+    )
+    def test_apply_veto_crash_degrades_gracefully(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        veto_side_effect: str,
+    ):
+        """AC-24 / sc-002: both raise AND non-zero return from veto are logged; cmd_run_start_classification exits 0.
+
+        Case 'raise': monkeypatched veto raises RuntimeError.
+        Case 'return_1': monkeypatched veto returns 1 (integer, no exception).
+        Both cases: auto_approve_gates remains false (or its prior value), stderr has warning.
+        """
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        import importlib
+        import ctl as _ctl  # noqa: PLC0415 — direct import to monkeypatch
+
+        if veto_side_effect == "raise":
+            def _veto_raise(args):  # type: ignore[misc]
+                raise RuntimeError("veto simulated crash")
+            monkeypatch.setattr(_ctl, "cmd_apply_auto_approve_veto", _veto_raise)
+        else:
+            def _veto_return1(args):  # type: ignore[misc]
+                return 1
+            monkeypatch.setattr(_ctl, "cmd_apply_auto_approve_veto", _veto_return1)
+
+        task_dir = self._make_classifiable_task(tmp_path)
+        import argparse as _argparse
+        ns = _argparse.Namespace(task_dir=str(task_dir))
+        import io, contextlib
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            rc = _ctl.cmd_run_start_classification(ns)
+
+        # Must not abort (exit 0)
+        assert rc == 0, f"cmd_run_start_classification must exit 0 even when veto {veto_side_effect}s"
+        # Stderr must have a warning about the veto failure
+        stderr_text = stderr_buf.getvalue()
+        assert "veto" in stderr_text.lower() or "apply-auto-approve-veto" in stderr_text or "warn" in stderr_text.lower(), (
+            f"Expected veto warning on stderr but got: {stderr_text!r}"
+        )
+        # auto_approve_gates must remain false (degraded to human-approval behavior)
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        assert manifest.get("auto_approve_gates", False) is False, (
+            "auto_approve_gates must remain false when veto crashes"
+        )
+
+    def test_apply_veto_called_after_classification(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """AC-24: apply-auto-approve-veto is called after manifest.classification is settled."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        import ctl as _ctl  # noqa: PLC0415
+
+        veto_calls: list[object] = []
+        original_veto = getattr(_ctl, "cmd_apply_auto_approve_veto", None)
+
+        def _tracking_veto(args):  # type: ignore[misc]
+            veto_calls.append(args)
+            return 0
+
+        monkeypatch.setattr(_ctl, "cmd_apply_auto_approve_veto", _tracking_veto)
+
+        task_dir = self._make_classifiable_task(tmp_path)
+        import argparse as _argparse
+        ns = _argparse.Namespace(task_dir=str(task_dir))
+        rc = _ctl.cmd_run_start_classification(ns)
+        # The veto must have been called at least once
+        assert len(veto_calls) >= 1, "cmd_apply_auto_approve_veto must be called from cmd_run_start_classification"
+
+
+# ===========================================================================
+# AC-21l: race condition — LOCK_EX test
+# ===========================================================================
+
+class TestLockExRace:
+    """AC-21l: concurrent set-auto-approve-gates calls must not corrupt manifest.json."""
+
+    def test_set_auto_approve_gates_lock_ex_race(self, tmp_path: Path):
+        """AC-21l: two concurrent subprocesses calling set-auto-approve-gates produce valid JSON.
+
+        Final manifest.auto_approve_gates must be a valid boolean (true) and the file
+        must remain parseable.
+        """
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / ".dynos").mkdir()
+        task_dir = _make_task(tmp_path / "td", stage="SPEC_REVIEW")
+        # Remove classification so both calls can proceed
+        manifest = json.loads((task_dir / "manifest.json").read_text())
+        manifest.pop("classification", None)
+        (task_dir / "manifest.json").write_text(json.dumps(manifest))
+        row = _default_row(source_auditor="code-quality-auditor", location="lib/utils.py")
+        _make_queue(root, row)
+        dynos_home = tmp_path / "home"
+        dynos_home.mkdir()
+        persistent = _persistent_dir(dynos_home, root)
+        _write_policy(persistent, disabled=False)
+
+        cmd = [
+            sys.executable, str(HOOKS / "ctl.py"),
+            "set-auto-approve-gates",
+            "--task-dir", str(task_dir),
+            "--from-residual-id", row["id"],
+        ]
+        env = _env(dynos_home)
+
+        results: list[subprocess.CompletedProcess] = []
+
+        def _run_proc() -> None:
+            r = subprocess.run(cmd, cwd=str(root), text=True, capture_output=True, check=False, env=env)
+            results.append(r)
+
+        t1 = threading.Thread(target=_run_proc)
+        t2 = threading.Thread(target=_run_proc)
+        t1.start()
+        t2.start()
+        t1.join(timeout=30)
+        t2.join(timeout=30)
+
+        # At least one must succeed
+        assert any(r.returncode == 0 for r in results), (
+            f"At least one concurrent call must succeed; results: {[(r.returncode, r.stderr) for r in results]}"
+        )
+        # manifest.json must be valid JSON
+        raw = (task_dir / "manifest.json").read_text()
+        final_manifest = json.loads(raw)  # Must not raise
+        # auto_approve_gates must be a valid boolean
+        assert isinstance(final_manifest.get("auto_approve_gates", False), bool)
+
+
+# ===========================================================================
+# IR-3: validate_chain returns no gap for auto-approval-only tasks
+# ===========================================================================
+
+class TestValidateChainGapFree:
+    """IR-3: validate_chain must not report a gap for auto-approval receipts."""
+
+    def test_validate_chain_no_gap_for_auto_approval_receipts(self, tmp_path: Path):
+        """IR-3: a task that used only auto-approval receipts at all three gates reports no gap."""
+        import sys
+        sys.path.insert(0, str(HOOKS))
+        from lib_receipts import validate_chain, hash_file  # noqa: PLC0415
+        task_dir = _make_task(tmp_path, stage="DONE")
+        (task_dir / "plan.md").write_text(PLAN_CONTENT)
+        (task_dir / "evidence").mkdir(exist_ok=True)
+        (task_dir / "evidence" / "tdd-tests.md").write_text(TDD_EVIDENCE_CONTENT)
+        sha_spec = hash_file(task_dir / "spec.md")
+        sha_plan = hash_file(task_dir / "plan.md")
+        sha_tdd = hash_file(task_dir / "evidence" / "tdd-tests.md")
+        _write_receipt_file(task_dir, "auto-approval-SPEC_REVIEW", {"artifact_sha256": sha_spec})
+        _write_receipt_file(task_dir, "auto-approval-PLAN_REVIEW", {"artifact_sha256": sha_plan})
+        _write_receipt_file(task_dir, "auto-approval-TDD_REVIEW", {"artifact_sha256": sha_tdd})
+        gaps = validate_chain(task_dir)
+        # auto-approval receipts must not introduce spurious gap reports
+        auto_gaps = [g for g in gaps if "auto-approval" in g]
+        assert auto_gaps == [], f"validate_chain must not gap-report auto-approval receipts: {auto_gaps}"

--- a/tests/test_log_messages_all_reachable.py
+++ b/tests/test_log_messages_all_reachable.py
@@ -68,9 +68,10 @@ def test_every_log_message_key_has_writer():
     dynamic_prefixes = {
         "planner-": "receipt_planner_spawn",
         "human-approval-": "receipt_human_approval",
+        "auto-approval-": "receipt_auto_approval",  # task-20260505-001 AC-8 / AC-11
         "executor-": "receipt_executor_done",  # also executor-routing (static)
         "audit-": "receipt_audit_done",  # also audit-routing (static)
-        "force-override-": "receipt_force_override",  # PR #130 G2 force-override
+        "force-override-": "receipt_force_override",  # PR G2 force-override
     }
 
     unmapped = []

--- a/tests/test_receipt_contract_version.py
+++ b/tests/test_receipt_contract_version.py
@@ -53,7 +53,7 @@ def test_contract_version_constant_is_five():
     force-override reason/approver. The rename (was _is_four) makes the
     current floor obvious to future readers — the old name would
     silently lie after a subsequent bump."""
-    assert RECEIPT_CONTRACT_VERSION == 5
+    assert RECEIPT_CONTRACT_VERSION == 6
 
 
 def test_write_receipt_embeds_contract_version(tmp_path: Path):
@@ -61,7 +61,7 @@ def test_write_receipt_embeds_contract_version(tmp_path: Path):
     td = _td(tmp_path)
     p = write_receipt(td, "spec-validated", criteria_count=1)
     payload = json.loads(p.read_text())
-    assert payload["contract_version"] == 5
+    assert payload["contract_version"] == 6
 
 
 def test_v1_receipt_without_contract_version_is_readable(tmp_path: Path):

--- a/tests/test_receipt_contract_version_bump.py
+++ b/tests/test_receipt_contract_version_bump.py
@@ -32,10 +32,10 @@ def _td(tmp_path: Path) -> Path:
 
 
 def test_contract_version_constant_is_five():
-    """AC 24 (task-009): RECEIPT_CONTRACT_VERSION == 5. Renamed from
+    """AC 24 (task-009): RECEIPT_CONTRACT_VERSION == 6. Renamed from
     _is_four to _is_five so the current floor is obvious to future
     readers rather than hidden behind a stale name."""
-    assert RECEIPT_CONTRACT_VERSION == 5
+    assert RECEIPT_CONTRACT_VERSION == 6
 
 
 def test_write_receipt_embeds_contract_version_five(tmp_path: Path):
@@ -43,7 +43,7 @@ def test_write_receipt_embeds_contract_version_five(tmp_path: Path):
     td = _td(tmp_path)
     p = write_receipt(td, "spec-validated", criteria_count=1, spec_sha256="x" * 64)
     payload = json.loads(p.read_text())
-    assert payload["contract_version"] == 5
+    assert payload["contract_version"] == 6
 
 
 def _exercise_writer(name: str, td: Path, tmp_path: Path | None = None):
@@ -166,7 +166,7 @@ def test_every_writer_in_all_embeds_contract_version_five(tmp_path: Path, monkey
             continue
         exercised += 1
         payload = json.loads(out.read_text())
-        assert payload["contract_version"] == 5, (
+        assert payload["contract_version"] == 6, (
             f"writer {name} did not embed contract_version=5 (got {payload.get('contract_version')!r})"
         )
     assert exercised >= 14, f"expected at least 14 writers exercised, got {exercised}"
@@ -210,7 +210,7 @@ def test_postmortem_analysis_keyword_path_happy(tmp_path: Path):
     assert payload["rules_sha256_after"] == hash_file(rules_file)
     assert payload["rules_added"] == 2
     # AC 18: contract_version still 5 (no bump)
-    assert payload["contract_version"] == 5
+    assert payload["contract_version"] == 6
 
 
 def test_postmortem_analysis_missing_analysis_path_raises(tmp_path: Path):

--- a/tests/test_receipts_exports.py
+++ b/tests/test_receipts_exports.py
@@ -49,4 +49,4 @@ def test_constants_exported():
     assert "RECEIPT_CONTRACT_VERSION" in lib_receipts.__all__
     assert "CALIBRATION_POLICY_FILES" in lib_receipts.__all__
     # Migrated task-20260419-009 AC 24: contract bumped 4 -> 5.
-    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 5
+    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 6

--- a/tests/test_task_006_self_proof_smoke.py
+++ b/tests/test_task_006_self_proof_smoke.py
@@ -152,4 +152,4 @@ def test_receipt_contract_version_constant_is_five():
     """AC 27 (migrated for task-009 AC 24): contract bumped to 5.
     Renamed from _is_four → _is_five so the pin value is legible to
     future readers rather than hidden behind a stale name."""
-    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 5
+    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 6

--- a/tests/test_task_007_self_proof_smoke.py
+++ b/tests/test_task_007_self_proof_smoke.py
@@ -27,7 +27,7 @@ def test_receipt_contract_version_is_five():
     fixtures; asserting the exact value here is the pin that catches
     an out-of-band bump. Rename _is_four → _is_five follows the
     task-009 policy of making the current floor visible in the test name."""
-    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 5
+    assert lib_receipts.RECEIPT_CONTRACT_VERSION == 6
 
 
 def test_plan_routing_writer_fully_deleted():


### PR DESCRIPTION
## Summary

- Adds opt-in `manifest.auto_approve_gates` so `/dynos-work:residual run-next` can drain low-risk residuals overnight without stalling at human-approval gates.
- Caller-asserted, classification-vetoed lifecycle: residual skill sets the flag at pick-time; `apply-auto-approve-veto` can downgrade `true→false` but never raise. Hash-mismatch refusal applies to `auto-approval-*` receipts identically to `human-approval-*`, preserving the 2026-04-30 audit-chain forgery hardening.
- Six hard ceilings (security-auditor source row, security domain, high/critical risk, external-surface paths, source-auditor allowlist, global policy disable). All evaluated fail-closed.

## Files

| Layer | Files |
|---|---|
| Receipts | `hooks/lib_receipts.py` — `receipt_auto_approval`, `RECEIPT_CONTRACT_VERSION` 5→6, `MIN_VERSION_PER_STEP`, three `_LOG_MESSAGES` keys, retrospective self-compute |
| Transition gate | `hooks/lib_core.py` — `_check_any_approval` closure, `_human_approval_err` mirror, `collect_retrospectives` propagation |
| ctl | `hooks/ctl.py` — `set-auto-approve-gates`, `apply-auto-approve-veto`, `approve-stage --auto-approved`, `_do_approve_stage` shared helper, `cmd_run_start_classification` integration with fail-closed degradation |
| Skill prose | `skills/residual/SKILL.md` (new step inserted), `skills/start/SKILL.md` (Steps 4/6/8 conditional auto-approve blocks) |
| Tests | `tests/test_auto_approve_gates.py` (71 tests), 6 contract-version migrations, log-messages reachability map update |

## Trust-substrate invariants preserved

1. Hash-mismatch refusal on tampered `auto-approval-*` receipts (same as `human-approval-*`).
2. Only `cmd_set_auto_approve_gates` may write `auto_approve_gates=true`.
3. `approve-stage --auto-approved` refuses if `manifest.auto_approve_gates` is not `true`.
4. In-lock classification re-check in `_atomic_set_auto_approve_gates_true` closes the TOCTOU window the security audit caught (sec-Re-001).
5. `_human_approval_err` mirror keeps `_compute_bypassed_gates_for_force` honest for previously auto-approved tasks.
6. Fail-closed force-downgrade on veto failure (raise OR non-zero return).

## Test plan

- [x] All 24 spec ACs covered by `tests/test_auto_approve_gates.py` (71 tests).
- [x] `test_apply_veto_crash_degrades_gracefully[raise]` and `[return_1]` cover sc-002 (both veto failure modes).
- [x] `test_log_messages_three_distinct_keys` covers sc-001 (no duplicate dict-key bug).
- [x] `test_apply_veto_no_residual_row_schema_complete` covers sc-003 (no-row schema completeness).
- [x] `test_receipt_auto_approval_no_duplicate_contract_version` covers sc-004.
- [x] `test_hash_mismatch_on_auto_approval_receipt_refused` proves the 2026-04-30 forgery hardening still applies.
- [x] `test_force_override_observability_on_previously_auto_approved_task` proves the `_human_approval_err` mirror is honest.
- [x] `test_set_auto_approve_gates_lock_ex_race` (parameterized concurrent) + in-lock classification re-check prevent the TOCTOU bypass.
- [x] Full regression: `pytest tests/` → 1894 passed, 0 failed, 8 skipped.

## Out of scope (v2 follow-ups)

- AST-based external-surface walker over `execution-graph.json[].files_expected`.
- Per-repo `.dynos/policy.json` disable layer (only global `~/.dynos/projects/{slug}/policy.json` honored in v1).
- Postmortem-derived residuals never auto-approve in v1 (source_auditor always `postmortem-analysis`, not in allowlist).
- Audit-time auto-approval, PR auto-merge, schedule windows, dashboard UI.

## Lifecycle

- 5 dynos-work segments executed under task-20260505-001 (lib_receipts → lib_core → ctl → SKILL.md prose; testing parallel).
- 1 audit-driven repair cycle: closed sec-Re-001 TOCTOU + 3 minor non-blocking findings documented.
- 1 prevention rule added by postmortem analysis (kill-switch readers must log to stderr on malformed policy.json before failing-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)