### PR TITLE
feat: learnable wasted-spawn auto-pause for executor/auditor spawn loops

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -42,6 +42,8 @@ from lib_receipts import (
     receipt_plan_validated,
     receipt_planner_spawn,
     receipt_search_conducted,
+    receipt_spawn_budget_paused,
+    receipt_spawn_budget_resumed,
     receipt_spec_validated,
     receipt_executor_routing,
 )
@@ -1458,7 +1460,7 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
     """Apply classification-time veto ceilings to ``manifest.auto_approve_gates``.
 
     Reads ``manifest.classification`` (must be settled — non-null), evaluates
-    six ceilings in order, and:
+    seven ceilings in order, and:
       * if any ceiling trips, sets ``policy.decision = "blocked"`` and
         downgrades ``manifest.auto_approve_gates`` to false (cannot raise
         false -> true);
@@ -1467,7 +1469,7 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
         flag, if present, is preserved).
 
     The ``classification.auto_approval_policy`` schema is exactly the shape
-    documented in AC-6:
+    documented in AC-6/AC-11:
 
       {
         "decision": "auto" | "blocked",
@@ -1477,12 +1479,13 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
           "source_auditor": <str|None>,
           "external_surface_path_match": <bool>,
           "global_policy_disabled": <bool>,
+          "spawn_budget_paused": <bool>,
           "no_residual_row": <bool>,    # only when row is missing (sc-003)
         },
         "ceilings_checked": [
           "risk_level", "domain_security", "source_auditor_security",
           "external_surface_path", "source_auditor_allowlist",
-          "global_policy",
+          "global_policy", "spawn_budget_paused",
         ],
         "blocked_by": null | <ceiling-name>,
       }
@@ -1581,6 +1584,7 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
         "external_surface_path",
         "source_auditor_allowlist",
         "global_policy",
+        "spawn_budget_paused",
     ]
 
     basis: dict = {
@@ -1589,6 +1593,8 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
         "source_auditor": row_source_auditor,
         "external_surface_path_match": bool(surface_match),
         "global_policy_disabled": bool(global_disabled),
+        # AC-11b: spawn_budget_paused is always present in basis.
+        "spawn_budget_paused": (manifest.get("blocked_reason") == "wasted_spawns_exceeded"),
     }
     if row is None:
         # sc-003: when no row is found basis is still fully populated, with
@@ -1612,6 +1618,9 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
         blocked_by = "external_surface_path"
     elif global_disabled:
         blocked_by = "global_policy"
+    # AC-11c: 7th ceiling — evaluated only when blocked_by is still None.
+    elif basis["spawn_budget_paused"]:
+        blocked_by = "spawn_budget_paused"
 
     decision = "blocked" if blocked_by is not None else "auto"
 
@@ -1640,6 +1649,14 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
     # *reason* the veto blocked, not a reason to refuse the decision.
     try:
         _persist_classification(task_dir, classification)
+        # AC-11c: _persist_classification re-reads manifest from disk and
+        # writes it back, which would overwrite the in-memory
+        # auto_approve_gates=False mutation set above. Patch the on-disk
+        # manifest a second time to preserve the downgrade.
+        if blocked_by is not None:
+            persisted = _load_manifest(task_dir)
+            persisted["auto_approve_gates"] = False
+            write_json(manifest_path, persisted)
     except Exception as _persist_exc:
         try:
             write_json(manifest_path, manifest)
@@ -1658,6 +1675,290 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
         "decision": decision,
         "blocked_by": blocked_by,
     }))
+    return 0
+
+
+def _collect_ensemble_auditors(plan: object) -> set:
+    """Permissively collect auditor names marked ensemble:true from audit-plan.json.
+
+    Handles two common shapes:
+      - plan["auditors"] as list of dicts with "name" and "ensemble" fields
+      - top-level dict keyed by auditor name with "ensemble" field
+
+    Returns a set of auditor name strings. If the plan has no recognised
+    shape, returns an empty set (no dedup applied).
+    """
+    result: set[str] = set()
+    if not isinstance(plan, dict):
+        return result
+    # Shape 1: plan["auditors"] as list of dicts
+    auds = plan.get("auditors")
+    if isinstance(auds, list):
+        for a in auds:
+            if isinstance(a, dict) and a.get("ensemble") is True:
+                name = a.get("name")
+                if isinstance(name, str):
+                    result.add(name)
+    # Shape 2: top-level dict keyed by auditor name
+    for k, v in plan.items():
+        if isinstance(v, dict) and v.get("ensemble") is True:
+            result.add(k)
+    return result
+
+
+def cmd_check_spawn_budget(args: argparse.Namespace) -> int:
+    """Check whether the current task has exhausted its wasted-spawn budget.
+
+    Reads spawn-budget-policy.json from the persistent project dir, counts
+    wasted (empty-findings) audit reports with ensemble-cascade dedup, and
+    either emits status "ok" / "paused" / "already_paused" to stdout as
+    single-line JSON (exit 0), or exits 1 when manifest.json is missing.
+
+    stdout: {"status": "ok"|"paused"|"already_paused", "count": <int>,
+             "threshold": <int>, "exempt_count": <int>, "task_class": "<str>"}
+    """
+    from lib_core import _persistent_project_dir  # noqa: PLC0415
+
+    task_dir = Path(args.task_dir).resolve()
+
+    # AC-8: missing manifest.json -> exit 1 with clear stderr.
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        print(
+            f"check-spawn-budget: manifest.json missing at {manifest_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        manifest = load_json(manifest_path)
+    except Exception as exc:
+        print(
+            f"check-spawn-budget: failed to read manifest.json: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    if not isinstance(manifest, dict):
+        print(
+            "check-spawn-budget: manifest.json must be a JSON object",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-8a: read spawn-budget-policy.json; missing/unreadable -> global fallback.
+    policy_path = _persistent_project_dir(Path.cwd()) / "spawn-budget-policy.json"
+    policy: dict = {}
+    try:
+        raw_policy = load_json(policy_path)
+        if isinstance(raw_policy, dict):
+            policy = raw_policy
+    except Exception:
+        policy = {}
+
+    # AC-1: schema places threshold under policy["global_fallback"]["threshold_count"]
+    # (matching what _build_spawn_budget_policy_data writes in memory/policy_engine.py).
+    # Reading the top-level key would silently always fall to the hardcoded literal 2.
+    gf = policy.get("global_fallback")
+    gf_threshold_raw = gf.get("threshold_count") if isinstance(gf, dict) else None
+    global_fallback_threshold: int = (
+        int(gf_threshold_raw) if isinstance(gf_threshold_raw, int) else 2
+    )
+    per_task_class: dict = {}
+    ptc = policy.get("per_task_class")
+    if isinstance(ptc, dict):
+        per_task_class = ptc
+
+    exempt_auditors: set[str] = set()
+    ea = policy.get("exempt_auditors")
+    if isinstance(ea, list):
+        for name in ea:
+            if isinstance(name, str):
+                exempt_auditors.add(name)
+
+    # AC-8b: extract task_class from manifest.classification. Note that
+    # manifest.classification uses "type" (matching lib_validate.py:308 and
+    # ctl.py:2798) while retrospectives use "task_type" — so the policy
+    # file's per_task_class keys (built from retrospective["task_type"])
+    # share the same string value as manifest classification["type"]
+    # (e.g. both yield "feature"). We accept "task_type" too for forward
+    # compat in case the spec wording becomes the canonical key later.
+    classification = manifest.get("classification") or {}
+    if isinstance(classification, dict):
+        task_type = classification.get("type") or classification.get("task_type")
+    else:
+        task_type = None
+    risk_level = classification.get("risk_level") if isinstance(classification, dict) else None
+    if isinstance(task_type, str) and task_type and isinstance(risk_level, str) and risk_level:
+        task_class = f"{task_type}:{risk_level}"
+    else:
+        task_class = "unknown:unknown"
+
+    # AC-8c: per-task-class threshold lookup.
+    task_class_policy = per_task_class.get(task_class)
+    if isinstance(task_class_policy, dict) and isinstance(task_class_policy.get("threshold_count"), int):
+        threshold: int = task_class_policy["threshold_count"]
+    else:
+        threshold = global_fallback_threshold
+
+    # AC-9: ensemble-cascade dedup — read audit-plan.json permissively.
+    ensemble_set: set[str] = set()
+    audit_plan_path = task_dir / "audit-plan.json"
+    try:
+        plan_raw = load_json(audit_plan_path)
+        ensemble_set = _collect_ensemble_auditors(plan_raw)
+    except Exception:
+        ensemble_set = set()
+
+    # Collect all audit reports from audit-reports/*.json.
+    # Each report dict must have "auditor" (str) and "findings" (list).
+    reports_dir = task_dir / "audit-reports"
+    # list of (auditor, findings, is_wasted, path, mtime)
+    all_reports: list[tuple[str, list, bool, Path, float]] = []
+    if reports_dir.is_dir():
+        for report_path in reports_dir.glob("*.json"):
+            try:
+                data = load_json(report_path)
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            auditor = data.get("auditor")
+            findings = data.get("findings")
+            if not isinstance(auditor, str) or not isinstance(findings, list):
+                continue
+            is_wasted = (findings == [])
+            try:
+                mtime = report_path.stat().st_mtime
+            except OSError:
+                mtime = 0.0
+            all_reports.append((auditor, findings, is_wasted, report_path, mtime))
+
+    # AC-9: apply ensemble dedup — for ensemble auditors, keep only the
+    # report with the greatest mtime; tie-break by filename descending.
+    # Group by auditor for ensemble members.
+    ensemble_by_auditor: dict[str, list[tuple[str, list, bool, Path, float]]] = {}
+    surviving_reports: list[tuple[str, list, bool, Path, float]] = []
+    for entry in all_reports:
+        auditor = entry[0]
+        if auditor in ensemble_set:
+            ensemble_by_auditor.setdefault(auditor, []).append(entry)
+        else:
+            # Non-ensemble auditors always survive.
+            surviving_reports.append(entry)
+
+    for auditor, entries in ensemble_by_auditor.items():
+        # Keep entry with greatest mtime; tie-break: filename descending.
+        best = max(entries, key=lambda e: (e[4], e[3].name))
+        surviving_reports.append(best)
+
+    # AC-8d/e: count wasted-and-not-exempt (count) and wasted-and-exempt (exempt_count).
+    count: int = 0
+    exempt_count: int = 0
+    contributing_auditors: set[str] = set()
+    for auditor, _findings, is_wasted, _path, _mtime in surviving_reports:
+        if not is_wasted:
+            continue
+        if auditor in exempt_auditors:
+            exempt_count += 1
+        else:
+            count += 1
+            contributing_auditors.add(auditor)
+
+    # AC-8h: already_paused branch — no mutation, no receipt.
+    if manifest.get("blocked_reason") == "wasted_spawns_exceeded":
+        print(json.dumps({
+            "status": "already_paused",
+            "count": count,
+            "threshold": threshold,
+            "exempt_count": exempt_count,
+            "task_class": task_class,
+        }))
+        return 0
+
+    # AC-8g: count >= threshold and not already paused -> write receipt + set blocked_reason.
+    if count >= threshold:
+        receipt_spawn_budget_paused(
+            task_dir,
+            count=count,
+            threshold=threshold,
+            exempt_count=exempt_count,
+            task_class=task_class,
+            contributing_auditors=sorted(contributing_auditors),
+        )
+        manifest["blocked_reason"] = "wasted_spawns_exceeded"
+        write_json(manifest_path, manifest)
+        print(json.dumps({
+            "status": "paused",
+            "count": count,
+            "threshold": threshold,
+            "exempt_count": exempt_count,
+            "task_class": task_class,
+        }))
+        return 0
+
+    # AC-8i: count < threshold -> status ok.
+    print(json.dumps({
+        "status": "ok",
+        "count": count,
+        "threshold": threshold,
+        "exempt_count": exempt_count,
+        "task_class": task_class,
+    }))
+    return 0
+
+
+def cmd_spawn_resume(args: argparse.Namespace) -> int:
+    """Clear a wasted_spawns_exceeded pause from a task manifest.
+
+    Validates --reason is at least 20 chars (stripped), then clears
+    manifest.blocked_reason and writes the spawn-budget-resumed receipt.
+
+    stdout: {"status": "resumed"} or {"status": "already_resumed"} (exit 0).
+    Exits 1 when --reason is too short, with no manifest mutation.
+    """
+    task_dir = Path(args.task_dir).resolve()
+
+    # AC-10a: validate --reason length before any manifest I/O.
+    reason_stripped = args.reason.strip()
+    if len(reason_stripped) < 20:
+        print(
+            f"spawn-resume: --reason must be at least 20 characters (got {len(reason_stripped)})",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-10b: read manifest.json.
+    manifest_path = task_dir / "manifest.json"
+    if not manifest_path.is_file():
+        print(
+            f"spawn-resume: manifest.json missing at {manifest_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        manifest = load_json(manifest_path)
+    except Exception as exc:
+        print(
+            f"spawn-resume: failed to read manifest.json: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    if not isinstance(manifest, dict):
+        print(
+            "spawn-resume: manifest.json must be a JSON object",
+            file=sys.stderr,
+        )
+        return 1
+
+    # AC-10c: not currently paused -> already_resumed, no mutation.
+    if manifest.get("blocked_reason") != "wasted_spawns_exceeded":
+        print(json.dumps({"status": "already_resumed"}))
+        return 0
+
+    # AC-10d: clear blocked_reason, write manifest, write receipt.
+    manifest["blocked_reason"] = None
+    write_json(manifest_path, manifest)
+    receipt_spawn_budget_resumed(task_dir, reason=args.reason)
+    print(json.dumps({"status": "resumed"}))
     return 0
 
 
@@ -5473,6 +5774,38 @@ def register_task_lifecycle_parsers(subparsers: argparse._SubParsersAction) -> N
         help="Path to .dynos/task-<id> directory whose classification will receive the veto.",
     )
     apply_auto_approve_veto_parser.set_defaults(func=cmd_apply_auto_approve_veto)
+
+    check_spawn_budget_parser = subparsers.add_parser(
+        "check-spawn-budget",
+        help=(
+            "Check whether the current task has exhausted its wasted-spawn budget. "
+            "Reads spawn-budget-policy.json, counts wasted audit reports (empty findings), "
+            "and emits status ok/paused/already_paused as single-line JSON."
+        ),
+    )
+    check_spawn_budget_parser.add_argument(
+        "task_dir",
+        help="Path to .dynos/task-<id> directory to evaluate.",
+    )
+    check_spawn_budget_parser.set_defaults(func=cmd_check_spawn_budget)
+
+    spawn_resume_parser = subparsers.add_parser(
+        "spawn-resume",
+        help=(
+            "Clear a wasted_spawns_exceeded pause from a task manifest. "
+            "Requires --reason of at least 20 characters."
+        ),
+    )
+    spawn_resume_parser.add_argument(
+        "task_dir",
+        help="Path to .dynos/task-<id> directory whose pause will be cleared.",
+    )
+    spawn_resume_parser.add_argument(
+        "--reason",
+        required=True,
+        help="Human-readable rationale for resuming (must be at least 20 characters).",
+    )
+    spawn_resume_parser.set_defaults(func=cmd_spawn_resume)
 
     amend_artifact_parser = subparsers.add_parser(
         "amend-artifact",

--- a/hooks/lib_receipts.py
+++ b/hooks/lib_receipts.py
@@ -69,6 +69,10 @@ from receipts.approval import (
     receipt_scheduler_refused,
     _POSTMORTEM_SKIP_REASONS,
 )
+from receipts.budget import (
+    receipt_spawn_budget_paused,
+    receipt_spawn_budget_resumed,
+)
 
 
 __all__ = [
@@ -106,4 +110,6 @@ __all__ = [
     "INJECTED_PROMPTS_DIR",
     "INJECTED_AUDITOR_PROMPTS_DIR",
     "INJECTED_PLANNER_PROMPTS_DIR",
+    "receipt_spawn_budget_paused",
+    "receipt_spawn_budget_resumed",
 ]

--- a/hooks/receipts/__init__.py
+++ b/hooks/receipts/__init__.py
@@ -48,6 +48,10 @@ from .approval import (
     receipt_rules_check_passed,
     receipt_force_override,
 )
+from .budget import (
+    receipt_spawn_budget_paused,
+    receipt_spawn_budget_resumed,
+)
 
 __all__ = [
     "write_receipt",
@@ -84,4 +88,6 @@ __all__ = [
     "INJECTED_PROMPTS_DIR",
     "INJECTED_AUDITOR_PROMPTS_DIR",
     "INJECTED_PLANNER_PROMPTS_DIR",
+    "receipt_spawn_budget_paused",
+    "receipt_spawn_budget_resumed",
 ]

--- a/hooks/receipts/budget.py
+++ b/hooks/receipts/budget.py
@@ -1,0 +1,98 @@
+"""Spawn-budget pause/resume receipt writers.
+
+Each function in this module writes a structured JSON receipt for a
+spawn-budget pipeline event:
+
+* ``receipt_spawn_budget_paused`` proves the spawn-budget gate fired
+  (auditor-spawn count crossed the threshold for the task class) and
+  records the contributing-auditor list, threshold, and exempt count
+  that justified the pause.
+
+* ``receipt_spawn_budget_resumed`` proves a paused budget was deliberately
+  resumed and records the human/operational reason.
+
+The counts/threshold/exempt_count fields ARE caller-supplied here — they
+are derived by ``cmd_check_spawn_budget`` at the call site, not by this
+writer. The writer only stamps a timestamp via ``now_iso()`` and
+forwards the contract version. See spec.md AC-6 for the exact payload
+shape contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib_core import now_iso
+
+from .core import (
+    RECEIPT_CONTRACT_VERSION,
+    write_receipt,
+)
+
+
+def receipt_spawn_budget_paused(
+    task_dir: Path,
+    *,
+    count: int,
+    threshold: int,
+    exempt_count: int,
+    task_class: str,
+    contributing_auditors: list[str],
+) -> Path:
+    """Write receipt proving the spawn-budget gate paused auditor spawning.
+
+    Writes ``receipts/spawn-budget-paused.json``. Step name:
+    ``"spawn-budget-paused"``.
+
+    Payload (every field forwarded verbatim — caller-derived):
+      - contract_version:       ``RECEIPT_CONTRACT_VERSION`` (injected by
+                                ``write_receipt`` from this kwarg)
+      - count:                  current auditor-spawn count for the task
+      - threshold:              configured threshold for ``task_class``
+      - exempt_count:           count of exempt auditors (excluded from the
+                                budget calculation)
+      - task_class:             classification key used to look up the
+                                threshold
+      - contributing_auditors:  list of auditor names that contributed to
+                                ``count`` (must be a list of strings)
+      - paused_at:              ``now_iso()`` timestamp
+
+    Returns the path to the written receipt.
+    """
+    return write_receipt(
+        task_dir,
+        "spawn-budget-paused",
+        contract_version=RECEIPT_CONTRACT_VERSION,
+        count=count,
+        threshold=threshold,
+        exempt_count=exempt_count,
+        task_class=task_class,
+        contributing_auditors=list(contributing_auditors),
+        paused_at=now_iso(),
+    )
+
+
+def receipt_spawn_budget_resumed(
+    task_dir: Path,
+    *,
+    reason: str,
+) -> Path:
+    """Write receipt proving a paused spawn-budget was resumed.
+
+    Writes ``receipts/spawn-budget-resumed.json``. Step name:
+    ``"spawn-budget-resumed"``.
+
+    Payload:
+      - contract_version: ``RECEIPT_CONTRACT_VERSION``
+      - reason:           operator-supplied rationale for resuming
+      - resumed_at:       ``now_iso()`` timestamp
+
+    Returns the path to the written receipt.
+    """
+    return write_receipt(
+        task_dir,
+        "spawn-budget-resumed",
+        contract_version=RECEIPT_CONTRACT_VERSION,
+        reason=reason,
+        resumed_at=now_iso(),
+    )

