### PR TITLE
fix: 3 more pipeline papercuts (eventbus debounce, postmortem default-template, --task-dir flag)

### DIFF
--- a/hooks/build_prompt_context.py
+++ b/hooks/build_prompt_context.py
@@ -10,8 +10,13 @@ Usage:
   python3 hooks/build_prompt_context.py file1 file2 ...
   python3 hooks/build_prompt_context.py --root /path/to/repo file1 file2 ...
   python3 hooks/build_prompt_context.py --diff <snapshot_sha> [--root .]
+  python3 hooks/build_prompt_context.py --task-dir .dynos/task-{id} [--root .]
 
-Output is printed to stdout for inclusion in a base prompt.
+Output is printed to stdout for inclusion in a base prompt. The
+``--task-dir`` form reads ``manifest.snapshot.head_sha`` and is
+preferred over ``--diff`` because it eliminates the SHA-handling
+failure mode (an abbreviated/wrong SHA passed to ``--diff`` produced
+a 1-byte sidecar silently).
 """
 
 from __future__ import annotations
@@ -153,11 +158,55 @@ def build_diff_context(snapshot_sha: str, root: Path) -> str:
     return header + "\n".join(blocks)
 
 
+def _resolve_task_dir_snapshot(task_dir: Path) -> str:
+    """Read manifest.snapshot.head_sha from a task dir and return it.
+
+    Raises ValueError when the manifest is absent / unreadable / lacks a
+    snapshot. The error message names the exact path so the operator can
+    fix the inputs without spelunking. Eliminates the abbreviated-SHA
+    failure mode of --diff because the SHA is read directly from the
+    state-machine's authoritative record rather than typed by hand.
+    """
+    import json as _json
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise ValueError(f"manifest.json not found at {manifest_path}")
+    try:
+        manifest = _json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"failed to read {manifest_path}: {exc}") from exc
+    snapshot = manifest.get("snapshot") if isinstance(manifest, dict) else None
+    if not isinstance(snapshot, dict):
+        raise ValueError(
+            f"{manifest_path} has no `snapshot` field — run "
+            "`ctl record-snapshot` before invoking --task-dir"
+        )
+    head_sha = snapshot.get("head_sha")
+    if not isinstance(head_sha, str) or not head_sha.strip():
+        raise ValueError(
+            f"{manifest_path}.snapshot.head_sha is empty or missing"
+        )
+    return head_sha.strip()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build pre-loaded file context for agent prompts")
     parser.add_argument("files", nargs="*", help="File paths to pre-load")
     parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
     parser.add_argument("--diff", metavar="SHA", help="Pre-load files changed since this git SHA")
+    parser.add_argument(
+        "--task-dir",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Pre-load files changed since the snapshot recorded in "
+            "PATH/manifest.json. Reads `snapshot.head_sha` from the "
+            "manifest — preferred over --diff for residual-drain "
+            "workflows because it removes the SHA-handling failure "
+            "mode (abbreviated/wrong SHAs passed to --diff produced "
+            "a 1-byte sidecar silently)."
+        ),
+    )
     parser.add_argument(
         "--sidecar",
         metavar="PATH",
@@ -177,7 +226,20 @@ def main() -> None:
 
     root = Path(args.root).resolve()
 
-    if args.diff:
+    # --task-dir and --diff are mutually exclusive. If both are passed,
+    # --task-dir wins (it's the authoritative source of the snapshot
+    # SHA) and --diff is silently ignored.
+    if args.task_dir:
+        task_dir_path = Path(args.task_dir)
+        if not task_dir_path.is_absolute():
+            task_dir_path = (root / task_dir_path).resolve()
+        try:
+            sha_from_manifest = _resolve_task_dir_snapshot(task_dir_path)
+        except ValueError as exc:
+            print(f"build_prompt_context: {exc}", file=sys.stderr)
+            sys.exit(1)
+        content = build_diff_context(sha_from_manifest, root)
+    elif args.diff:
         content = build_diff_context(args.diff, root)
     elif args.files:
         content = build_file_context(args.files, root)

--- a/hooks/eventbus.py
+++ b/hooks/eventbus.py
@@ -130,8 +130,45 @@ def run_dashboard(root: Path, _payload: dict) -> bool:
     )
 
 
+# Skip the registry set-active update if the project was marked active
+# within the last _REGISTER_DEBOUNCE_SECONDS. /dynos-work:start runs
+# `registry.py register` at task init (which itself sets last_active_at),
+# so a task-completed handler firing seconds-to-minutes later just
+# overwrites a recent-enough timestamp. Same pattern as
+# _DASHBOARD_DEBOUNCE_SECONDS above. Skipping saves ~one registry-file
+# read+write per completed task.
+_REGISTER_DEBOUNCE_SECONDS = 60
+
+
 def run_register(root: Path, _payload: dict) -> bool:
-    """Mark project active in global registry."""
+    """Mark project active in global registry. Debounced: skip if the
+    registry entry's last_active_at is within _REGISTER_DEBOUNCE_SECONDS
+    of now."""
+    try:
+        from datetime import datetime, timezone  # noqa: PLC0415
+        import json  # noqa: PLC0415
+        registry_path = Path.home() / ".dynos" / "registry.json"
+        if registry_path.is_file():
+            data = json.loads(registry_path.read_text(encoding="utf-8"))
+            target = str(root.resolve())
+            for proj in data.get("projects", []) or []:
+                if proj.get("path") != target:
+                    continue
+                last = proj.get("last_active_at", "")
+                if not isinstance(last, str) or not last:
+                    break
+                try:
+                    last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
+                    age = (datetime.now(timezone.utc) - last_dt).total_seconds()
+                except (ValueError, TypeError):
+                    break
+                if 0 <= age < _REGISTER_DEBOUNCE_SECONDS:
+                    return True  # Skip — registry is fresh enough
+                break
+    except (OSError, ValueError):
+        # Registry missing/unreadable — fall through to the subprocess
+        # call which will create it (or surface the underlying error).
+        pass
     return _run(
         [_PYTHON3, str(SCRIPT_DIR / "registry.py"), "set-active", str(root)],
         root,

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -97,12 +97,31 @@ def _validate_rule_schema(rule: object) -> tuple[bool, str]:
 
     Returns (ok, reason). When ok is False, *reason* names the exact
     check that failed so the REJECT stderr line is actionable.
+
+    Default-template fallback: when the LLM emits a rule without a
+    `template` field but with `rule`/`rationale`/`executor`/`category`
+    fields (the common shape across the PRO-001/005/007 postmortems),
+    treat it as `template: "advisory"`. The advisory template has no
+    required params and is always permitted; this stops the schema from
+    silently dropping every untemplated rule. Rules that lack BOTH a
+    template AND any rule/rationale text are still rejected.
     """
     if not isinstance(rule, dict):
         return False, "rule is not a dict"
     template = rule.get("template")
     if template is None:
