### PR TITLE
feat: auditor envelope-contract hardening (three layered defenses)

### DIFF
--- a/agents/_shared/audit-report.md
+++ b/agents/_shared/audit-report.md
@@ -55,3 +55,16 @@ Auditor-specific notes:
 - `db-schema-auditor`: `severity` meanings: `critical` = data loss risk or broken referential integrity, `major` = missing index or N+1, `minor` = naming or minor optimization. Finding IDs use prefix `db-`.
 - `dead-code-auditor`: `severity` meanings: `critical` = unreferenced files or unused exports from core modules, `major` = dead functions or unused imports in multiple files, `minor` = single unused import or isolated commented-out block. Finding IDs use prefix `dc-`.
 - `performance-auditor`: `severity` meanings: `critical` = will cause outage at scale (connection leak, unbounded query), `major` = significant latency risk (N+1, missing index, missing timeout), `minor` = optimization opportunity. Finding IDs use prefix `perf-`. Category: `performance`.
+
+## Final-Message Envelope
+
+Your final message — the last text you return to the orchestrator — MUST be ONLY the following single-line JSON object, bare with no code fences and no surrounding prose:
+
+{"report_path": "<absolute-path-to-written-report>", "findings_count": N, "blocking_count": M}
+
+Rules:
+- `report_path` must exactly match the path string you used in your Write or Bash call — character for character.
+- `findings_count` is the integer count of all entries in the `findings` array.
+- `blocking_count` is the integer count of findings where `blocking` is `true`.
+- The JSON must fit on a single line. No code fences. No prose before or after. No whitespace before the opening `{` or after the closing `}`.
+- Even if you found zero findings, emit the envelope with `findings_count: 0` and `blocking_count: 0`.

--- a/agents/code-quality-auditor.md
+++ b/agents/code-quality-auditor.md
@@ -42,8 +42,6 @@ Violating this budget can waste 1M+ tokens per audit spawn.
 
 ## Turn Budget Discipline
 
-Final message MUST contain only a JSON code block matching the canonical audit-report schema. No prose, no commentary, no markdown around the JSON.
-
 Tool-use budget by model:
 
 | Model  | Max tool uses |
@@ -137,3 +135,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Doc-accuracy findings are based on deterministic hook output — do not hallucinate broken paths
 - Always write report
 - If evidence is ambiguous, classify against completion and maintainability, not in their favor
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/db-schema-auditor.md
+++ b/agents/db-schema-auditor.md
@@ -67,3 +67,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Think about production scale — not just "does it work in dev"
 - Always write report
 - If a migration or query is only safe under ideal data assumptions, report that assumption as a risk
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/dead-code-auditor.md
+++ b/agents/dead-code-auditor.md
@@ -40,8 +40,6 @@ Violating this budget can waste 1M+ tokens per audit spawn.
 
 ## Turn Budget Discipline
 
-Final message MUST contain only a JSON code block matching the canonical audit-report schema. No prose, no commentary, no markdown around the JSON.
-
 Tool-use budget by model:
 
 | Model  | Max tool uses |
@@ -100,3 +98,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Do not flag public API exports defined in the spec as unused
 - Always write your report
 - If an exception might apply, verify it; do not guess your way into leniency
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/performance-auditor.md
+++ b/agents/performance-auditor.md
@@ -88,3 +88,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Performance findings are based on code patterns and deterministic hook output — do not guess about runtime behavior without evidence
 - Always write report
 - If uncertainty remains, name the risky assumption instead of downgrading the issue
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -42,8 +42,6 @@ Violating this budget can waste 1M+ tokens per audit spawn.
 
 ## Turn Budget Discipline
 
-Final message MUST contain only a JSON code block matching the canonical audit-report schema. No prose, no commentary, no markdown around the JSON.
-
 Tool-use budget by model:
 
 | Model  | Max tool uses |
@@ -123,3 +121,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Focus on actual vulnerabilities, not best-practice suggestions
 - Compliance findings are based on deterministic hook output — do not hallucinate license or dependency data
 - Always write your report
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/spec-completion-auditor.md
+++ b/agents/spec-completion-auditor.md
@@ -42,8 +42,6 @@ Violating this budget can waste 1M+ tokens per audit spawn.
 
 ## Turn Budget Discipline
 
-Final message MUST contain only a JSON code block matching the canonical audit-report schema. No prose, no commentary, no markdown around the JSON.
-
 Tool-use budget by model:
 
 | Model  | Max tool uses |