--- a/memory/policy_engine.py
+++ b/memory/policy_engine.py
@@ -6,6 +6,8 @@ import sys as _sys; _sys.path.insert(0, str(__import__("pathlib").Path(__file__)
 
 import argparse
 import json
+import math
+import statistics
 from pathlib import Path
 
 from lib_core import collect_retrospectives, now_iso, _persistent_project_dir, load_json, write_json, VALID_EXECUTORS
@@ -668,17 +670,172 @@ def _migrate_model_overrides(root: Path, model_policy_data: dict[str, dict]) -> 
     return merged
 
 
+def _build_spawn_budget_policy_data(retrospectives: list[dict]) -> dict:
+    """Compute spawn-budget policy data from task retrospectives.
+
+    Returns a dict matching this exact schema:
+
+        {
+          "version": 1,
+          "computed_at": "<ISO 8601 UTC string>",
+          "per_task_class": {
+            "<task_type>:<risk_level>": {
+              "waste_count_baseline": <float>,
+              "waste_count_stddev": <float>,
+              "n_observations": <int>,
+              "threshold_count": <int>
+            }
+          },
+          "global_fallback": {"threshold_count": 2},
+          "exempt_auditors": ["<auditor_name>", ...]
+        }
+
+    Aggregation rules (AC-2 / AC-3):
+
+    * The ``wasted_spawns`` field is sourced from each retrospective dict
+      (top-level field). Source-of-truth: ``task-retrospective.json``
+      schema, top-level ``wasted_spawns`` (int|float). Missing or
+      non-numeric values are coerced to ``0``.
+    * Retrospectives missing ``task_type`` or ``risk_level`` are SKIPPED
+      entirely — no ``unknown:unknown`` aggregation is performed.
+    * Observations are grouped by ``f"{task_type}:{risk_level}"``.
+    * A ``per_task_class`` entry is emitted only when ``n_observations
+      >= 3``. Classes with fewer observations are omitted.
+    * ``baseline = statistics.mean(values)``. ``stddev =
+      statistics.stdev(values)`` (sample stddev, requires n>=2). For
+      n==1 the stddev is forced to ``0.0``. n>=3 with all-identical
+      observations yields ``stddev == 0.0`` and
+      ``threshold_count = max(2, ceil(baseline))``.
+    * ``threshold_count = max(2, min(10, math.ceil(baseline + 2 *
+      stddev)))`` — capped to the inclusive range [2, 10].
+
+    Exempt-auditor rules (AC-4):
+
+    * For each task (keyed by ``task_id``), select the most-recent
+      retrospective by ``computed_at`` (ISO descending). When two
+      retros for the same task share an identical ``computed_at``,
+      the tiebreaker prefers the retro with the higher
+      ``wasted_spawns`` count (more conservative — picks the noisier
+      observation).
+    * From the selected retro's ``auditor_zero_finding_streaks`` dict
+      (top-level, ``dict[str, int|float]``), collect every key whose
+      value is ``>= 5``.
+    * Union across all tasks; deduplicate; sort ascending.
+
+    Source-of-truth field paths (``task-retrospective.json``):
+    ``wasted_spawns``, ``task_type``, ``risk_level``, ``task_id``,
+    ``computed_at``, ``auditor_zero_finding_streaks``.
+    """
+    # ----- per-task-class aggregation (AC-2 / AC-3) --------------------
+    grouped: dict[str, list[float]] = {}
+    for retro in retrospectives:
+        if not isinstance(retro, dict):
+            continue
+        task_type = retro.get("task_type")
+        risk_level = retro.get("risk_level")
+        # Hard rule: skip retrospectives missing task_type / risk_level
+        # — never silently default to "unknown:unknown".
+        if not isinstance(task_type, str) or not task_type:
+            continue
+        if not isinstance(risk_level, str) or not risk_level:
+            continue
+        raw_waste = retro.get("wasted_spawns", 0)
+        if isinstance(raw_waste, bool) or not isinstance(raw_waste, (int, float)):
+            # bool is a subclass of int — exclude explicitly. Non-numeric
+            # values become 0 per AC-2 ("default 0 when absent or
+            # non-numeric").
+            waste = 0.0
+        else:
+            waste = float(raw_waste)
+        key = f"{task_type}:{risk_level}"
+        grouped.setdefault(key, []).append(waste)
+
+    per_task_class: dict[str, dict] = {}
+    for key, values in grouped.items():
+        n = len(values)
+        if n < 3:
+            # AC-2: only emit entries when n_observations >= 3.
+            continue
+        baseline = statistics.mean(values)
+        # statistics.stdev requires n >= 2; n is already >= 3 here, but
+        # we keep the n==1 branch documented for AC-3 completeness.
+        stddev = statistics.stdev(values) if n >= 2 else 0.0
+        threshold_count = max(2, min(10, math.ceil(baseline + 2 * stddev)))
+        per_task_class[key] = {
+            "waste_count_baseline": float(baseline),
+            "waste_count_stddev": float(stddev),
+            "n_observations": int(n),
+            "threshold_count": int(threshold_count),
+        }
+
+    # ----- exempt auditors (AC-4) --------------------------------------
+    # Pick the most-recent retrospective per task_id by computed_at (ISO
+    # descending). Tiebreaker on identical computed_at: higher
+    # wasted_spawns wins (the more conservative — noisier — observation).
+    most_recent_per_task: dict[str, dict] = {}
+    for retro in retrospectives:
+        if not isinstance(retro, dict):
+            continue
+        task_id = retro.get("task_id")
+        if not isinstance(task_id, str) or not task_id:
+            continue
+        computed_at = retro.get("computed_at")
+        if not isinstance(computed_at, str):
+            computed_at = ""
+        existing = most_recent_per_task.get(task_id)
+        if existing is None:
+            most_recent_per_task[task_id] = retro
+            continue
+        existing_ts = existing.get("computed_at")
+        if not isinstance(existing_ts, str):
+            existing_ts = ""
+        if computed_at > existing_ts:
+            most_recent_per_task[task_id] = retro
+        elif computed_at == existing_ts:
+            new_waste = retro.get("wasted_spawns", 0)
+            old_waste = existing.get("wasted_spawns", 0)
+            if not isinstance(new_waste, (int, float)) or isinstance(new_waste, bool):
+                new_waste = 0
+            if not isinstance(old_waste, (int, float)) or isinstance(old_waste, bool):
+                old_waste = 0
+            if float(new_waste) > float(old_waste):
+                most_recent_per_task[task_id] = retro
+
+    exempt: set[str] = set()
+    for retro in most_recent_per_task.values():
+        streaks = retro.get("auditor_zero_finding_streaks", {})
+        if not isinstance(streaks, dict):
+            continue
+        for auditor_name, value in streaks.items():
+            if not isinstance(auditor_name, str) or not auditor_name:
+                continue
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            if float(value) >= 5:
+                exempt.add(auditor_name)
+
+    return {
+        "version": 1,
+        "computed_at": now_iso(),
+        "per_task_class": per_task_class,
+        "global_fallback": {"threshold_count": 2},
+        "exempt_auditors": sorted(exempt),
+    }
+
+
 def _write_policy_json_files(
     root: Path,
     model_policy_data: dict[str, dict],
     skip_policy_data: dict[str, dict],
     route_policy_data: dict[str, dict],
+    spawn_budget_policy_data: dict,
 ) -> None:
-    """Write all three JSON policy files atomically."""
+    """Write all four JSON policy files atomically."""
     persistent = _persistent_project_dir(root)
     write_json(persistent / "model-policy.json", model_policy_data)
     write_json(persistent / "skip-policy.json", skip_policy_data)
     write_json(persistent / "route-policy.json", route_policy_data)
+    write_json(persistent / "spawn-budget-policy.json", spawn_budget_policy_data)
 
 
 def build_patterns_markdown(
@@ -825,13 +982,26 @@ def write_patterns(root: Path) -> dict:
 
     steps_completed.append(f"route:{len(route_policy_data)} routes")
 
-    # Step 4: Write JSON policy files + effectiveness scores
-    _write_policy_json_files(root, model_policy_data, skip_policy_data, route_policy_data)
+    # Step 4: Write JSON policy files + effectiveness scores.
+    # spawn_budget_policy_data is computed here (not passed as None) so
+    # that empty retrospectives still yield a valid schema with
+    # per_task_class={}, exempt_auditors=[].
+    spawn_budget_policy_data = _build_spawn_budget_policy_data(retrospectives)
+    _write_policy_json_files(
+        root,
+        model_policy_data,
+        skip_policy_data,
+        route_policy_data,
+        spawn_budget_policy_data,
+    )
     persistent = _persistent_project_dir(root)
     write_json(persistent / "effectiveness-scores.json", effectiveness_scores)
     steps_completed.append("json_written")
     log_event(root, "learn_step", step="write_json_policies",
-              model_count=len(model_policy_data), skip_count=len(skip_policy_data), route_count=len(route_policy_data))
+              model_count=len(model_policy_data), skip_count=len(skip_policy_data),
+              route_count=len(route_policy_data),
+              spawn_budget_class_count=len(spawn_budget_policy_data.get("per_task_class", {})),
+              spawn_budget_exempt_count=len(spawn_budget_policy_data.get("exempt_auditors", [])))
 
     # Step 5: Render markdown from the same data
     content = build_patterns_markdown(

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -146,6 +146,22 @@ The role string strips the `-auditor` suffix from the agent file name: `spec-com
 
 When auditors run in parallel, the role file is overwritten on each stamp; this is fine because each subagent reads the file at its own first tool call within its own session. The post-spawn cleanup (delete `active-segment-role`) happens after the entire audit batch, not per auditor.
 
+**Spawn budget check (MANDATORY — BEFORE every batch):**
+
+Before issuing each parallel auditor batch (this includes the first batch AND every subsequent re-audit batch — the check runs once per spawn cycle, before EACH batch, not only the first), run:
+
+```bash
+python3 hooks/ctl.py check-spawn-budget .dynos/task-{id}
+```
+
+Parse the JSON output. The command emits a single-line JSON object with keys `status`, `count`, `threshold`, `exempt_count`, and `task_class`. If `status` is `'paused'` or `'already_paused'`:
+
+1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the auditor count, the threshold, the `task_class`, and instruct the operator to run `python3 hooks/ctl.py spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
+2. Append a line beginning with `[BUDGET-PAUSE]` to `execution-log.md` that records the timestamp, count, and threshold.
+3. Exit non-zero.
+
+Do not proceed with spawning auditors. The pause is intentional — the policy is calibrated from this project's retrospective history, and the wasted-spawn count has crossed the learned threshold.
+
 Spawn the determined auditors simultaneously, passing the resolved model for each auditor in the subagent spawn configuration. For alongside-mode auditors, this means two spawns for that role (generic + learned), both counted in {N}.
 
 Each auditor writes its own report to `.dynos/task-{id}/audit-reports/{auditor}-checkpoint-{timestamp}.json`. Every auditor agent has a write capability sufficient for this: auditors with `Bash` use a heredoc; `spec-completion-auditor` has the `Write` tool scoped via `write_policy.py` to its own report path. The role file stamped above is what unlocks the `audit-reports/` write rule for these subagents.

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -171,6 +171,22 @@ Where `{executor-role}` is the exact role string from the executor plan (e.g. `b
 
 **TDD-First Awareness:** Check if `.dynos/task-{id}/evidence/tdd-tests.md` exists. If it does, include this instruction in the base prompt (before piping through inject-prompt): "A TDD test suite has already been committed. Your implementation must make those tests pass. Do NOT write new tests or modify existing test files."
 
+**Spawn budget check (MANDATORY — BEFORE every batch):**
+
+Before issuing each parallel next_batch executor batch (this includes the first batch AND every subsequent next_batch — the check runs once per spawn cycle, before EACH batch, not only the first), run:
+
+```bash
+python3 hooks/ctl.py check-spawn-budget .dynos/task-{id}
+```
+
+Parse the JSON output. The command emits a single-line JSON object with keys `status`, `count`, `threshold`, `exempt_count`, and `task_class`. If `status` is `'paused'` or `'already_paused'`:
+
+1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the executor count, the threshold, the `task_class`, and instruct the operator to run `python3 hooks/ctl.py spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
+2. Append a line beginning with `[BUDGET-PAUSE]` to `execution-log.md` that records the timestamp, count, and threshold.
+3. Exit non-zero.
+
+Do not proceed with spawning executors. The pause is intentional — the policy is calibrated from this project's retrospective history, and the wasted-spawn count has crossed the learned threshold.
+
 Spawn the `next_batch` executor agents in parallel.
 
 Executor agents by type:

--- a/tests/test_auto_approve_gates.py
+++ b/tests/test_auto_approve_gates.py
@@ -772,6 +772,7 @@ class TestAutoApprovalPolicySchema:
             "external_surface_path",
             "source_auditor_allowlist",
             "global_policy",
+            "spawn_budget_paused",
         }
 
     def test_apply_veto_no_residual_row_schema_complete(self, tmp_path: Path):

--- a/tests/test_spawn_budget_policy.py
+++ b/tests/test_spawn_budget_policy.py
@@ -1,0 +1,538 @@
+"""Tests for spawn-budget policy engine, ctl check-spawn-budget, ctl spawn-resume,
+and auto-approve-veto spawn_budget_paused ceiling.
+
+Covers AC-14 (13 exact test names) and AC-15 (full suite passes, no skip/xfail).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "memory"))
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from policy_engine import _build_spawn_budget_policy_data
+import ctl
+from receipts.budget import (
+    receipt_spawn_budget_paused,
+    receipt_spawn_budget_resumed,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _retro(
+    task_id: str,
+    task_type: str,
+    risk_level: str,
+    wasted_spawns: int,
+    *,
+    computed_at: str = "2026-05-01T00:00:00Z",
+    streaks: dict | None = None,
+) -> dict:
+    """Build a minimal retrospective dict for policy-engine tests."""
+    r: dict = {
+        "task_id": task_id,
+        "task_type": task_type,
+        "risk_level": risk_level,
+        "wasted_spawns": wasted_spawns,
+        "computed_at": computed_at,
+    }
+    if streaks is not None:
+        r["auditor_zero_finding_streaks"] = streaks
+    return r
+
+
+def _make_task_dir(
+    tmp_path: Path,
+    *,
+    task_id: str = "task-test-001",
+    classification: dict | None = None,
+    blocked_reason: str | None = None,
+    auto_approve_gates: bool | None = None,
+) -> Path:
+    """Create a minimal task directory with manifest.json."""
+    task_dir = tmp_path / ".dynos" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    cls = classification or {
+        "type": "feature",
+        "risk_level": "medium",
+        "domains": ["backend"],
+    }
+    manifest: dict = {
+        "task_id": task_id,
+        "created_at": "2026-05-06T00:00:00Z",
+        "title": "Spawn budget test",
+        "raw_input": "x",
+        "stage": "AUDIT",
+        "classification": cls,
+        "retry_counts": {},
+        "blocked_reason": blocked_reason,
+        "completion_at": None,
+    }
+    if auto_approve_gates is not None:
+        manifest["auto_approve_gates"] = auto_approve_gates
+    (task_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return task_dir
+
+
+def _write_audit_report(
+    task_dir: Path,
+    auditor: str,
+    findings: list,
+    *,
+    filename: str | None = None,
+) -> Path:
+    """Write a wasted (empty findings) or non-wasted audit report."""
+    reports_dir = task_dir / "audit-reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    fname = filename or f"{auditor}.json"
+    report = {"auditor": auditor, "findings": findings}
+    p = reports_dir / fname
+    p.write_text(json.dumps(report, indent=2))
+    return p
+
+
+def _write_spawn_budget_policy(
+    persistent_dir: Path,
+    *,
+    per_task_class: dict | None = None,
+    exempt_auditors: list | None = None,
+    global_fallback_threshold: int = 2,
+) -> None:
+    """Write spawn-budget-policy.json into the persistent dir."""
+    persistent_dir.mkdir(parents=True, exist_ok=True)
+    policy = {
+        "version": 1,
+        "computed_at": "2026-05-06T00:00:00Z",
+        "per_task_class": per_task_class or {},
+        "global_fallback": {"threshold_count": global_fallback_threshold},
+        "exempt_auditors": exempt_auditors or [],
+    }
+    (persistent_dir / "spawn-budget-policy.json").write_text(
+        json.dumps(policy, indent=2)
+    )
+
+
+def _set_dynos_home(monkeypatch, tmp_path: Path) -> Path:
+    """Set DYNOS_HOME env var and return the persistent project dir for cwd."""
+    dynos_home = tmp_path / "dynos_home"
+    monkeypatch.setenv("DYNOS_HOME", str(dynos_home))
+    return dynos_home
+
+
+def _persistent_for_cwd(dynos_home: Path) -> Path:
+    """Compute the persistent project dir for the current working directory.
+
+    Mirrors the slug logic in lib_core._persistent_project_dir when not inside
+    a git repo (tmp_path is outside the project git tree).
+    """
+    slug = str(Path.cwd().resolve()).strip("/").replace("/", "-")
+    return dynos_home / "projects" / slug
+
+
+# ---------------------------------------------------------------------------
+# AC-14 Tests
+# ---------------------------------------------------------------------------
+
+
+def test_policy_emits_per_class_statistics():
+    """Policy engine emits n_observations, baseline, stddev, and threshold for
+    a class with >= 3 retrospectives."""
+    retros = [
+        _retro("t1", "feature", "medium", 3, computed_at="2026-05-01T00:00:00Z"),
+        _retro("t2", "feature", "medium", 5, computed_at="2026-05-02T00:00:00Z"),
+        _retro("t3", "feature", "medium", 4, computed_at="2026-05-03T00:00:00Z"),
+    ]
+    policy = _build_spawn_budget_policy_data(retros)
+    entry = policy["per_task_class"]["feature:medium"]
+    assert entry["n_observations"] == 3
+    # mean = 4.0, sample stddev of [3, 5, 4] = 1.0, threshold = max(2, min(10, ceil(4 + 2*1))) = 6
+    assert entry["waste_count_baseline"] == pytest.approx(4.0)
+    assert entry["waste_count_stddev"] == pytest.approx(1.0)
+    assert entry["threshold_count"] == 6
+
+
+def test_policy_cold_start_omits_class():
+    """Policy engine omits a class with fewer than 3 observations (cold start)."""
+    retros = [
+        _retro("t1", "feature", "low", 1),
+        _retro("t2", "feature", "low", 2),
+    ]
+    policy = _build_spawn_budget_policy_data(retros)
+    assert "feature:low" not in policy["per_task_class"]
+
+
+def test_exempt_auditors_derived_from_streaks():
+    """Auditors with streak >= 5 in the most-recent retro per task are exempt."""
+    retros = [
+        _retro(
+            "t1",
+            "feature",
+            "medium",
+            0,
+            streaks={"vision-auditor": 6},
+            computed_at="2026-05-03T00:00:00Z",
+        ),
+        _retro(
+            "t2",
+            "feature",
+            "medium",
+            0,
+            streaks={"vision-auditor": 5},
+            computed_at="2026-05-02T00:00:00Z",
+        ),
+    ]
+    policy = _build_spawn_budget_policy_data(retros)
+    assert "vision-auditor" in policy["exempt_auditors"]
+
+
+def test_exempt_auditors_excludes_reset_streak():
+    """When the same task has two retros, the latest computed_at wins.
+    If the latest retro shows streak < 5, auditor is NOT exempt."""
+    retros = [
+        _retro(
+            "t1",
+            "feature",
+            "medium",
+            0,
+            streaks={"vision-auditor": 6},
+            computed_at="2026-05-01T00:00:00Z",
+        ),
+        _retro(
+            "t1",
+            "feature",
+            "medium",
+            0,
+            streaks={"vision-auditor": 3},
+            computed_at="2026-05-02T00:00:00Z",
+        ),
+    ]
+    policy = _build_spawn_budget_policy_data(retros)
+    assert "vision-auditor" not in policy["exempt_auditors"]
+
+
+def test_check_spawn_budget_ok_under_threshold_cold_start(
+    tmp_path, monkeypatch, capsys
+):
+    """check-spawn-budget returns status=ok when no policy file exists (cold start)
+    and count < fallback threshold of 2."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    task_dir = _make_task_dir(tmp_path)
+
+    # Write one wasted audit report (count=1 < threshold=2)
+    _write_audit_report(task_dir, "code-quality-auditor", [])
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["status"] == "ok"
+    assert payload["count"] == 1
+    assert payload["threshold"] == 2  # global fallback
+
+
+def test_check_spawn_budget_paused_above_learned_threshold(
+    tmp_path, monkeypatch, capsys
+):
+    """check-spawn-budget returns status=paused and writes receipt when count >= threshold."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Policy with learned threshold of 3 for feature:medium
+    persistent = _persistent_for_cwd(dynos_home)
+    _write_spawn_budget_policy(
+        persistent,
+        per_task_class={
+            "feature:medium": {
+                "threshold_count": 3,
+                "waste_count_baseline": 2.0,
+                "waste_count_stddev": 0.5,
+                "n_observations": 5,
+            }
+        },
+    )
+
+    task_dir = _make_task_dir(tmp_path)
+    # Write 3 wasted reports => count=3 >= threshold=3
+    _write_audit_report(task_dir, "code-quality-auditor", [], filename="r1.json")
+    _write_audit_report(task_dir, "dead-code-auditor", [], filename="r2.json")
+    _write_audit_report(task_dir, "db-schema-auditor", [], filename="r3.json")
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["status"] == "paused"
+    assert payload["count"] == 3
+    assert payload["threshold"] == 3
+    assert payload["task_class"] == "feature:medium"
+
+    # Manifest must be updated
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["blocked_reason"] == "wasted_spawns_exceeded"
+
+    # Receipt must be written
+    assert (task_dir / "receipts" / "spawn-budget-paused.json").is_file()
+
+
+def test_check_spawn_budget_uses_global_fallback_threshold(
+    tmp_path, monkeypatch, capsys
+):
+    """When per_task_class lookup misses, the threshold is read from
+    policy['global_fallback']['threshold_count'], not the top-level key.
+
+    Regression: the original implementation read policy['threshold_count']
+    which silently always fell back to the hardcoded literal 2 because the
+    schema places the threshold under 'global_fallback'. With a policy file
+    setting global_fallback.threshold_count=5 and only 4 wasted reports,
+    the broken path emitted status='paused' (4 >= 2). The fix reads the
+    nested path so the same input emits status='ok' (4 < 5).
+    """
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Policy file with global_fallback=5 and NO matching per_task_class
+    # entry. Reader must consult the nested path to honor the 5.
+    persistent = _persistent_for_cwd(dynos_home)
+    _write_spawn_budget_policy(
+        persistent,
+        per_task_class={},  # no entry for "feature:medium"
+        global_fallback_threshold=5,
+    )
+
+    task_dir = _make_task_dir(tmp_path)
+    # 4 wasted reports — between the broken-default 2 and the configured 5.
+    for i in range(4):
+        _write_audit_report(
+            task_dir, f"auditor-{i}", [], filename=f"r{i}.json"
+        )
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    # If the bug regresses, threshold would be 2 and status would be "paused".
+    assert payload["threshold"] == 5
+    assert payload["count"] == 4
+    assert payload["status"] == "ok"
+
+
+def test_ensemble_cascade_final_tier_only_counted(tmp_path, monkeypatch, capsys):
+    """For ensemble auditors, only the final (highest mtime) report is counted.
+    Earlier reports are deduplicated away."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Policy: threshold 2 for feature:medium (learned)
+    persistent = _persistent_for_cwd(dynos_home)
+    _write_spawn_budget_policy(
+        persistent,
+        per_task_class={
+            "feature:medium": {
+                "threshold_count": 2,
+                "waste_count_baseline": 1.0,
+                "waste_count_stddev": 0.0,
+                "n_observations": 3,
+            }
+        },
+    )
+
+    task_dir = _make_task_dir(tmp_path)
+
+    # Write audit-plan.json marking "vision-auditor" as ensemble
+    (task_dir / "audit-plan.json").write_text(
+        json.dumps({"auditors": [{"name": "vision-auditor", "ensemble": True}]})
+    )
+
+    # Two wasted reports for the same ensemble auditor (simulating cascade tiers)
+    # The final tier (r2.json) has findings, so it is NOT wasted -> count stays 0
+    reports_dir = task_dir / "audit-reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    import time
+
+    p1 = reports_dir / "vision-auditor-r1.json"
+    p1.write_text(json.dumps({"auditor": "vision-auditor", "findings": []}))
+    time.sleep(0.01)  # ensure different mtime
+    p2 = reports_dir / "vision-auditor-r2.json"
+    p2.write_text(json.dumps({"auditor": "vision-auditor", "findings": ["finding"]}))
+
+    # One non-ensemble wasted report
+    _write_audit_report(task_dir, "dead-code-auditor", [], filename="dead-code.json")
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    # Only dead-code-auditor counts as wasted (count=1); vision-auditor's final
+    # report has findings so is not wasted after dedup
+    assert payload["count"] == 1
+    assert payload["status"] == "ok"
+
+
+def test_ensemble_cascade_succeeded_not_wasted(tmp_path, monkeypatch, capsys):
+    """An ensemble auditor whose final (latest mtime) report has findings is NOT
+    counted as wasted, even if earlier cascade tiers were empty."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    persistent = _persistent_for_cwd(dynos_home)
+    _write_spawn_budget_policy(persistent)
+
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "audit-plan.json").write_text(
+        json.dumps({"auditors": [{"name": "spec-auditor", "ensemble": True}]})
+    )
+
+    reports_dir = task_dir / "audit-reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    import time
+
+    p1 = reports_dir / "spec-auditor-tier1.json"
+    p1.write_text(json.dumps({"auditor": "spec-auditor", "findings": []}))
+    time.sleep(0.01)
+    p2 = reports_dir / "spec-auditor-tier2.json"
+    p2.write_text(json.dumps({"auditor": "spec-auditor", "findings": ["real-finding"]}))
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["count"] == 0
+    assert payload["status"] == "ok"
+
+
+def test_exempt_auditor_not_counted(tmp_path, monkeypatch, capsys):
+    """Auditors listed in policy exempt_auditors are NOT counted toward the budget."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    persistent = _persistent_for_cwd(dynos_home)
+    _write_spawn_budget_policy(
+        persistent,
+        per_task_class={
+            "feature:medium": {
+                "threshold_count": 2,
+                "waste_count_baseline": 1.0,
+                "waste_count_stddev": 0.0,
+                "n_observations": 3,
+            }
+        },
+        exempt_auditors=["vision-auditor"],
+    )
+
+    task_dir = _make_task_dir(tmp_path)
+
+    # Two wasted reports: one exempt, one not
+    _write_audit_report(task_dir, "vision-auditor", [], filename="exempt.json")
+    _write_audit_report(task_dir, "dead-code-auditor", [], filename="nonexempt.json")
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_check_spawn_budget(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    # Only dead-code-auditor counts (1 < threshold 2)
+    assert payload["count"] == 1
+    assert payload["exempt_count"] == 1
+    assert payload["status"] == "ok"
+
+
+def test_spawn_resume_clears_pause(tmp_path, monkeypatch, capsys):
+    """cmd_spawn_resume clears blocked_reason and writes spawn-budget-resumed receipt."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    task_dir = _make_task_dir(tmp_path, blocked_reason="wasted_spawns_exceeded")
+
+    args = argparse.Namespace(
+        task_dir=str(task_dir),
+        reason="enough chars to clear the pause cleanly",
+    )
+    rc = ctl.cmd_spawn_resume(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert json.loads(out) == {"status": "resumed"}
+
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    # blocked_reason should be cleared (None or absent)
+    assert manifest.get("blocked_reason") in (None,)
+
+    assert (task_dir / "receipts" / "spawn-budget-resumed.json").is_file()
+
+
+def test_spawn_resume_rejects_short_reason(tmp_path, monkeypatch, capsys):
+    """cmd_spawn_resume returns rc=1 and does NOT mutate manifest when reason < 20 chars."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    task_dir = _make_task_dir(tmp_path, blocked_reason="wasted_spawns_exceeded")
+
+    args = argparse.Namespace(task_dir=str(task_dir), reason="short")
+    rc = ctl.cmd_spawn_resume(args)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "--reason must be at least 20 characters" in err
+
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest.get("blocked_reason") == "wasted_spawns_exceeded"  # NOT mutated
+
+
+def test_spawn_resume_noop_when_not_paused(tmp_path, monkeypatch, capsys):
+    """cmd_spawn_resume returns already_resumed and writes no receipt when not paused."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    task_dir = _make_task_dir(tmp_path)  # no blocked_reason
+
+    args = argparse.Namespace(
+        task_dir=str(task_dir),
+        reason="long enough rationale here please",
+    )
+    rc = ctl.cmd_spawn_resume(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert json.loads(out) == {"status": "already_resumed"}
+    assert not (task_dir / "receipts" / "spawn-budget-resumed.json").exists()
+
+
+def test_auto_approve_veto_downgrades_when_paused(tmp_path, monkeypatch, capsys):
+    """cmd_apply_auto_approve_veto sets auto_approve_gates=False and blocked_by=spawn_budget_paused
+    when manifest.blocked_reason == wasted_spawns_exceeded."""
+    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    task_dir = _make_task_dir(
+        tmp_path,
+        classification={
+            "type": "feature",
+            "risk_level": "medium",
+            "domains": ["backend"],
+        },
+        blocked_reason="wasted_spawns_exceeded",
+        auto_approve_gates=True,
+    )
+
+    args = argparse.Namespace(task_dir=str(task_dir))
+    rc = ctl.cmd_apply_auto_approve_veto(args)
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["auto_approve_gates"] is False
+    assert payload["blocked_by"] == "spawn_budget_paused"
+
+    manifest = json.loads((task_dir / "manifest.json").read_text())
+    assert manifest["auto_approve_gates"] is False
+    policy = manifest["classification"]["auto_approval_policy"]
+    assert policy["blocked_by"] == "spawn_budget_paused"
+    assert policy["basis"]["spawn_budget_paused"] is True
+    assert "spawn_budget_paused" in policy["ceilings_checked"]


### PR DESCRIPTION
## Summary

- **Calibrates per-(task_type, risk_level) wasted-spawn thresholds** from retrospective history (`mean + 2*stddev`, capped 2..10, n>=3 gate) and emits `spawn-budget-policy.json` alongside the existing three policy files.
- **Pauses spawning live** via a new `ctl check-spawn-budget` subcommand that auditor and executor skill prose now run before each parallel batch. On `paused`/`already_paused`, skills write `escalation.md`, append `[BUDGET-PAUSE]` to `execution-log.md`, and exit non-zero.
- **Auto-derives `exempt_auditors`** from `auditor_zero_finding_streaks >= 5` in the most-recent retrospective per task. Streaks that reset (e.g. 6 → 3) drop the auditor from the exempt list.
- **Pause clearing** via `ctl spawn-resume --reason "..."` with a >=20-char rationale check; writes `spawn-budget-resumed` receipt.
- **Auto-approve gates** gain a 7th ceiling `spawn_budget_paused` evaluated after `global_policy` (one-way downgrade per existing convention).

## Files

- `memory/policy_engine.py` — `_build_spawn_budget_policy_data` + extended `_write_policy_json_files` (4-arg signature).
- `hooks/receipts/budget.py` (NEW) — `receipt_spawn_budget_paused` and `receipt_spawn_budget_resumed`.
- `hooks/lib_receipts.py`, `hooks/receipts/__init__.py` — re-exports.
- `hooks/ctl.py` — `cmd_check_spawn_budget`, `cmd_spawn_resume`, modified `cmd_apply_auto_approve_veto`.
- `skills/audit/SKILL.md`, `skills/execute/SKILL.md` — Step 3 preamble.
- `tests/test_spawn_budget_policy.py` (NEW) — 14 tests covering ACs 1-13 + the global_fallback regression test described below.
- `tests/test_auto_approve_gates.py` — schema test extended for the 7-ceiling list.

## Notable details

- **Spec drift**: spec said `manifest.classification["task_type"]`, but the codebase canonically uses `["type"]` (see `lib_validate.py:308` and `ctl.py:2798`). Implementation reads `type` first with `task_type` fallback. Documented in `evidence/segment-C-ctl-check-spawn.md`.
- **Audit-surfaced bug fixed inline**: `cmd_check_spawn_budget` originally read `policy["threshold_count"]` instead of `policy["global_fallback"]["threshold_count"]`. Bug was silent because the cold-start default and the hardcoded literal both equal 2, but a future change to the global fallback would have silently no-op'd. Added `test_check_spawn_budget_uses_global_fallback_threshold` as a regression guard.
- **Audit findings deferred** (non-blocking, tracked in postmortem-derived prevention rules): three new manifest writes use `write_json` instead of `_write_ctl_json` (matching existing `cmd_apply_auto_approve_veto` fallback pattern); `_persist_classification` clobbers caller-side mutations forcing a defensive load+rewrite in the new 7th-ceiling path; `_collect_ensemble_auditors` permissive dual-shape parser; `task_dir` `Path.resolve()` follows symlinks.

## Test plan

- [x] `python3 -m pytest tests/test_spawn_budget_policy.py -v` — 14 tests pass
- [x] `python3 -m pytest tests/ -p no:randomly` — full suite green: 1955 passed, 7 pre-existing skips
- [x] `python3 hooks/ctl.py check-spawn-budget --help` returns usage
- [x] `python3 hooks/ctl.py spawn-resume --help` returns usage
- [x] `python3 hooks/ctl.py check-spawn-budget .dynos/task-20260506-001` returns valid single-line JSON with the 5 spec'd keys

## Foundry pipeline

- Stage: DONE (15 ACs verified by spec-completion-auditor; 5 auditors PASS)
- Audit findings: 32 non-blocking across 5 auditors (security 7, code-quality 6, performance 4, spec-completion 15 info-tier, dead-code 0)
- Quality score: 0.9, Efficiency: 1.0
- Postmortem analysis ran (10 prevention rules generated, all dedup'd against existing rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)