-        return False, "missing template field"
+        # Default to advisory when the rule otherwise has the expected
+        # shape (non-empty rule text). This matches the natural output
+        # the postmortem LLM produces when not explicitly asked for the
+        # template field. The rule is mutated so the persisted form
+        # carries the explicit template, satisfying downstream readers
+        # that branch on `template`.
+        has_rule_text = isinstance(rule.get("rule"), str) and rule.get("rule", "").strip()
+        if has_rule_text:
+            rule["template"] = "advisory"
+            template = "advisory"
+        else:
+            return False, "missing template field"
     if template not in TEMPLATE_SCHEMAS:
         return False, f"unknown template: {template}"
     schema = TEMPLATE_SCHEMAS[template]

--- a/tests/test_dynos_papercut_fixes_2.py
+++ b/tests/test_dynos_papercut_fixes_2.py
@@ -1,0 +1,370 @@
+"""Regression tests for three more dynos-work pipeline papercuts:
+
+  A. ``hooks/eventbus.py:run_register`` debounces the registry
+     ``set-active`` call when the last_active_at timestamp is recent
+     (default 60s). The /dynos-work:start skill calls
+     ``registry.py register`` at task init (which itself updates
+     last_active_at), so the task-completed handler firing seconds
+     later was overwriting a fresh timestamp with another fresh
+     timestamp — pure I/O waste. Mirrors the existing
+     ``_DASHBOARD_DEBOUNCE_SECONDS`` pattern.
+
+  B. ``memory/postmortem_analysis.py:_validate_rule_schema`` defaults
+     a missing ``template`` field to ``"advisory"`` when the rule
+     otherwise has the expected shape (non-empty `rule` text). Every
+     postmortem during PRO-001/005/007 had 4-8 rules rejected as
+     "missing template field" because the LLM output didn't include
+     the field. The advisory template has no required params and is
+     always permitted; this stops zero-rules-merged from being the
+     default outcome.
+
+  C. ``hooks/build_prompt_context.py`` gains a ``--task-dir`` flag
+     that reads ``manifest.snapshot.head_sha`` and uses it as the
+     diff base. Eliminates the abbreviated-SHA failure mode from
+     ``--diff`` since the SHA comes from the state-machine's
+     authoritative record, not the operator's keyboard.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Fix A — eventbus run_register debounces recent set-active calls
+# ---------------------------------------------------------------------------
+
+
+def test_run_register_skips_when_last_active_at_is_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the registry already has the project marked active within
+    the debounce window, run_register must short-circuit without
+    spawning the subprocess."""
+    from datetime import datetime, timezone
+    import eventbus  # type: ignore[import-not-found]
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    # Pre-populate registry with a fresh last_active_at (right now).
+    reg_dir = fake_home / ".dynos"
+    reg_dir.mkdir()
+    fresh_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (reg_dir / "registry.json").write_text(json.dumps({
+        "projects": [{
+            "path": str(project_root.resolve()),
+            "registered_at": fresh_ts,
+            "last_active_at": fresh_ts,
+            "status": "active",
+        }],
+    }))
+
+    spawn_calls: list[list[str]] = []
+
+    def fake_run(cmd, *_args, **_kwargs):
+        spawn_calls.append(list(cmd))
+        return True
+
+    monkeypatch.setattr(eventbus, "_run", fake_run)
+
+    rc = eventbus.run_register(project_root, {})
+    assert rc is True, "skip path returns True (success)"
+    assert spawn_calls == [], (
+        "fresh last_active_at must short-circuit the subprocess spawn; "
+        f"got calls: {spawn_calls!r}"
+    )
+
+
+def test_run_register_fires_when_last_active_at_is_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the registry's last_active_at is older than the debounce
+    window, run_register must call set-active."""
+    import eventbus  # type: ignore[import-not-found]
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    # Last_active_at is 10 minutes ago — past the debounce window.
+    reg_dir = fake_home / ".dynos"
+    reg_dir.mkdir()
+    (reg_dir / "registry.json").write_text(json.dumps({
+        "projects": [{
+            "path": str(project_root.resolve()),
+            "registered_at": "2024-01-01T00:00:00Z",
+            "last_active_at": "2024-01-01T00:00:00Z",
+            "status": "active",
+        }],
+    }))
+
+    spawn_calls: list[list[str]] = []
+
+    def fake_run(cmd, *_args, **_kwargs):
+        spawn_calls.append(list(cmd))
+        return True
+
+    monkeypatch.setattr(eventbus, "_run", fake_run)
+
+    rc = eventbus.run_register(project_root, {})
+    assert rc is True
+    assert len(spawn_calls) == 1, "stale timestamp must trigger one spawn"
+    assert "set-active" in spawn_calls[0]
+
+
+def test_run_register_fires_when_no_registry_file_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the registry file does not exist yet, run_register must
+    fall through to the subprocess (which creates the registry)."""
+    import eventbus  # type: ignore[import-not-found]
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    # No registry.json on disk.
+
+    spawn_calls: list[list[str]] = []
+
+    def fake_run(cmd, *_args, **_kwargs):
+        spawn_calls.append(list(cmd))
+        return True
+
+    monkeypatch.setattr(eventbus, "_run", fake_run)
+
+    rc = eventbus.run_register(project_root, {})
+    assert rc is True
+    assert len(spawn_calls) == 1, "missing registry must fall through"
+
+
+def test_run_register_fires_when_project_not_in_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the registry exists but doesn't list this project, the
+    handler must fall through and let the subprocess decide."""
+    import eventbus  # type: ignore[import-not-found]
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    reg_dir = fake_home / ".dynos"
+    reg_dir.mkdir()
+    (reg_dir / "registry.json").write_text(json.dumps({
+        "projects": [{
+            "path": "/some/other/path",
+            "registered_at": "2099-01-01T00:00:00Z",
+            "last_active_at": "2099-01-01T00:00:00Z",
+            "status": "active",
+        }],
+    }))
+
+    spawn_calls: list[list[str]] = []
+
+    def fake_run(cmd, *_args, **_kwargs):
+        spawn_calls.append(list(cmd))
+        return True
+
+    monkeypatch.setattr(eventbus, "_run", fake_run)
+
+    rc = eventbus.run_register(project_root, {})
+    assert rc is True
+    assert len(spawn_calls) == 1, "unregistered project must trigger spawn"
+
+
+# ---------------------------------------------------------------------------
+# Fix B — postmortem _validate_rule_schema defaults to advisory
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rule_schema_defaults_template_to_advisory():
+    """A rule without a `template` field but with a non-empty `rule`
+    text must validate (defaulted to advisory) and gain
+    `template: "advisory"` on the in-place dict so the persisted form
+    carries the explicit template."""
+    sys.path.insert(0, str(REPO_ROOT / "memory"))
+    from postmortem_analysis import _validate_rule_schema  # type: ignore[import-not-found]
+
+    rule = {
+        "executor": "all",
+        "category": "process",
+        "rule": "Run residual-freshness probe before draining.",
+        "rationale": "PRO-001 underlying code was already remediated.",
+    }
+    ok, reason = _validate_rule_schema(rule)
+    assert ok is True, f"expected default-template acceptance; got reason={reason!r}"
+    assert rule["template"] == "advisory", (
+        "the rule dict must be mutated in place to carry the explicit "
+        "default template so downstream readers see it"
+    )
+
+
+def test_validate_rule_schema_rejects_missing_rule_text():
+    """A rule with no `template` AND no `rule` text is still rejected
+    — the default-to-advisory fallback only applies when the rule
+    looks like a real rule otherwise."""
+    sys.path.insert(0, str(REPO_ROOT / "memory"))
+    from postmortem_analysis import _validate_rule_schema  # type: ignore[import-not-found]
+
+    rule = {"executor": "all", "category": "process"}  # no `rule` key
+    ok, reason = _validate_rule_schema(rule)
+    assert ok is False
+    assert reason == "missing template field"
+
+
+def test_validate_rule_schema_rejects_blank_rule_text():
+    """An all-whitespace `rule` is treated as no rule text — rejected."""
+    sys.path.insert(0, str(REPO_ROOT / "memory"))
+    from postmortem_analysis import _validate_rule_schema  # type: ignore[import-not-found]
+
+    rule = {"executor": "all", "rule": "   "}
+    ok, _reason = _validate_rule_schema(rule)
+    assert ok is False
+
+
+def test_validate_rule_schema_explicit_template_unchanged():
+    """When the LLM does include `template`, it is honored verbatim
+    (no overwriting). Regression net for the default-fallback."""
+    sys.path.insert(0, str(REPO_ROOT / "memory"))
+    from postmortem_analysis import _validate_rule_schema  # type: ignore[import-not-found]
+
+    rule = {"template": "advisory", "rule": "explicit advisory rule"}
+    ok, _reason = _validate_rule_schema(rule)
+    assert ok is True
+    assert rule["template"] == "advisory"
+
+
+# ---------------------------------------------------------------------------
+# Fix C — build_prompt_context --task-dir reads snapshot from manifest
+# ---------------------------------------------------------------------------
+
+
+def _git_init_with_one_commit(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", "init", "--initial-branch=main", "-q"], cwd=str(repo), check=True, env=env)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=str(repo), check=True, env=env)
+    f = repo / "f.txt"
+    f.write_text("baseline\n")
+    subprocess.run(["git", "add", str(f)], cwd=str(repo), check=True, env=env)
+    subprocess.run(["git", "commit", "-m", "feat: baseline", "-q"], cwd=str(repo), check=True, env=env)
+    sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    return repo, sha
+
+
+def test_build_prompt_context_task_dir_reads_snapshot_sha(tmp_path: Path):
+    """--task-dir must read manifest.snapshot.head_sha and use it as
+    the diff base. Operator never types the SHA."""
+    repo, sha = _git_init_with_one_commit(tmp_path)
+    task_dir = repo / ".dynos" / "task-fixc"
+    task_dir.mkdir(parents=True)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-fixc",
+        "stage": "EXECUTION",
+        "created_at": "2026-05-06T00:00:00Z",
+        "raw_input": "fixture",
+        "snapshot": {"head_sha": sha, "branch": "main", "recorded_at": "2026-05-06T00:00:00Z"},
+    }))
+
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "build_prompt_context.py"),
+         "--task-dir", str(task_dir), "--root", str(repo)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    # Real-SHA path must NOT trigger the fix-#4 validation error
+    assert "does not resolve" not in result.stderr
+
+
+def test_build_prompt_context_task_dir_missing_manifest(tmp_path: Path):
+    """Missing manifest must produce a clear error (not silent empty)."""
+    task_dir = tmp_path / ".dynos" / "task-x"
+    task_dir.mkdir(parents=True)
+    # No manifest.json
+
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "build_prompt_context.py"),
+         "--task-dir", str(task_dir), "--root", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "manifest.json not found" in result.stderr
+
+
+def test_build_prompt_context_task_dir_missing_snapshot(tmp_path: Path):
+    """Manifest without `snapshot` must produce a clear error naming
+    the missing field and the recovery action."""
+    task_dir = tmp_path / ".dynos" / "task-y"
+    task_dir.mkdir(parents=True)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-y",
+        "stage": "PLANNING",
+        "created_at": "2026-05-06T00:00:00Z",
+        "raw_input": "fixture",
+    }))
+
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "build_prompt_context.py"),
+         "--task-dir", str(task_dir), "--root", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "no `snapshot` field" in result.stderr
+    assert "ctl record-snapshot" in result.stderr
+
+
+def test_build_prompt_context_task_dir_empty_head_sha(tmp_path: Path):
+    """Manifest with empty/missing head_sha must produce a clear error."""
+    task_dir = tmp_path / ".dynos" / "task-z"
+    task_dir.mkdir(parents=True)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-z",
+        "stage": "EXECUTION",
+        "created_at": "2026-05-06T00:00:00Z",
+        "raw_input": "fixture",
+        "snapshot": {"head_sha": "", "branch": "main", "recorded_at": "2026-05-06T00:00:00Z"},
+    }))
+
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "build_prompt_context.py"),
+         "--task-dir", str(task_dir), "--root", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "head_sha is empty or missing" in result.stderr


### PR DESCRIPTION
## Summary

Three more small fixes for footguns surfaced during the residual-drain sessions. Stacks on top of #162 conceptually but is independent (no file overlap with #162).

## A — `eventbus.py:run_register` debounces fresh `last_active_at`

The `/dynos-work:start` skill calls `registry.py register` at task init (which itself updates `last_active_at`). When the `task-completed` handler fires seconds-to-minutes later it ran `set-active` again, overwriting one fresh timestamp with another — pure I/O waste.

Mirrors the existing `_DASHBOARD_DEBOUNCE_SECONDS` pattern with a 60-second window. Falls through to the subprocess when the registry is missing, the project isn't listed, or the timestamp is genuinely stale.

## B — Postmortem rule schema defaults missing `template` to `"advisory"`

Every postmortem during PRO-001/005/007 had 4–8 LLM-generated rules rejected with "missing template field" — the LLM output simply didn't include the field. Net effect: **zero rules from those drains made it into `prevention-rules.json`**.

`_validate_rule_schema` now defaults `template` to `"advisory"` when the rule otherwise has the expected shape (non-empty `rule` text). The advisory template has no required params and is always permitted. The rule dict is mutated in-place so the persisted form carries the explicit template.

Rules with no template AND no rule text are still rejected (covered by test).

## C — `build_prompt_context.py --task-dir` auto-reads snapshot SHA

Adds a `--task-dir PATH` flag that reads `manifest.snapshot.head_sha` from the named task directory and uses it as the diff base. Eliminates the abbreviated/wrong-SHA failure mode of `--diff` (which silently produced a 1-byte sidecar in PRO-005's audit) by reading the SHA from the state-machine's authoritative record.

Clear error messages for the three failure cases:
- `manifest.json not found at <path>`
- `<path> has no \`snapshot\` field — run \`ctl record-snapshot\` before invoking --task-dir`
- `<path>.snapshot.head_sha is empty or missing`

## Test plan

- [x] `pytest tests/test_dynos_papercut_fixes_2.py -v`: 12 tests pass — 4 eventbus (skip + 3 fall-through), 4 postmortem (default + 2 reject + explicit-template regression), 4 `--task-dir` (happy + 3 errors).
- [x] `pytest`: 1920 passed, 0 failed, 7 skipped (pre-existing).
- [ ] Reviewer: confirm B's heuristic ("rule text exists ⇒ default to advisory") is the right fallback. The alternative is to update the postmortem prompt to explicitly require `template`, but the LLM has consistently dropped it across 3 separate runs which suggests prompt-side reinforcement won't stick.
- [ ] Reviewer: A's debounce window is 60s. The dashboard debounce is 30s. Different magnitudes are intentional — registry I/O is cheaper than full dashboard regeneration, but the registry rarely changes meaningfully within a task lifetime either. Open to tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)