@@ -87,3 +85,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Do not modify any files — you are read-only
 - Always write your report to the audit-reports directory
 - If evidence is ambiguous, resolve ambiguity against completion, not in its favor
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/agents/ui-auditor.md
+++ b/agents/ui-auditor.md
@@ -69,3 +69,15 @@ Write your report following the canonical schema defined in `agents/_shared/audi
 - Do not modify files
 - Always write report
 - If a state is implied by logic but never visibly rendered, treat it as missing
+
+## Final-Message Contract
+
+Your final message MUST be ONLY the envelope JSON defined in `agents/_shared/audit-report.md` — one line, no markdown fences, no prose:
+
+{"report_path": "<absolute-path>", "findings_count": N, "blocking_count": M}
+
+The full findings JSON lives on disk via your Write or Bash heredoc call. It NEVER appears inline in your final message.
+
+Returning the full report inline = failed run, will be re-spawned.
+
+This applies regardless of findings count — even zero findings requires the envelope with counts set to 0.

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2193,6 +2193,7 @@ def cmd_audit_receipt(args: argparse.Namespace) -> int:
             agent_path=args.agent_path,
             injected_agent_sha256=args.injected_agent_sha256,
             ensemble_context=args.ensemble_context,
+            final_envelope=args.final_envelope,
         )
     except Exception as exc:
         print(str(exc), file=sys.stderr)
@@ -6080,6 +6081,14 @@ def register_audit_parsers(subparsers: argparse._SubParsersAction) -> None:
         "--ensemble-context",
         action="store_true",
         help="Mark this receipt as part of ensemble voting/escalation.",
+    )
+    audit_receipt_parser.add_argument(
+        "--final-envelope",
+        default=None,
+        help=(
+            "Single-line bare JSON envelope returned in the auditor's final "
+            "message. Required for non-generic route_mode; optional for generic."
+        ),
     )
     audit_receipt_parser.set_defaults(func=cmd_audit_receipt)
 

--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -106,6 +106,14 @@ DIAGNOSTIC_ONLY_EVENTS: frozenset[str] = frozenset({
     # writer. Emitted when an auditor's spawn-log.jsonl is missing during
     # receipt write; observability only, no gate blocks on it.
     "audit_receipt_spawn_log_missing",
+    # Envelope cross-check failure (task-20260506-002). Emitted by
+    # _validate_final_envelope when the auditor's final-message envelope
+    # JSON does not match the on-disk report (path/findings_count/
+    # blocking_count) or fails parse/missing-keys/non-int validation.
+    # The receipt write also raises ValueError, so the gate path is the
+    # ValueError; this event is the forensic counterpart for diagnosing
+    # which of the 9 envelope fields diverged. Observability only.
+    "audit_envelope_mismatch",
     # Defense-in-depth content pairing (task-20260430-021). Emitted when
     # both spawn-log post entry AND on-disk audit-report file are present
     # at receipt time, recording the report file's sha256 alongside the

--- a/hooks/receipts/stage.py
+++ b/hooks/receipts/stage.py
@@ -550,6 +550,237 @@ def _assert_sidecar_match(
         )
 
 
+def _validate_final_envelope(
+    task_dir: Path,
+    auditor_name: str,
+    route_mode: str,
+    report_path: str | None,
+    final_envelope: str | None,
+) -> None:
+    """Validate the auditor's final-message JSON envelope.
+
+    Implements AC 5 sub-rules a–i:
+      a. generic + None  -> silent skip.
+      b. non-generic + None -> emit ``audit_envelope_mismatch`` event,
+         raise ValueError naming auditor + non-generic route_mode.
+      c. final_envelope not None -> ``json.loads`` with NO preprocessing.
+         JSONDecodeError -> emit + raise.
+      d. Result must be a dict containing keys ``report_path``,
+         ``findings_count``, ``blocking_count``.
+      e. ``findings_count`` and ``blocking_count`` must be int (booleans
+         excluded via ``isinstance(v, int) and not isinstance(v, bool)``).
+      f. STRICT string equality between envelope.report_path and the
+         caller-supplied ``report_path`` arg (no Path.resolve()).
+      g. Read on-disk report; assert envelope.findings_count ==
+         len(findings).
+      h. Assert envelope.blocking_count == count of findings whose
+         ``blocking is True`` (mirrors ``_build_audit_receipt_payload``).
+      i. Every emitted ``audit_envelope_mismatch`` event carries exactly
+         9 fields: task, auditor_name, route_mode,
+         expected_report_path, envelope_report_path,
+         expected_findings_count, envelope_findings_count,
+         expected_blocking_count, envelope_blocking_count. Each
+         ``log_event`` call wrapped in ``try/except Exception: pass``.
+    """
+    # Sub-rule (a): generic + None — silent skip.
+    if route_mode == "generic" and final_envelope is None:
+        return
+
+    def _emit(
+        envelope_report_path: Any,
+        expected_findings_count: int | None,
+        envelope_findings_count: Any,
+        expected_blocking_count: int | None,
+        envelope_blocking_count: Any,
+    ) -> None:
+        try:
+            log_event(
+                task_dir.parent.parent,
+                "audit_envelope_mismatch",
+                task=task_dir.name,
+                auditor_name=auditor_name,
+                route_mode=route_mode,
+                expected_report_path=report_path,
+                envelope_report_path=envelope_report_path,
+                expected_findings_count=expected_findings_count,
+                envelope_findings_count=envelope_findings_count,
+                expected_blocking_count=expected_blocking_count,
+                envelope_blocking_count=envelope_blocking_count,
+            )
+        except Exception:
+            pass
+
+    # Sub-rule (b): non-generic + None — required.
+    if final_envelope is None:
+        _emit(None, None, None, None, None)
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope is required for "
+            f"non-generic route_mode (got route_mode={route_mode!r}); "
+            f"the auditor's final message must be the bare JSON envelope."
+        )
+
+    # Sub-rule (c): json.loads with NO preprocessing.
+    try:
+        envelope = json.loads(final_envelope)
+    except json.JSONDecodeError as exc:
+        _emit(None, None, None, None, None)
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope is not valid JSON "
+            f"(route_mode={route_mode!r}): {exc}. The envelope must be a "
+            f"single bare JSON line — no markdown fences, no preprocessing."
+        ) from exc
+
+    # Sub-rule (d): must be dict with required keys.
+    if not isinstance(envelope, dict):
+        _emit(None, None, None, None, None)
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope must decode to a JSON "
+            f"object (got {type(envelope).__name__})."
+        )
+
+    required_keys = ("report_path", "findings_count", "blocking_count")
+    missing = [k for k in required_keys if k not in envelope]
+    if missing:
+        _emit(
+            envelope.get("report_path"),
+            None,
+            envelope.get("findings_count"),
+            None,
+            envelope.get("blocking_count"),
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope missing required "
+            f"key(s) {missing!r}; envelope must contain "
+            f"report_path, findings_count, blocking_count."
+        )
+
+    env_report_path = envelope.get("report_path")
+    env_findings_count = envelope.get("findings_count")
+    env_blocking_count = envelope.get("blocking_count")
+
+    # Sub-rule (e): integer (not bool) check on counts.
+    if not (isinstance(env_findings_count, int) and not isinstance(env_findings_count, bool)):
+        _emit(
+            env_report_path,
+            None,
+            env_findings_count,
+            None,
+            env_blocking_count,
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope.findings_count must "
+            f"be int, got {type(env_findings_count).__name__} "
+            f"({env_findings_count!r})."
+        )
+    if not (isinstance(env_blocking_count, int) and not isinstance(env_blocking_count, bool)):
+        _emit(
+            env_report_path,
+            None,
+            env_findings_count,
+            None,
+            env_blocking_count,
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope.blocking_count must "
+            f"be int, got {type(env_blocking_count).__name__} "
+            f"({env_blocking_count!r})."
+        )
+
+    # Sub-rule (f): STRICT string equality on report_path.
+    if env_report_path != report_path:
+        _emit(
+            env_report_path,
+            None,
+            env_findings_count,
+            None,
+            env_blocking_count,
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope.report_path mismatch "
+            f"(envelope={env_report_path!r}, expected={report_path!r}). "
+            f"Strict string equality required — no path normalization."
+        )
+
+    # Sub-rules (g)/(h): cross-check counts against on-disk report.
+    # SEC-001 (task-20260506-002): mirror the SEC-004 path-traversal guard
+    # used by _build_audit_receipt_payload. The validator must not open a
+    # path that escapes task_dir even when env_report_path == report_path
+    # (a compromised orchestrator could pass a traversal path that matches
+    # itself in both fields).
+    # IR 13 (task-20260506-002): missing/unreadable report file is a hard
+    # failure for any non-generic auditor or any caller that supplied a
+    # report_path. Silent skip on OSError/JSONDecodeError would let an
+    # auditor claim arbitrary counts for a report that was never written —
+    # exactly the upstream forgery vector this defense closes.
+    # SEC-002 (task-20260506-002): error messages must NOT echo
+    # ``actual_finding_count`` / ``actual_blocking_count``; the
+    # ``audit_envelope_mismatch`` event already records both values in
+    # structured form for forensic review. Exception text is propagated to
+    # stderr where a hostile orchestrator could read it back to discover
+    # the true counts and reconstruct a passing forged envelope.
+    actual_finding_count: int | None = None
+    actual_blocking_count: int | None = None
+    if isinstance(report_path, str) and report_path:
+        report_file = Path(report_path)
+        try:
+            resolved_report = report_file.resolve()
+            resolved_task = Path(task_dir).resolve()
+            resolved_report.relative_to(resolved_task)
+        except (ValueError, OSError) as exc:
+            _emit(env_report_path, None, env_findings_count, None, env_blocking_count)
+            raise ValueError(
+                f"audit-{auditor_name}: final_envelope.report_path must be "
+                f"inside task_dir ({resolved_task}); got {report_path!r}"
+            ) from exc
+        try:
+            with report_file.open("r", encoding="utf-8") as fh:
+                report_payload = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            _emit(env_report_path, None, env_findings_count, None, env_blocking_count)
+            raise ValueError(
+                f"audit-{auditor_name}: report file at {report_path!r} is "
+                f"missing or unreadable; the report must exist on disk "
+                f"before the envelope can be validated. Cause: "
+                f"{type(exc).__name__}."
+            ) from exc
+        findings = report_payload.get("findings", []) if isinstance(report_payload, dict) else []
+        if not isinstance(findings, list):
+            findings = []
+        actual_finding_count = len(findings)
+        actual_blocking_count = sum(
+            1 for f in findings
+            if isinstance(f, dict) and f.get("blocking") is True
+        )
+
+    if actual_finding_count is not None and env_findings_count != actual_finding_count:
+        _emit(
+            env_report_path,
+            actual_finding_count,
+            env_findings_count,
+            actual_blocking_count,
+            env_blocking_count,
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope.findings_count does "
+            f"not match the on-disk report. See audit_envelope_mismatch "
+            f"event for the structured field comparison."
+        )
+
+    if actual_blocking_count is not None and env_blocking_count != actual_blocking_count:
+        _emit(
+            env_report_path,
+            actual_finding_count,
+            env_findings_count,
+            actual_blocking_count,
+            env_blocking_count,
+        )
+        raise ValueError(
+            f"audit-{auditor_name}: final_envelope.blocking_count does "
+            f"not match the on-disk report. See audit_envelope_mismatch "
+            f"event for the structured field comparison."
+        )
+
+
 def _build_audit_receipt_payload(
     task_dir: Path,
     auditor_name: str,
@@ -849,6 +1080,7 @@ def receipt_audit_done(
     agent_path: str | None,
     injected_agent_sha256: str | None,
     ensemble_context: bool = False,
+    final_envelope: str | None = None,
 ) -> Path:
     """Write receipt proving an auditor completed.
 
@@ -883,6 +1115,15 @@ def receipt_audit_done(
     if injected_agent_sha256 is not None:
         _assert_sidecar_match(task_dir, auditor_name, model_used, injected_agent_sha256)
     _assert_spawn_log_evidence(task_dir, auditor_name)
+    _validate_final_envelope(
+        task_dir, auditor_name, route_mode, report_path, final_envelope,
+    )
+    if final_envelope is not None:
+        envelope_sha256: str | None = hashlib.sha256(
+            final_envelope.encode("utf-8")
+        ).hexdigest()
+    else:
+        envelope_sha256 = None
     _emit_content_pairing_event(task_dir, auditor_name, report_path)
     if tokens_used and tokens_used > 0:
         _record_tokens(task_dir, auditor_name, model_used or "default", tokens_used)
@@ -914,6 +1155,7 @@ def receipt_audit_done(
         route_mode=route_mode,
         agent_path=agent_path,
         injected_agent_sha256=injected_agent_sha256,
+        envelope_sha256=envelope_sha256,
     )
 
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -102,16 +102,22 @@ The command logs `learned_auditor_applied`, `learned_auditor_missing`, or `learn
 
 After each auditor spawn returns, you MUST write the audit receipt via the deterministic ctl wrapper below. Do NOT hand-write a Python `receipt_audit_done(...)` call. The wrapper derives `finding_count` and `blocking_count` from the on-disk report file so the model cannot mix one auditor/model's counts with another auditor/model's report. The captured digest must be the contents of the sidecar file the router just wrote — read it back rather than re-hashing:
 
