### PR TITLE
fix: pin python3/git via shutil.which() across hooks/ (PRO-007)

### DIFF
--- a/hooks/build_prompt_context.py
+++ b/hooks/build_prompt_context.py
@@ -17,9 +17,16 @@ Output is printed to stdout for inclusion in a base prompt.
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+# PRO-007: pin python3/git binaries to absolute paths resolved at import time
+# so PATH-shadowing cannot substitute a malicious binary. Mirrors hooks/worktree.py
+# and hooks/daemon.py.
+_PYTHON3: str = shutil.which("python3") or sys.executable
+_GIT: str | None = shutil.which("git")
 
 # Hard caps to prevent the pre-load itself from blowing up context
 _MAX_FILE_CHARS = 40_000
@@ -93,7 +100,7 @@ def build_file_context(files: list[str], root: Path) -> str:
 def build_diff_context(snapshot_sha: str, root: Path) -> str:
     try:
         result = subprocess.run(
-            ["git", "-C", str(root), "diff", "--name-only", "--diff-filter=AMRD", snapshot_sha],
+            [_GIT or "git", "-C", str(root), "diff", "--name-only", "--diff-filter=AMRD", snapshot_sha],
             capture_output=True, text=True, check=True,
         )
         changed = [f.strip() for f in result.stdout.splitlines() if f.strip()]
