### PR TITLE
fix: salvage 42 rejected postmortem rules + document tdd: convention + 3 PR-#162 regression fixes

### DIFF
--- a/hooks/build_prompt_context.py
+++ b/hooks/build_prompt_context.py
@@ -108,7 +108,7 @@ def build_diff_context(snapshot_sha: str, root: Path) -> str:
     # an empty diff silently, leading to a 1-byte sidecar. Surface the bad
     # SHA via stderr + non-empty return so the caller notices.
     verify = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", f"{snapshot_sha}^{{commit}}"],
+        [_GIT or "git", "-C", str(root), "rev-parse", "--verify", "--quiet", f"{snapshot_sha}^{{commit}}"],
         capture_output=True, text=True,
     )
     if verify.returncode != 0:

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2804,12 +2804,12 @@ def cmd_record_snapshot(args: argparse.Namespace) -> int:
     if not explicit_head and head_sha:
         try:
             msg = _sub.run(
-                ["git", "-C", str(root), "log", "-1", "--format=%s", head_sha],
+                [_GIT or "git", "-C", str(root), "log", "-1", "--format=%s", head_sha],
                 capture_output=True, text=True, timeout=10, check=False,
             )
             if msg.returncode == 0 and msg.stdout.strip().lower().startswith("tdd:"):
                 parent = _sub.run(
-                    ["git", "-C", str(root), "rev-parse", f"{head_sha}^"],
+                    [_GIT or "git", "-C", str(root), "rev-parse", f"{head_sha}^"],
                     capture_output=True, text=True, timeout=10, check=False,
                 )
                 if parent.returncode == 0:

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -930,6 +930,108 @@ def cmd_apply(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_backfill_rejected(args: argparse.Namespace) -> int:
+    """Walk every `.dynos/task-*/postmortem-analysis.json` under --root,
+    find rules that were rejected by the old `_validate_rule_schema`
+    (missing `template` field but otherwise valid), apply the
+    default-to-advisory fallback now baked into the validator, and
+    merge them into `prevention-rules.json` if novel.
+
+    Dedup criterion: (executor, category, rule[:200]). Rules already in
+    prevention-rules.json under that key are skipped. Rules already
+    accepted at original-apply-time (template was set) are skipped
+    because re-merging them would be a no-op.
+    """
+    from pathlib import Path as _Path
+    from lib_core import _persistent_project_dir  # noqa: PLC0415
+
+    root = _Path(args.root).resolve()
+    persistent = _persistent_project_dir(root)
+    rules_path = persistent / "prevention-rules.json"
+
+    # Collect candidate rules from every task's saved analysis.
+    candidates: list[dict] = []
+    by_task: dict[str, int] = {}
+    task_dirs = sorted((root / ".dynos").glob("task-*"))
+    for td in task_dirs:
+        analysis_path = td / "postmortem-analysis.json"
+        if not analysis_path.is_file():
+            continue
+        try:
+            analysis = json.loads(analysis_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        rules = analysis.get("prevention_rules") if isinstance(analysis, dict) else None
+        if not isinstance(rules, list):
+            continue
+        salvaged = 0
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            if "template" in rule and rule["template"] is not None:
+                continue  # Was already accepted on original apply.
+            if not (isinstance(rule.get("rule"), str) and rule["rule"].strip()):
+                continue  # No rule text — schema would reject anyway.
+            # Build a fresh dict to avoid mutating the on-disk file.
+            candidate = dict(rule)
+            candidate["template"] = "advisory"
+            candidate.setdefault("source_task", td.name)
+            candidates.append(candidate)
+            salvaged += 1
+        if salvaged:
+            by_task[td.name] = salvaged
+
+    # Load existing rules + dedup key set.
+    if rules_path.is_file():
+        try:
+            existing_doc = json.loads(rules_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            existing_doc = {"rules": []}
+    else:
+        existing_doc = {"rules": []}
+    existing_rules = existing_doc.get("rules") if isinstance(existing_doc, dict) else None
+    if not isinstance(existing_rules, list):
+        existing_rules = []
+        existing_doc = {"rules": existing_rules}
+
+    def _dedup_key(r: dict) -> tuple[str, str, str]:
+        return (
+            str(r.get("executor", "")).strip(),
+            str(r.get("category", "")).strip(),
+            str(r.get("rule", "")).strip()[:200],
+        )
+
+    existing_keys = {_dedup_key(r) for r in existing_rules if isinstance(r, dict)}
+
+    novel: list[dict] = []
+    for cand in candidates:
+        key = _dedup_key(cand)
+        if key in existing_keys:
+            continue
+        novel.append(cand)
+        existing_keys.add(key)
+
+    result = {
+        "scanned_tasks": len(task_dirs),
+        "tasks_with_salvageable_rules": len(by_task),
+        "candidate_rules": len(candidates),
+        "novel_rules": len(novel),
+        "by_task": by_task,
+        "rules_path": str(rules_path),
+        "dry_run": bool(args.dry_run),
+    }
+    if not novel or args.dry_run:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    existing_rules.extend(novel)
+    existing_doc["rules"] = existing_rules
+    rules_path.parent.mkdir(parents=True, exist_ok=True)
+    rules_path.write_text(json.dumps(existing_doc, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -941,6 +1043,23 @@ def build_parser() -> argparse.ArgumentParser:
     ap = sub.add_parser("apply", help="Apply LLM analysis output (reads JSON from stdin)")
     ap.add_argument("task_dir")
     ap.set_defaults(func=cmd_apply)
+
+    bf = sub.add_parser(
+        "backfill-rejected",
+        help=(
+            "Walk every task's postmortem-analysis.json and merge rules "
+            "that were rejected by the old missing-template check into "
+            "prevention-rules.json (post-PR#163 fix that accepts default "
+            "advisory template). Novel rules only; existing rules are "
+            "preserved verbatim."
+        ),
+    )
+    bf.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    bf.add_argument(
+        "--dry-run", action="store_true",
+        help="Report counts without writing prevention-rules.json",
+    )
+    bf.set_defaults(func=cmd_backfill_rejected)
 
     return parser
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -586,7 +586,7 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
 
    Exit code 0 means the receipt was written and the stage advanced. Exit code 1 means the gate refused — the stderr text identifies the cause. Do not bypass with `transition --force`. (If step 6's auto-approval already advanced the stage, this human-path call is unreachable.)
 
-8. Commit the approved tests to the snapshot branch before any production code is written.
+8. Commit the approved tests to the snapshot branch before any production code is written. **The commit message MUST start with `tdd:`** (e.g. `tdd: PRO-XYZ test suite (RED)`). This is a load-bearing convention, not just a style hint: `ctl record-snapshot` in the execute skill detects HEAD's commit message and rewinds the recorded snapshot SHA to `HEAD^` when the message starts with `tdd:`. Without that rewind, the TDD-committed test files end up AT the snapshot SHA, never appear in `git diff <snapshot>`, and break `run-execution-segment-done`'s coverage check for the test segment. Other commit-message prefixes (`feat:`, `fix:`, `refactor:`, etc.) suppress the rewind.
 
 ---
 

--- a/tests/test_postmortem_backfill_rejected.py
+++ b/tests/test_postmortem_backfill_rejected.py
@@ -1,0 +1,252 @@
+"""Tests for ``memory/postmortem_analysis.py backfill-rejected``.
+
+Walks every ``.dynos/task-*/postmortem-analysis.json`` and merges rules
+that were dropped by the original "missing template" check (since fixed
+in PR #163 to default to ``"advisory"``) into the persistent
+``prevention-rules.json``. The recent PRO-001/005/007 residual drains
+each had 2-8 rules sitting unmerged for this exact reason.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+MEMORY_DIR = REPO_ROOT / "memory"
+sys.path.insert(0, str(HOOKS_DIR))
+sys.path.insert(0, str(MEMORY_DIR))
+
+
+def _make_task_with_analysis(root: Path, task_id: str, rules: list[dict]) -> None:
+    task_dir = root / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "postmortem-analysis.json").write_text(
+        json.dumps({"task_id": task_id, "prevention_rules": rules})
+    )
+
+
+def _run_backfill(root: Path, dry_run: bool = False) -> dict:
+    """Invoke cmd_backfill_rejected via in-process import."""
+    import argparse
+    import io
+    import contextlib
+
+    from postmortem_analysis import cmd_backfill_rejected
+
+    args = argparse.Namespace(root=str(root), dry_run=dry_run)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = cmd_backfill_rejected(args)
+    assert rc == 0
+    return json.loads(buf.getvalue())
+
+
+def test_backfill_salvages_untemplated_rules(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Rules with non-empty ``rule`` text but no ``template`` field
+    must be merged with template defaulted to ``"advisory"``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    _make_task_with_analysis(tmp_path, "task-A", [
+        {
+            "executor": "all",
+            "category": "process",
+            "rule": "Always do X before Y.",
+            "rationale": "Y depends on X.",
+        },
+        {
+            "executor": "testing-executor",
+            "category": "test",
+            "rule": "Tests for forbidden patterns must walk all ast.List nodes.",
+            "rationale": "Helper-mediated patterns silently bypass narrower scans.",
+        },
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=False)
+    assert result["scanned_tasks"] == 1
+    assert result["candidate_rules"] == 2
+    assert result["novel_rules"] == 2
+
+    rules_path = Path(result["rules_path"])
+    assert rules_path.is_file()
+    doc = json.loads(rules_path.read_text())
+    rules = doc["rules"]
+    assert len(rules) == 2
+    for r in rules:
+        assert r["template"] == "advisory", "salvaged rules must carry the default template"
+        assert r["source_task"] == "task-A", "source_task should be set on backfilled rules"
+
+
+def test_backfill_skips_rules_with_existing_template(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Rules that already have a ``template`` were accepted on the
+    original apply pass — backfill must not double-merge them."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    _make_task_with_analysis(tmp_path, "task-B", [
+        {
+            "executor": "all",
+            "category": "process",
+            "rule": "Already-accepted rule.",
+            "template": "advisory",
+            "params": {},
+        },
+        {
+            "executor": "all",
+            "category": "process",
+            "rule": "Untemplated rule that is salvageable.",
+        },
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=False)
+    assert result["candidate_rules"] == 1, (
+        "templated rules must not appear as candidates"
+    )
+    assert result["novel_rules"] == 1
+
+
+def test_backfill_skips_rules_with_no_rule_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Rules with empty/missing ``rule`` text don't satisfy the
+    default-to-advisory heuristic and must be skipped (the original
+    schema rejection was correct for them)."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    _make_task_with_analysis(tmp_path, "task-C", [
+        {"executor": "all", "category": "process"},
+        {"executor": "all", "rule": "   "},
+        {"executor": "all", "rule": "valid rule text"},
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=False)
+    assert result["candidate_rules"] == 1
+    assert result["novel_rules"] == 1
+
+
+def test_backfill_dedups_against_existing_prevention_rules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A salvageable rule whose (executor, category, rule[:200]) key
+    already appears in prevention-rules.json must be skipped."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    # Run first backfill to seed prevention-rules.json.
+    _make_task_with_analysis(tmp_path, "task-D1", [
+        {
+            "executor": "backend-executor",
+            "category": "sec",
+            "rule": "Pin python3 binaries via shutil.which().",
+        },
+    ])
+    first = _run_backfill(tmp_path, dry_run=False)
+    assert first["novel_rules"] == 1
+
+    # Add the same rule under a new task — second backfill must skip.
+    _make_task_with_analysis(tmp_path, "task-D2", [
+        {
+            "executor": "backend-executor",
+            "category": "sec",
+            "rule": "Pin python3 binaries via shutil.which().",
+        },
+    ])
+    second = _run_backfill(tmp_path, dry_run=False)
+    assert second["candidate_rules"] == 2  # both tasks contribute
+    assert second["novel_rules"] == 0, (
+        "duplicate (executor, category, rule) must not double-merge"
+    )
+
+
+def test_backfill_dry_run_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """``--dry-run`` reports the counts but never touches the file."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    _make_task_with_analysis(tmp_path, "task-E", [
+        {"executor": "all", "category": "process", "rule": "salvageable rule"},
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=True)
+    assert result["dry_run"] is True
+    assert result["novel_rules"] == 1
+    rules_path = Path(result["rules_path"])
+    assert not rules_path.exists(), "dry-run must not create the rules file"
+
+
+def test_backfill_handles_missing_or_malformed_analysis_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Tasks without postmortem-analysis.json, or with malformed JSON,
+    must be skipped silently (they don't tell us anything about
+    salvageable rules)."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    # Task with no postmortem-analysis.json
+    (tmp_path / ".dynos" / "task-noanalysis").mkdir(parents=True)
+    # Task with malformed JSON
+    bad_dir = tmp_path / ".dynos" / "task-bad"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "postmortem-analysis.json").write_text("not json {")
+    # Task with valid analysis
+    _make_task_with_analysis(tmp_path, "task-good", [
+        {"executor": "all", "rule": "real salvageable rule"},
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=False)
+    assert result["scanned_tasks"] == 3
+    assert result["novel_rules"] == 1
+
+
+def test_backfill_handles_existing_rules_doc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Pre-existing prevention-rules.json must be preserved verbatim.
+    Backfill appends; it never overwrites."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    # Compute the rules path manually (matches _persistent_project_dir logic).
+    from lib_core import _persistent_project_dir
+    persistent = _persistent_project_dir(tmp_path)
+    persistent.mkdir(parents=True, exist_ok=True)
+    rules_path = persistent / "prevention-rules.json"
+
+    pre_existing = {
+        "rules": [
+            {
+                "executor": "all",
+                "category": "process",
+                "rule": "pre-existing rule from earlier work",
+                "template": "advisory",
+                "params": {},
+            }
+        ],
+        "extra_field": "must be preserved",
+    }
+    rules_path.write_text(json.dumps(pre_existing))
+
+    _make_task_with_analysis(tmp_path, "task-mix", [
+        {"executor": "testing-executor", "rule": "new rule from backfill"},
+    ])
+
+    _run_backfill(tmp_path, dry_run=False)
+
+    final = json.loads(rules_path.read_text())
+    assert len(final["rules"]) == 2
+    # Original rule preserved
+    assert any(r["rule"] == "pre-existing rule from earlier work" for r in final["rules"])
+    # New rule appended
+    assert any(r["rule"] == "new rule from backfill" for r in final["rules"])
+    # Top-level extra fields preserved
+    assert final["extra_field"] == "must be preserved"


### PR DESCRIPTION
## Summary

Two follow-up cleanups from the residual-drain sessions plus a self-cleanup of three regressions PR #162 introduced.

## A. `backfill-rejected`: salvage 42 untemplated rules (95 → 137 in prevention-rules.json)

PR #163 fixed `_validate_rule_schema` to default a missing `template` field to `"advisory"`, but only for future drains. The 12+ untemplated rules from PRO-001/005/007 (plus 28 more from older tasks) had been silently dropped at their original apply pass and sat unmerged in `task-*/postmortem-analysis.json`.

Adds `memory/postmortem_analysis.py backfill-rejected --root .`:
- Walks every `.dynos/task-*/postmortem-analysis.json`
- Finds rules with non-empty `rule` text but missing `template`
- Applies the default-to-advisory fallback
- Dedups against existing `prevention-rules.json` by `(executor, category, rule[:200])`
- Merges novel rules; preserves pre-existing rules + extra top-level fields verbatim

Run for this repo recovered **42 rules across 7 tasks** (95 → 137 in `~/.dynos/projects/<slug>/prevention-rules.json`):

```
task-20260418-001: 6
task-20260418-004: 10
task-20260423-002: 8
task-20260424-001: 4
task-20260504-008: 8   ← PRO-001 drain
task-20260505-002: 4   ← PRO-005 drain
task-20260505-003: 2   ← PRO-007 drain
```

The 14 rules from this session's residual-drain postmortems are now actually enforced.

## B. Document the `tdd:` commit-message convention

`skills/start/SKILL.md` Step 8 ("Commit the approved tests to the snapshot branch") now explicitly calls out that the commit message MUST start with `tdd:`. PR #162's `record-snapshot` rewind logic detects this prefix to decide HEAD vs HEAD^ for the snapshot SHA. Without the rewind, TDD-committed test files end up AT the snapshot and never appear in `git diff <snap>`, breaking segment-done's coverage check.

## C. Self-fix: three regressions introduced by PR #162

PR #162's fixes themselves added 3 raw `["git", ...]` literals that violated the PRO-007 structural test:
- `hooks/build_prompt_context.py:111` (rev-parse --verify in fix #4)
- `hooks/ctl.py:2807` (git log in record-snapshot rewind)
- `hooks/ctl.py:2812` (git rev-parse in record-snapshot rewind)

All three switched to `_GIT or "git"`. Caught by `tests/test_no_raw_subprocess_python_git.py` — exactly what that test exists for.

## Test plan

- [x] `pytest tests/test_postmortem_backfill_rejected.py -v`: 7 tests pass — salvage default + skip-templated + skip-no-text + dedup + dry-run + malformed-handling + preserve-existing.
- [x] `pytest`: 1937 passed, 0 failed, 7 skipped (pre-existing).
- [x] Live backfill on this repo: 42 rules merged, no overwrites.
- [ ] Reviewer: spot-check the dedup criterion `(executor, category, rule[:200])` against your actual rule corpus — if you have rules with identical first-200-char text but different rationales, they'll dedupe (probably what you want, but worth a glance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)