+The auditor's final text message IS the envelope JSON (a single bare JSON line). Capture the result content from the Agent tool spawn return and pass it verbatim as `--final-envelope`.
+
 ```bash
 INJECTED_AGENT_SHA256=$(cat .dynos/task-{id}/receipts/_injected-auditor-prompts/{auditor_name}-{model_used}.sha256)
+FINAL_ENVELOPE=$(... <extract last line of Agent tool return>)
 python3 hooks/ctl.py audit-receipt .dynos/task-{id} {auditor_name} \
   --model {model_used} \
   --report-path .dynos/task-{id}/audit-reports/{report_filename}.json \
   --tokens-used {tokens_used} \
   --route-mode {route_mode} \
   --agent-path {agent_path} \
-  --injected-agent-sha256 "${INJECTED_AGENT_SHA256}"
+  --injected-agent-sha256 "${INJECTED_AGENT_SHA256}" \
+  --final-envelope "${FINAL_ENVELOPE}"
 ```
+
+For `route_mode == "generic"` the `--final-envelope` argument may be omitted.
 
 `python3 hooks/ctl.py audit-receipt ...` calls `receipt_audit_done(...)`, which re-asserts the same sidecar exists at that exact path and that its contents match `injected_agent_sha256`. A mismatch raises `ValueError`. For `route_mode == "generic"` (no learned agent) the sidecar assertion is skipped and `injected_agent_sha256` may be `None`; `route_mode` and `agent_path` are still required keyword arguments. The wrapper derives counts from `--report-path`; when no report exists it writes literal zero findings only. The new `receipt_audit_routing` writer also enforces these fields per-entry, so any auditor entry missing `injected_agent_sha256` (when non-generic) or `agent_path` will hard-fail at the routing-receipt write.
 