@@ -105,7 +112,7 @@ def build_diff_context(snapshot_sha: str, root: Path) -> str:
 
     try:
         diff_result = subprocess.run(
-            ["git", "-C", str(root), "diff", snapshot_sha, "--", *changed],
+            [_GIT or "git", "-C", str(root), "diff", snapshot_sha, "--", *changed],
             capture_output=True, text=True, check=True,
         )
         diff_text = diff_result.stdout

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -8,11 +8,15 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+# PRO-007: pin git binary to absolute path resolved at import time.
+_GIT: str | None = shutil.which("git")
 
 from lib_core import (
     VALID_CLASSIFICATION_TYPES,
@@ -1956,7 +1960,7 @@ def _git_dirty_files(root: Path, files_expected: list[str]) -> set[str]:
         return set()
     import subprocess as _subprocess
 
-    cmd = ["git", "status", "--porcelain", "--", *files_expected]
+    cmd = [_GIT or "git", "status", "--porcelain", "--", *files_expected]
     result = _subprocess.run(
         cmd,
         cwd=root,
@@ -1997,7 +2001,7 @@ def _verify_git_diff_covers_files(
     if not snapshot_sha or not isinstance(snapshot_sha, str) or not snapshot_sha.strip():
         raise ValueError("snapshot_sha required")
 
-    diff_cmd = ["git", "-C", str(root), "diff", "--name-only", "--diff-filter=AMRD", snapshot_sha]
+    diff_cmd = [_GIT or "git", "-C", str(root), "diff", "--name-only", "--diff-filter=AMRD", snapshot_sha]
     try:
         diff_result = _subprocess.run(
             diff_cmd,
@@ -2014,7 +2018,7 @@ def _verify_git_diff_covers_files(
     if diff_result.returncode != 0:
         raise ValueError(f"git command failed: {diff_result.returncode} (cmd: {diff_cmd!r})")
 
-    untracked_cmd = ["git", "-C", str(root), "ls-files", "--others", "--exclude-standard"]
+    untracked_cmd = [_GIT or "git", "-C", str(root), "ls-files", "--others", "--exclude-standard"]
     try:
         untracked_result = _subprocess.run(
             untracked_cmd,
@@ -2735,7 +2739,7 @@ def cmd_record_snapshot(args: argparse.Namespace) -> int:
     if head_sha is None:
         try:
             r = _sub.run(
-                ["git", "-C", str(root), "rev-parse", "HEAD"],
+                [_GIT or "git", "-C", str(root), "rev-parse", "HEAD"],
                 capture_output=True, text=True, timeout=10, check=False,
             )
             if r.returncode != 0:
@@ -2760,7 +2764,7 @@ def cmd_record_snapshot(args: argparse.Namespace) -> int:
     if branch is None:
         try:
             r = _sub.run(
-                ["git", "-C", str(root), "symbolic-ref", "--short", "HEAD"],
+                [_GIT or "git", "-C", str(root), "symbolic-ref", "--short", "HEAD"],
                 capture_output=True, text=True, timeout=10, check=False,
             )
             branch = r.stdout.strip() if r.returncode == 0 else ""
@@ -3035,7 +3039,7 @@ def cmd_run_audit_setup(args: argparse.Namespace) -> int:
             import subprocess as _subprocess
 
             result = _subprocess.run(
-                ["git", "diff", "--name-only", diff_base],
+                [_GIT or "git", "diff", "--name-only", diff_base],
                 cwd=root,
                 text=True,
                 capture_output=True,
@@ -3640,7 +3644,7 @@ def cmd_run_audit_reaudit_plan(args: argparse.Namespace) -> int:
         import subprocess as _subprocess
 
         result = _subprocess.run(
-            ["git", "diff", "--name-only", diff_base],
+            [_GIT or "git", "diff", "--name-only", diff_base],
             cwd=root,
             text=True,
             capture_output=True,

--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -10,6 +10,7 @@ previous || true behavior).
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -27,6 +28,10 @@ from lib_events import (
 from lib_log import log_event
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+
+# PRO-007: pin python3 to absolute path resolved at import time so
+# PATH-shadowing cannot substitute a malicious binary.
+_PYTHON3: str = shutil.which("python3") or sys.executable
 
 # ---------------------------------------------------------------------------
 # Handler functions
@@ -83,7 +88,7 @@ def _run(cmd: list[str], root: Path, timeout: int = _DEFAULT_HANDLER_TIMEOUT) ->
 def run_policy_engine(root: Path, _payload: dict) -> bool:
     """Compute EMA scores and write routing policies from retrospectives."""
     return _run(
-        ["python3", str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "patterns.py"), "--root", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["policy_engine"],
     )
@@ -92,7 +97,7 @@ def run_policy_engine(root: Path, _payload: dict) -> bool:
 def run_postmortem(root: Path, _payload: dict) -> bool:
     """Generate human-readable postmortem report."""
     return _run(
-        ["python3", str(SCRIPT_DIR / "postmortem.py"), "generate", "--root", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "postmortem.py"), "generate", "--root", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["postmortem"],
     )
@@ -119,7 +124,7 @@ def run_dashboard(root: Path, _payload: dict) -> bool:
         except OSError:
             pass
     return _run(
-        ["python3", str(SCRIPT_DIR / "dashboard.py"), "generate", "--root", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "dashboard.py"), "generate", "--root", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["dashboard"],
     )
@@ -128,7 +133,7 @@ def run_dashboard(root: Path, _payload: dict) -> bool:
 def run_register(root: Path, _payload: dict) -> bool:
     """Mark project active in global registry."""
     return _run(
-        ["python3", str(SCRIPT_DIR / "registry.py"), "set-active", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "registry.py"), "set-active", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["register"],
     )
@@ -156,7 +161,7 @@ def run_improve(root: Path, payload: dict) -> bool:
             # spend the 300ms than silently skip improvement.
             pass
     return _run(
-        ["python3", str(SCRIPT_DIR / "postmortem_improve.py"), "improve", "--root", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "postmortem_improve.py"), "improve", "--root", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["improve"],
     )
@@ -165,7 +170,7 @@ def run_improve(root: Path, payload: dict) -> bool:
 def run_agent_generator(root: Path, _payload: dict) -> bool:
     """Discover uncovered (role, task_type) slots and generate shadow agents."""
     return _run(
-        ["python3", str(SCRIPT_DIR / "agent_generator.py"), "auto", "--root", str(root)],
+        [_PYTHON3, str(SCRIPT_DIR / "agent_generator.py"), "auto", "--root", str(root)],
         root,
         timeout=_HANDLER_TIMEOUTS["agent_generator"],
     )

--- a/hooks/handlers/benchmark_scheduler.py
+++ b/hooks/handlers/benchmark_scheduler.py
@@ -4,13 +4,18 @@ Runs at most one benchmark per task-completed event. The scheduler's
 windowing logic (shadow_rebenchmark_task_window) prevents over-firing.
 """
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 EVENT_TYPE = "task-completed"
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 AUTO_PY = SCRIPT_DIR.parent / "sandbox" / "calibration" / "auto.py"
+
+# PRO-007: pin python3 to absolute path resolved at import time.
+_PYTHON3: str = shutil.which("python3") or sys.executable
 
 
 def run(root, payload):
@@ -19,7 +24,7 @@ def run(root, payload):
     env = {**os.environ, "PYTHONPATH": f"{SCRIPT_DIR}:{os.environ.get('PYTHONPATH', '')}"}
     try:
         result = subprocess.run(
-            ["python3", str(AUTO_PY), "run", "--root", str(root), "--limit", "1"],
+            [_PYTHON3, str(AUTO_PY), "run", "--root", str(root), "--limit", "1"],
             cwd=str(root),
             env=env,
             capture_output=True,

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -7,7 +7,9 @@ import fcntl
 import functools
 import json
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,6 +21,11 @@ from write_policy import WriteAttempt, _get_capability_key, require_write_allowe
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
+# PRO-007: pin python3/git binaries to absolute paths resolved at import time
+# so PATH-shadowing cannot substitute a malicious binary.
+_PYTHON3: str = shutil.which("python3") or sys.executable
+_GIT: str | None = shutil.which("git")
 
 def _discover_executors() -> set[str]:
     """Auto-discover executor types from agents/*-executor.md files."""
@@ -214,7 +221,7 @@ def _resolve_git_toplevel(root_str: str) -> Optional[str]:
     """
     try:
         result = subprocess.run(
-            ["git", "-C", root_str, "rev-parse", "--git-common-dir"],
+            [_GIT or "git", "-C", root_str, "rev-parse", "--git-common-dir"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -3233,7 +3240,7 @@ def _fire_task_completed(task_dir: Path) -> None:
     payload = json.dumps({"task_id": task_id, "task_dir": str(task_dir)})
     try:
         subprocess.run(
-            ["python3", str(hooks_dir / "lib_events.py"), "emit",
+            [_PYTHON3, str(hooks_dir / "lib_events.py"), "emit",
              "--root", str(root), "--type", "task-completed", "--source", "task",
              "--payload", payload],
             env={**__import__("os").environ, "PYTHONPATH": env_path},
@@ -3255,7 +3262,7 @@ def _fire_task_completed(task_dir: Path) -> None:
             log_fh.write(f"\n=== drain dispatched for {task_id} at {now_iso()} ===\n".encode())
             log_fh.flush()
             subprocess.Popen(
-                ["python3", str(hooks_dir / "eventbus.py"), "drain",
+                [_PYTHON3, str(hooks_dir / "eventbus.py"), "drain",
                  "--root", str(root)],
                 env={**__import__("os").environ, "PYTHONPATH": env_path},
                 stdin=subprocess.DEVNULL,

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -13,9 +13,13 @@ import json
 import hashlib
 import math
 import os
+import shutil
 import tempfile
 import zlib
 from pathlib import Path
+
+# PRO-007: pin git binary to absolute path resolved at import time.
+_GIT: str | None = shutil.which("git")
 
 from lib_core import (
     _persistent_project_dir,
@@ -1378,7 +1382,7 @@ def _resolve_diff_files(root: Path, args: argparse.Namespace) -> list[str] | Non
     import subprocess
     try:
         proc = subprocess.run(
-            ["git", "diff", "--name-only", base],
+            [_GIT or "git", "diff", "--name-only", base],
             cwd=str(root),
             capture_output=True,
             text=True,

--- a/hooks/rules_engine.py
+++ b/hooks/rules_engine.py
@@ -36,6 +36,7 @@ import inspect
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -50,6 +51,9 @@ if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
 from lib_core import _persistent_project_dir  # noqa: E402
+
+# PRO-007: pin git binary to absolute path resolved at import time.
+_GIT: str | None = shutil.which("git")
 
 
 __all__ = [
@@ -283,7 +287,7 @@ def _staged_files(root: Path) -> list[Path]:
     """
     try:
         result = subprocess.run(
-            ["git", "-C", str(root), "diff", "--cached", "--name-only"],
+            [_GIT or "git", "-C", str(root), "diff", "--cached", "--name-only"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -311,7 +315,7 @@ def _all_tracked_files(root: Path) -> list[Path]:
     """
     try:
         result = subprocess.run(
-            ["git", "-C", str(root), "ls-files"],
+            [_GIT or "git", "-C", str(root), "ls-files"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -1126,7 +1130,7 @@ def _cmd_describe(args: argparse.Namespace) -> int:
 def _repo_toplevel(root: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            [_GIT or "git", "-C", str(root), "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/hooks/verify_behavior_preserved.py
+++ b/hooks/verify_behavior_preserved.py
@@ -50,6 +50,9 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+# PRO-007: pin git binary to absolute path resolved at import time.
+_GIT: str | None = shutil.which("git")
+
 # ---------------------------------------------------------------------------
 # Worktree management
 # ---------------------------------------------------------------------------
@@ -65,7 +68,7 @@ def create_worktree(repo: Path, ref: str, dest: Path) -> None:
     keeps full control of branches and HEAD.
     """
     r = subprocess.run(
-        ["git", "worktree", "add", "--detach", str(dest), ref],
+        [_GIT or "git", "worktree", "add", "--detach", str(dest), ref],
         cwd=repo, capture_output=True, text=True,
     )
     if r.returncode != 0:
@@ -79,7 +82,7 @@ def remove_worktree(repo: Path, dest: Path) -> None:
     if not dest.exists():
         return
     r = subprocess.run(
-        ["git", "worktree", "remove", "--force", str(dest)],
+        [_GIT or "git", "worktree", "remove", "--force", str(dest)],
         cwd=repo, capture_output=True, text=True,
     )
     if r.returncode != 0:
@@ -325,7 +328,7 @@ def main() -> int:
     # Validate refs exist before doing expensive worktree work
     for ref in (args.before, args.after):
         r = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", ref],
+            [_GIT or "git", "rev-parse", "--verify", "--quiet", ref],
             cwd=repo, capture_output=True, text=True,
         )
         if r.returncode != 0:

--- a/tests/test_no_raw_subprocess_python_git.py
+++ b/tests/test_no_raw_subprocess_python_git.py
@@ -1,0 +1,91 @@
+"""Structural regression test: no `hooks/` Python file (excluding `worktree.py`
+and `daemon.py`, which already define `_PYTHON3`/`_GIT` constants) may use a
+bare `"python3"` or `"git"` string literal as the first element of a list.
+
+PRO-007 (task-20260505-003) widened scope after the freshness-probe found that
+the original residual under-counted: literals appear via three patterns —
+direct `subprocess.run([...])`, helper indirection (`_run([...], ...)`), and
+variable-stored lists later passed to `subprocess.run`. The original AST-only
+test missed the latter two. This test scans for ANY list literal whose first
+element is a bare `"python3"`/`"git"` constant, regardless of where the list
+flows. False-positives are avoided: `_GIT or "git"` produces an `ast.BoolOp`
+as the list element, not an `ast.Constant`, so it does not match.
+
+Expected state on unmodified main: RED (25 violations across 8 files).
+Expected state after the PRO-007 fix lands: GREEN (0 violations).
+"""
+
+import ast
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+EXCLUDE_FILES = {"worktree.py", "daemon.py"}
+RAW_LITERALS = {"python3", "git"}
+
+
+def _hook_source_files() -> list[Path]:
+    """Yield every .py file under hooks/ excluding test files and the two
+    files that already define `_PYTHON3`/`_GIT` (worktree.py, daemon.py).
+
+    Recurses into subdirectories (e.g. `hooks/handlers/`) because subprocess
+    helpers live there too.
+    """
+    files: list[Path] = []
+    for py_file in HOOKS_DIR.rglob("*.py"):
+        if py_file.name in EXCLUDE_FILES:
+            continue
+        if py_file.name.startswith("test_"):
+            continue
+        files.append(py_file)
+    return sorted(files)
+
+
+def _collect_violations() -> list[tuple[str, int]]:
+    """Find every `ast.List` literal in the source whose first element is a
+    bare `"python3"` or `"git"` `ast.Constant`.
+
+    This is broader than scanning only direct `subprocess.run(...)` calls —
+    it catches helper indirection (`_run([...], ...)`) and variable-stored
+    forms (`cmd = ["git", ...]; subprocess.run(cmd, ...)`) too. Both
+    patterns are common in `hooks/` and were the root cause of PRO-007's
+    scope under-count.
+
+    Returns a sorted list of `(filepath_str, lineno)` violations.
+    """
+    violations: list[tuple[str, int]] = []
+
+    for py_file in _hook_source_files():
+        source = py_file.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.List):
+                continue
+            if not node.elts:
+                continue
+            first_elt = node.elts[0]
+            if not isinstance(first_elt, ast.Constant):
+                continue
+            if first_elt.value in RAW_LITERALS:
+                violations.append((str(py_file), node.lineno))
+
+    return sorted(violations)
+
+
+def test_no_raw_subprocess_python_git_in_hooks() -> None:
+    """Assert that no hooks/ file uses a bare `"python3"` or `"git"` string
+    constant as the first element of a list literal. Catches direct,
+    helper-indirected, and variable-stored subprocess command patterns.
+    """
+    violations = _collect_violations()
+    assert violations == [], (
+        f"Found {len(violations)} raw 'python3'/'git' list-literal(s) in "
+        f"hooks/ (excluding worktree.py + daemon.py). Each must be replaced "
+        f"with the resolved `_PYTHON3` / `_GIT or \"git\"` constant from the "
+        f"file's module scope.\n"
+        f"Offending (file, line) pairs:\n"
+        + "\n".join(f"  {filepath}:{lineno}" for filepath, lineno in violations)
+    )


### PR DESCRIPTION
## Summary

Closes the PATH-shadowing risk in subprocess invocations across 8 `hooks/` modules by resolving `python3`/`git` binary paths once at import time via `shutil.which()`. Mirrors the canonical pattern already in `hooks/worktree.py` and `hooks/daemon.py`. Drains residual PRO-007 (last item in the proactive-findings queue).

Each touched module gains module-level constants:

```python
_PYTHON3: str = shutil.which("python3") or sys.executable
_GIT: str | None = shutil.which("git")
```

Raw `"python3"` literals → `_PYTHON3`. Raw `"git"` literals → `[_GIT or "git", ...]` (the or-fallback preserves behavior when git is missing — existing `FileNotFoundError` handlers continue to fire on actual absence).

## Sites fixed (26 total across 8 files)

| File | Count | Type |
|------|-------|------|
| `hooks/build_prompt_context.py` | 2 | git |
| `hooks/ctl.py` | 6 | git (variable-stored: `cmd = [...]`) |
| `hooks/eventbus.py` | 6 | python3 (via `_run` helper) |
| `hooks/handlers/benchmark_scheduler.py` | 1 | python3 |
| `hooks/lib_core.py` | 3 | 1 git + 2 python3 |
| `hooks/router.py` | 1 | git |
| `hooks/rules_engine.py` | 3 | git |
| `hooks/verify_behavior_preserved.py` | 3 | git |

## Scope expansion vs original spec

The freshness probe was grep-based and incomplete; the original spec scoped 9 sites in 2 files. The broadened AST-based regression test (`tests/test_no_raw_subprocess_python_git.py`, committed earlier in `236d119`) surfaced 26 sites across 8 files — catching helper-indirection (eventbus.py via `_run`) and variable-stored patterns (`ctl.py`) that grep cannot see. User authorized expanding scope to all 26; rationale in `evidence/segment-B-fix-all-hooks.md`.

## Test plan

- [x] `pytest`: 1908 passed, 0 failed, 7 skipped (pre-existing). Confirmed.
- [x] `pytest tests/test_no_raw_subprocess_python_git.py -v`: PASSED — zero raw `"python3"`/`"git"` list-literals across `hooks/` (excluding `worktree.py`, `daemon.py`).
- [x] All 6 checkpoint auditors (spec-completion, security, claude-md, performance, dead-code, code-quality): 0 blocking findings.
- [x] Behavior preserved: every replacement is identity-equivalent on systems with `python3`/`git` on PATH; `_GIT or "git"` fallback preserves missing-git semantics.
- [ ] Reviewer: spot-check that the 18 `_GIT or "git"` substitutions land in subprocess calls whose existing exception handlers tolerate `FileNotFoundError` (they do, but worth a sanity pass).
- [ ] Reviewer: verify the new structural test won't false-flag legitimate future patterns (e.g., a list literal that intentionally starts with `"git"` for a docstring example would trip it — current code has none, but worth flagging).

## Closes

PRO-007 (last residual in the queue). Queue state after merge: 7/7 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)