--- a/tests/test_audit_receipt_content_pairing.py
+++ b/tests/test_audit_receipt_content_pairing.py
@@ -100,10 +100,12 @@ def test_content_pairing_event_emitted_when_report_and_post_both_present(tmp_pat
     report_path.write_text(report_content)
     expected_report_sha = hashlib.sha256(report_content.encode("utf-8")).hexdigest()
 
+    envelope = json.dumps({"report_path": str(report_path), "findings_count": 0, "blocking_count": 0})
     receipt_audit_done(
         td, "security-auditor", "haiku", 0, 0, str(report_path), 100,
         route_mode="replace", agent_path="learned/x.md",
         injected_agent_sha256=digest,
+        final_envelope=envelope,
     )
 
     events = _read_events(td)
@@ -117,10 +119,14 @@ def test_content_pairing_event_emitted_when_report_and_post_both_present(tmp_pat
 
 def test_no_pairing_event_when_report_file_missing(tmp_path: Path):
     """When report_path is None (no on-disk file the receipt is binding to),
-    the pairing event is not emitted — there's nothing to pair against."""
+    the pairing event is not emitted — there's nothing to pair against.
+
+    Uses route_mode='generic' because task-20260506-002's final-envelope
+    contract makes 'replace' + report_path=None unreachable: the validator
+    requires either an envelope (which would also need a report file to
+    cross-check counts) or generic mode. The pairing-event semantics
+    (no report → no pairing) are independent of route_mode."""
     td = _task_dir(tmp_path)
-    digest = "a" * 64
-    _write_sidecar(td, "security-auditor", "haiku", digest)
     _write_spawn_log(td, [
         {"phase": "post", "tool": "Agent", "subagent_type": "security-auditor",
          "result_sha256": "r" * 64, "stop_reason": "end_turn", "timestamp": _ts()},
@@ -128,8 +134,8 @@ def test_no_pairing_event_when_report_file_missing(tmp_path: Path):
 
     receipt_audit_done(
         td, "security-auditor", "haiku", 0, 0, None, 100,
-        route_mode="replace", agent_path="learned/x.md",
-        injected_agent_sha256=digest,
+        route_mode="generic", agent_path=None,
+        injected_agent_sha256=None,
     )
 
     events = _read_events(td)

--- a/tests/test_receipt_audit_done.py
+++ b/tests/test_receipt_audit_done.py
@@ -27,14 +27,30 @@ def _write_sidecar(td: Path, auditor: str, model: str, digest: str) -> Path:
     return p
 
 
+def _write_report(td: Path, findings: list[dict]) -> Path:
+    """Write a real audit report JSON and return its path."""
+    report = td / "audit-reports" / "sec.json"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(json.dumps({"findings": findings}))
+    return report
+
+
 def test_matching_sidecar_passes(tmp_path: Path):
     td = _task_dir(tmp_path)
     digest = "a" * 64
     _write_sidecar(td, "security-auditor", "haiku", digest)
+    # Write an empty report so the envelope path and counts match on disk.
+    report = _write_report(td, [])
+    final_envelope = json.dumps({
+        "report_path": str(report),
+        "findings_count": 0,
+        "blocking_count": 0,
+    })
     out = receipt_audit_done(
-        td, "security-auditor", "haiku", 0, 0, None, 100,
+        td, "security-auditor", "haiku", 0, 0, str(report), 100,
         route_mode="replace", agent_path="learned/x.md",
         injected_agent_sha256=digest,
+        final_envelope=final_envelope,
     )
     assert out.exists()
     payload = json.loads(out.read_text())

--- a/tests/test_receipt_audit_done_envelope.py
+++ b/tests/test_receipt_audit_done_envelope.py
@@ -140,15 +140,20 @@ def test_envelope_report_path_mismatch_raises(tmp_path: Path):
 
     assert not receipt_path.exists(), "Receipt must NOT be written when envelope mismatches"
 
-    # Verify audit_envelope_mismatch event was emitted
-    events_file = td.parent.parent / "events.jsonl"
+    # Verify audit_envelope_mismatch event was emitted.
+    # log_event is called with task_dir.parent.parent as root and task_dir.name
+    # as the task kwarg. Since the task directory exists, log_event routes the
+    # event to the task-scoped log: <root>/.dynos/<task>/events.jsonl, which
+    # equals td / "events.jsonl".
+    events_file = td / "events.jsonl"
     assert events_file.exists(), "events.jsonl must exist after mismatch event"
     lines = [l.strip() for l in events_file.read_text().splitlines() if l.strip()]
     assert lines, "events.jsonl must have at least one event"
     last_event = json.loads(lines[-1])
 
-    assert last_event.get("type") == "audit_envelope_mismatch", (
-        f"Last event type must be 'audit_envelope_mismatch', got {last_event.get('type')!r}"
+    # log_event stores the event type under the key "event", not "type"
+    assert last_event.get("event") == "audit_envelope_mismatch", (
+        f"Last event type must be 'audit_envelope_mismatch', got {last_event.get('event')!r}"
     )
     # Verify all 9 required fields are present
     required_fields = [

--- a/tests/test_receipt_audit_done_envelope.py
+++ b/tests/test_receipt_audit_done_envelope.py
@@ -1,0 +1,351 @@
+"""Tests for receipt_audit_done final-envelope validation (AC 9).
+
+Eight tests covering:
+  - valid envelope → receipt written with envelope_sha256 (64-char hex)
+  - envelope report_path mismatch → ValueError + audit_envelope_mismatch event
+  - envelope findings_count mismatch → ValueError
+  - envelope blocking_count mismatch → ValueError
+  - final_envelope=None on non-generic → ValueError naming "required"/"non-generic"
+  - final_envelope=None on generic → receipt written, envelope_sha256 is None
+  - invalid JSON (code-fenced) → ValueError
+  - non-integer count field → ValueError naming the field and its type
+
+These tests are written TDD-first: they WILL FAIL until segment-2-code lands
+the _validate_final_envelope helper and the final_envelope kwarg on
+receipt_audit_done. That failure is the intended TDD signal.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from lib_receipts import receipt_audit_done  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — mirrors tests/test_receipt_audit_done_selfverify.py exactly
+# ---------------------------------------------------------------------------
+
+def _make_task(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    td = project / ".dynos" / "task-20260419-AS"
+    td.mkdir(parents=True)
+    return td
+
+
+def _write_report(task_dir: Path, findings: list[dict]) -> Path:
+    """Write a real audit report JSON and return its path."""
+    report = task_dir / "audit-reports" / "sec.json"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(json.dumps({"findings": findings}))
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Sidecar helper — mirrors tests/test_receipt_audit_done.py _write_sidecar
+# ---------------------------------------------------------------------------
+
+def _write_sidecar(task_dir: Path, auditor: str, model: str, digest: str) -> Path:
+    sidecar_dir = task_dir / "receipts" / "_injected-auditor-prompts"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    p = sidecar_dir / f"{auditor}-{model}.sha256"
+    p.write_text(digest)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Test 1: valid envelope for non-generic route → receipt written with 64-char hex
+# ---------------------------------------------------------------------------
+
+def test_envelope_match_passes(tmp_path: Path):
+    """AC 9: valid envelope matching on-disk report for non-generic auditor.
+
+    Receipt must be written and envelope_sha256 must be a 64-char lowercase hex
+    string derived from SHA-256 of the final_envelope string.
+    """
+    td = _make_task(tmp_path)
+    findings = [
+        {"id": "F-1", "blocking": True},
+        {"id": "F-2", "blocking": False},
+        {"id": "F-3", "blocking": True},
+    ]
+    report = _write_report(td, findings)
+    digest = "a" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    envelope = json.dumps({
+        "report_path": str(report),
+        "findings_count": 3,
+        "blocking_count": 2,
+    })
+
+    out = receipt_audit_done(
+        td, "security-auditor", "haiku", 3, 2, str(report), 100,
+        route_mode="replace",
+        agent_path="learned/security-auditor.md",
+        injected_agent_sha256=digest,
+        final_envelope=envelope,
+    )
+
+    assert out.exists(), "Receipt file must be written on valid envelope"
+    payload = json.loads(out.read_text())
+    sha = payload.get("envelope_sha256")
+    assert sha is not None, "envelope_sha256 must be present in receipt"
+    assert isinstance(sha, str), "envelope_sha256 must be a string"
+    assert len(sha) == 64, f"envelope_sha256 must be 64 hex chars, got {len(sha)}"
+    assert sha == sha.lower(), "envelope_sha256 must be lowercase hex"
+    # Verify the hash is actually SHA-256 of the envelope bytes
+    import hashlib
+    expected_sha = hashlib.sha256(envelope.encode("utf-8")).hexdigest()
+    assert sha == expected_sha, "envelope_sha256 must be SHA-256 of the final_envelope string"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: envelope report_path mismatch → ValueError + event in events.jsonl
+# ---------------------------------------------------------------------------
+
+def test_envelope_report_path_mismatch_raises(tmp_path: Path):
+    """AC 9: envelope.report_path != arg.report_path → ValueError raised.
+
+    Receipt must not be written. An audit_envelope_mismatch event must be
+    emitted to events.jsonl with all 9 required fields.
+    """
+    td = _make_task(tmp_path)
+    findings = [{"id": "F-1", "blocking": False}]
+    report = _write_report(td, findings)
+    digest = "b" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    wrong_path = str(report.parent / "other-report.json")
+    envelope = json.dumps({
+        "report_path": wrong_path,       # <-- deliberately wrong
+        "findings_count": 1,
+        "blocking_count": 0,
+    })
+
+    receipt_path = td / "receipts" / "audit-security-auditor.json"
+
+    with pytest.raises(ValueError):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 1, 0, str(report), 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=envelope,
+        )
+
+    assert not receipt_path.exists(), "Receipt must NOT be written when envelope mismatches"
+
+    # Verify audit_envelope_mismatch event was emitted
+    events_file = td.parent.parent / "events.jsonl"
+    assert events_file.exists(), "events.jsonl must exist after mismatch event"
+    lines = [l.strip() for l in events_file.read_text().splitlines() if l.strip()]
+    assert lines, "events.jsonl must have at least one event"
+    last_event = json.loads(lines[-1])
+
+    assert last_event.get("type") == "audit_envelope_mismatch", (
+        f"Last event type must be 'audit_envelope_mismatch', got {last_event.get('type')!r}"
+    )
+    # Verify all 9 required fields are present
+    required_fields = [
+        "task", "auditor_name", "route_mode",
+        "expected_report_path", "envelope_report_path",
+        "expected_findings_count", "envelope_findings_count",
+        "expected_blocking_count", "envelope_blocking_count",
+    ]
+    for field in required_fields:
+        assert field in last_event, f"audit_envelope_mismatch event must contain field {field!r}"
+
+    assert last_event["task"] == td.name
+    assert last_event["auditor_name"] == "security-auditor"
+    assert last_event["route_mode"] == "replace"
+    assert last_event["expected_report_path"] == str(report)
+    assert last_event["envelope_report_path"] == wrong_path
+
+
+# ---------------------------------------------------------------------------
+# Test 3: findings_count mismatch → ValueError
+# ---------------------------------------------------------------------------
+
+def test_envelope_findings_count_mismatch_raises(tmp_path: Path):
+    """AC 9: envelope claims wrong findings_count → ValueError raised, no receipt."""
+    td = _make_task(tmp_path)
+    findings = [
+        {"id": "F-1", "blocking": False},
+        {"id": "F-2", "blocking": False},
+        {"id": "F-3", "blocking": False},
+    ]
+    report = _write_report(td, findings)  # 3 findings on disk
+    digest = "c" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    envelope = json.dumps({
+        "report_path": str(report),
+        "findings_count": 5,   # <-- wrong: disk has 3
+        "blocking_count": 0,
+    })
+
+    receipt_path = td / "receipts" / "audit-security-auditor.json"
+
+    with pytest.raises(ValueError):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 3, 0, str(report), 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=envelope,
+        )
+
+    assert not receipt_path.exists(), "Receipt must NOT be written on findings_count mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: blocking_count mismatch → ValueError
+# ---------------------------------------------------------------------------
+
+def test_envelope_blocking_count_mismatch_raises(tmp_path: Path):
+    """AC 9: envelope claims wrong blocking_count → ValueError raised, no receipt."""
+    td = _make_task(tmp_path)
+    findings = [
+        {"id": "F-1", "blocking": True},
+        {"id": "F-2", "blocking": True},
+        {"id": "F-3", "blocking": False},
+    ]
+    report = _write_report(td, findings)  # 2 blocking on disk
+    digest = "d" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    envelope = json.dumps({
+        "report_path": str(report),
+        "findings_count": 3,
+        "blocking_count": 0,   # <-- wrong: disk has 2 blocking
+    })
+
+    receipt_path = td / "receipts" / "audit-security-auditor.json"
+
+    with pytest.raises(ValueError):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 3, 2, str(report), 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=envelope,
+        )
+
+    assert not receipt_path.exists(), "Receipt must NOT be written on blocking_count mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: final_envelope=None on non-generic → ValueError
+# ---------------------------------------------------------------------------
+
+def test_missing_envelope_non_generic_raises(tmp_path: Path):
+    """AC 9: final_envelope=None with route_mode='replace' → ValueError.
+
+    The error message must name 'required' or 'non-generic' so the orchestrator
+    knows why the receipt was refused.
+    """
+    td = _make_task(tmp_path)
+    digest = "e" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    with pytest.raises(ValueError, match=r"required|non-generic"):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 0, 0, None, 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: final_envelope=None on generic → receipt written, envelope_sha256 is None
+# ---------------------------------------------------------------------------
+
+def test_generic_skips_envelope_check(tmp_path: Path):
+    """AC 9: final_envelope=None with route_mode='generic' → receipt written.
+
+    envelope_sha256 must be None in the receipt JSON (validation skipped).
+    """
+    td = _make_task(tmp_path)
+
+    out = receipt_audit_done(
+        td, "security-auditor", "haiku", 0, 0, None, 100,
+        route_mode="generic",
+        agent_path=None,
+        injected_agent_sha256=None,
+        final_envelope=None,
+    )
+
+    assert out.exists(), "Receipt must be written for generic route_mode with no envelope"
+    payload = json.loads(out.read_text())
+    assert "envelope_sha256" in payload, "envelope_sha256 field must be present in receipt"
+    assert payload["envelope_sha256"] is None, (
+        "envelope_sha256 must be None when envelope validation was skipped (generic mode)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: invalid JSON (code-fenced) → ValueError
+# ---------------------------------------------------------------------------
+
+def test_invalid_json_envelope_raises(tmp_path: Path):
+    """AC 9 / Error 2: code-fenced envelope triggers json.JSONDecodeError → ValueError.
+
+    An auditor that wraps its JSON in markdown fences violates the single-line
+    bare JSON contract. The validator must reject it without preprocessing.
+    """
+    td = _make_task(tmp_path)
+    findings = [{"id": "F-1", "blocking": False}]
+    report = _write_report(td, findings)
+    digest = "f" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    # Code-fenced envelope — json.loads will raise JSONDecodeError
+    fenced_envelope = f'```json\n{{"report_path": "{report}", "findings_count": 1, "blocking_count": 0}}\n```'
+
+    with pytest.raises(ValueError):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 1, 0, str(report), 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=fenced_envelope,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: non-integer counts → ValueError naming field and type
+# ---------------------------------------------------------------------------
+
+def test_non_integer_counts_raise(tmp_path: Path):
+    """AC 9 / Error 4: findings_count as string '5' → ValueError naming the field.
+
+    The error message must name the non-integer field and its actual type so
+    the orchestrator can diagnose the auditor's emission mistake.
+    """
+    td = _make_task(tmp_path)
+    findings = [{"id": "F-1", "blocking": False}]
+    report = _write_report(td, findings)
+    digest = "0" * 64
+    _write_sidecar(td, "security-auditor", "haiku", digest)
+
+    envelope = json.dumps({
+        "report_path": str(report),
+        "findings_count": "5",   # <-- string, not int
+        "blocking_count": 0,
+    })
+
+    with pytest.raises(ValueError, match=r"findings_count|str"):
+        receipt_audit_done(
+            td, "security-auditor", "haiku", 1, 0, str(report), 100,
+            route_mode="replace",
+            agent_path="learned/security-auditor.md",
+            injected_agent_sha256=digest,
+            final_envelope=envelope,
+        )

--- a/tests/test_receipt_audit_spawn_log_crosscheck.py
+++ b/tests/test_receipt_audit_spawn_log_crosscheck.py
@@ -71,6 +71,26 @@ def _ts() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+def _write_zero_report(td: Path, auditor: str) -> Path:
+    """Write a minimal zero-finding audit-report so the new envelope cross-check
+    (task-20260506-002) has a real on-disk file to compare against. Returns the
+    report path. Spawn-log tests use this to keep route_mode='replace' coverage
+    while satisfying the envelope contract."""
+    audit_dir = td / "audit-reports"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    p = audit_dir / f"{auditor}-checkpoint-001.json"
+    p.write_text(json.dumps({"findings": [], "auditor": auditor}, indent=2))
+    return p
+
+
+def _envelope_for(report_path: Path, findings_count: int = 0, blocking_count: int = 0) -> str:
+    return json.dumps({
+        "report_path": str(report_path),
+        "findings_count": findings_count,
+        "blocking_count": blocking_count,
+    })
+
+
 # ---------------------------------------------------------------------------
 # Existing sidecar contract still holds; spawn-log enforcement is additive.
 # ---------------------------------------------------------------------------
@@ -86,10 +106,12 @@ def test_matching_spawn_log_entry_passes(tmp_path: Path):
          "result_excerpt": "FINDINGS: none", "stop_reason": "end_turn",
          "timestamp": _ts()},
     ])
+    report = _write_zero_report(td, "security-auditor")
     out = receipt_audit_done(
-        td, "security-auditor", "haiku", 0, 0, None, 100,
+        td, "security-auditor", "haiku", 0, 0, str(report), 100,
         route_mode="replace", agent_path="learned/x.md",
         injected_agent_sha256=digest,
+        final_envelope=_envelope_for(report),
     )
     assert out.exists()
 
@@ -137,10 +159,12 @@ def test_subagent_type_audit_prefix_matches_auditor_suffix(tmp_path: Path):
         {"phase": "post", "tool": "Agent", "subagent_type": "audit-spec-completion",
          "result_sha256": "r" * 64, "stop_reason": "end_turn", "timestamp": _ts()},
     ])
+    report = _write_zero_report(td, "spec-completion-auditor")
     out = receipt_audit_done(
-        td, "spec-completion-auditor", "haiku", 0, 0, None, 100,
+        td, "spec-completion-auditor", "haiku", 0, 0, str(report), 100,
         route_mode="replace", agent_path="learned/x.md",
         injected_agent_sha256=digest,
+        final_envelope=_envelope_for(report),
     )
     assert out.exists()
 
@@ -153,10 +177,12 @@ def test_missing_spawn_log_file_proceeds_gracefully(tmp_path: Path, monkeypatch)
     digest = "a" * 64
     _write_sidecar(td, "security-auditor", "haiku", digest)
     # No spawn-log.jsonl at all
+    report = _write_zero_report(td, "security-auditor")
     out = receipt_audit_done(
-        td, "security-auditor", "haiku", 0, 0, None, 100,
+        td, "security-auditor", "haiku", 0, 0, str(report), 100,
         route_mode="replace", agent_path="learned/x.md",
         injected_agent_sha256=digest,
+        final_envelope=_envelope_for(report),
     )
     assert out.exists()
 


### PR DESCRIPTION
## Summary

- Closes the upstream behavior that triggered audit re-spawn loops and was the upstream precondition for the 2026-04-30 audit-chain forgery incident. The forgery vector itself is already closed by `write_policy` + spawn-log cross-check; this task fixes the contradictory prompt that caused auditors to emit JSON inline instead of writing the report file.
- **L1** — delete contradictory `Final message MUST contain only a JSON code block` line from 4 auditor agents. It told auditors their final message WAS the report, conflicting with the separate Write instruction; auditors obeyed the stronger terminal-position constraint and skipped the Write call.
- **L2** — add `Final-Message Envelope` schema to `agents/_shared/audit-report.md` defining `{report_path, findings_count, blocking_count}`. Byte-identical `Final-Message Contract` block added to all 7 auditor agents.
- **L3** — new `--final-envelope` arg on `hooks/ctl.py audit-receipt` forwards to `receipt_audit_done`. New `_validate_final_envelope` helper in `hooks/receipts/stage.py`: strict `json.loads`, strict string equality on `report_path`, hard-fail when missing on non-generic, boolean-as-int defended count check, 9-field `audit_envelope_mismatch` event. Receipt JSON gains `envelope_sha256` for chain-of-custody.

## Repair-cycle hardening (post-checkpoint-audit)

- **Path-traversal guard**: `_validate_final_envelope` now resolves `report_path` and rejects paths escaping `task_dir`, mirroring SEC-004 in `_build_audit_receipt_payload`.
- **Missing-file is hard fail**: previous silent-skip on `OSError`/`JSONDecodeError` violated implicit requirement 13 (an auditor could claim arbitrary counts for a report never written).
- **Error messages sanitized**: no longer echo actual on-disk counts (info-disclosure oracle); structured event still has them for forensics.

## Test plan

- [x] `pytest tests/test_receipt_audit_done_envelope.py` — 8 new envelope tests (match passes, path mismatch, count mismatches, missing-envelope hard fail, generic skip, invalid JSON, code-fenced JSON rejected, non-int counts rejected)
- [x] `pytest tests/test_receipt_audit_done.py tests/test_receipt_audit_done_selfverify.py` — existing non-generic calls updated for new contract
- [x] `pytest tests/test_audit_receipt_content_pairing.py tests/test_receipt_audit_spawn_log_crosscheck.py` — 5 collateral test updates
- [x] `pytest tests/` — full suite passes (1958/0)
- [x] `audit_envelope_mismatch` added to `DIAGNOSTIC_ONLY_EVENTS` allowlist in `hooks/lib_log.py`
- [x] dynos-work checkpoint audit: 7/7 auditors PASS after repair cycle 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)