### PR TITLE
feat: residual queue dependency gating + OSS Tier 0/1 hardening spec

### DIFF
--- a/docs/foundry-hardening-spec.md
+++ b/docs/foundry-hardening-spec.md
@@ -1,0 +1,221 @@
+# Foundry Hardening Spec — OSS Tier 0/1
+
+**Status:** Proposal. Decomposes into three execution-phase tasks.
+
+**Predecessor docs:** `docs/write-boundary-spec.md`, `ARCHITECTURE.md`, `memory/project_audit_forgery_incident.md`, `memory/project_open_trust_residuals.md`.
+
+**Scope:** This spec covers what an open-source `dynos-work` should ship. It closes the two CRITICAL findings (C1: native Python I/O bypasses write-policy; C2: predictable HMAC project-secret) and one HIGH finding (H1: cross-task `eventbus_handler` forgery) without degrading the single-developer workflow. Higher-assurance controls (signed artifacts, two-actor approval, off-host append-only logs, confidential computing, post-quantum crypto) are explicitly out of scope and tracked as Tier 2+ for downstream/proprietary forks.
+
+---
+
+## 0. Bottom Line
+
+Today, dynos-work has a homemade userspace integrity layer. Several defenses (HMAC-chained receipt log, spawn-log cross-check, write-policy gate) are well-engineered. None of them survives an executor subagent that does `Bash python3 -c "Path('spawn-log.jsonl').write_text(...)"` because all enforcement lives in code that the subagent's Bash tool can also run.
+
+This spec does NOT add features. It moves three existing defenses from advisory (a comment in `write_policy.py`) to mechanical (kernel-enforced, hardware-anchored, per-task isolated) — and does so under a `compliance-tier` setting that defaults to today's behavior so no current user sees breakage.
+
+**Tier 0 (default, unchanged):** Today's behavior. Userspace policy. Cleartext secret cache. Project-global events.jsonl. The single developer running `/dynos-work:start` on their laptop sees zero change.
+
+**Tier 1 (opt-in, ships with OSS):** Kernel-enforced subagent sandbox + OS-keychain-anchored project secret + per-task events log. Closes C1, C2, H1. Activated by `compliance-tier=tier-1` in the project's policy.json. UX cost: one-time keychain setup at first task; sub-millisecond sandbox launch overhead per spawn.
+
+---
+
+## 1. Threat Model (OSS scope)
+
+### Adversary classes IN scope
+
+- **A1 — Compromised orchestrator LLM.** The model running the skill prompt is hostile or coerced (jailbreak, prompt injection from upstream input). It can call any tool the harness exposes and can spawn subagents whose prompts it controls.
+- **A2 — Compromised subagent.** A spawned executor or auditor returns hostile output, attempts to escalate role, attempts to write a control-plane file via Bash → Python.
+- **A3 — Same-UID persistent-state attacker.** Any process with the same UID as the orchestrator (other terminals, background jobs, post-exploitation footholds) has read/write access to `~/.dynos/projects/<slug>/` and `.dynos/`.
+
+### Adversary classes OUT of scope (deferred to Tier 2+)
+
+- **A4 — Supply-chain attacker** controlling a learned-agent file or a prevention rule. Tier 2 closes this with signed artifacts; Tier 1 leaves it residual and documents the gap.
+- **A5 — Distribution attacker** substituting plugin contents in transit. Closed by repo-level mechanisms (git, GitHub) and operator install hygiene; Tier 2 adds Sigstore.
+- **A6 — Insider** acting outside policy. Closed by Tier 2 two-actor approval; Tier 1 single-developer use accepts insider risk by definition.
+- **A7 — Hardware compromise** of the workstation. Defended by the host platform (Secure Boot, TPM, full-disk encryption); not in foundry's scope.
+- **A8 — LLM provider trust.** Mitigated at the contract layer with the model provider; not in foundry's code.
+
+### Security goals (must hold under any A1–A3 compromise at Tier 1)
+
+- **G1 — No forged receipts.** A subagent cannot create or modify a receipt that passes chain validation.
+- **G2 — No forged spawns.** The `spawn-log.jsonl` cross-check (the post-2026-04-30 forgery defense) cannot be defeated by a subagent appending to the log.
+- **G3 — No project-secret recovery.** An A3 attacker reading the persistent project directory cannot recover the HMAC project secret.
+- **G4 — No cross-task event injection.** Events written by task A cannot be consumed as evidence by task B's gates.
+
+---
+
+## 2. Architectural Principles (Tier 1)
+
+- **P1 — Userspace policy is advisory; kernel policy is authoritative.** Every load-bearing trust boundary at Tier 1 is enforced by the OS (Landlock on Linux 5.13+, `sandbox-exec` on macOS, `bwrap` namespace fallback on older Linux) at subagent process boundary. `write_policy.py` remains as a fast pre-check + diagnostic layer; it is no longer the only enforcement.
+- **P2 — Anchored secrets only.** No HMAC key derives from environment-deterministic inputs (path, hostname, user). The project secret lives in the OS keychain (macOS Keychain Services, Linux Secret Service / libsecret). Per-task derivations chain via HKDF-SHA256 from the anchored secret.
+- **P3 — Per-task evidence isolation.** Events used as evidence for a specific task's gates live in that task's directory, signed under that task's per-task HMAC. Cross-task aggregation reads from the on-host stream but only consumes events whose signature verifies under the consuming task's anchor.
+- **P4 — Tier 0 backward compatibility.** Tier 1 must be opt-in. A repository with `compliance-tier` unset or `tier-0` runs unchanged. A repository setting `tier-1` runs hardened. Both modes pass the same test suite.
+
+---
+
+## 3. Phased Program
+
+Each phase becomes one `/dynos-work:start` task. ACs are concrete and testable.
+
+### Phase 1 — Subagent process sandbox (closes C1)
+
+**Goal:** Make `write_policy.py`'s decisions kernel-enforced for the subagent boundary at Tier 1.
+
+**Acceptance criteria:**
+
+1. New module `hooks/sandbox.py` exposes `launch_sandboxed_subagent(role, allowed_writes: list[Path], task_dir: Path)` that wraps the harness's Agent-spawn entry point with a per-platform kernel sandbox:
+   - **Linux 5.13+**: Landlock ABI v3+ (filesystem rules) plus seccomp-bpf (block `ptrace`, `process_vm_writev`, `bpf`).
+   - **Linux <5.13**: `bwrap` (bubblewrap) with read-only bind mounts for `hooks/` + `agents/`, tmpfs for everything else, an explicit allowlist of writable paths.
+   - **macOS**: `sandbox-exec` with a generated `.sb` profile derived from `write_policy.py`'s decisions for the role. Acknowledged that `sandbox-exec` is deprecated; macOS support is best-effort and gap-documented (see R1).
+2. The role-specific allowlist is materialized from `hooks/write_policy.py`'s decision matrix at sandbox-launch time and embedded in the kernel policy. The Python-level `decide_write` function is no longer consulted by sandboxed subagents — they simply receive `EACCES` from the kernel on disallowed writes.
+3. `hooks/agent-spawn-log` runs in its own sandbox where `spawn-log.jsonl` is the ONLY writable path (no other principal — including the orchestrator's own process — can `open()` it for writing under Tier 1).
+4. Adversarial test in `tests/test_sandbox_executor_cannot_write_control_plane.py`:
+   - Spawns an executor subagent under Tier 1.
+   - Subagent runs `Bash python3 -c "from pathlib import Path; Path('.dynos/task-X/spawn-log.jsonl').write_text(...)"`.
+   - Test asserts: write fails with `PermissionError`, no spawn-log entry was added, and a `sandbox_violation` event is emitted under the supervisor's secret (separate from the task's HMAC).
+5. Tier 0 path is preserved: when `compliance-tier` is unset or `tier-0`, `launch_sandboxed_subagent` becomes a passthrough that calls the existing Agent-spawn entry point with no kernel policy applied. Existing test suite must pass unchanged.
+6. Sandbox launch overhead measured at <2ms per spawn on Linux Landlock and <10ms on macOS `sandbox-exec`. Recorded as a deterministic event for telemetry; regression is a CI failure.
+7. New CLI: `python3 hooks/ctl.py sandbox-test --role <role>` runs a self-check that verifies the sandbox actually denies a known-bad write. Operator runs this once after installation; result becomes part of `compliance-check` (Phase 4).
+
+**Out of scope for Phase 1:** Windows support. Sandboxing the orchestrator itself (orchestrator is the Claude Code harness; not foundry's process to sandbox). Confidential computing / SEV-SNP / TDX (Tier 3).
+
+**Audit gate:** After implementation, run a one-shot adversarial test pack that exercises every documented write_policy denial path through a Tier 1 subagent's Bash → Python escape route. All must produce `EACCES`, not silent success.
+
+### Phase 2 — OS-keychain-anchored project secret (closes C2)
+
+**Goal:** Eliminate the predictable `sha256(path:hostname)` derivation in `hooks/lib_log.py:192-195`.
+
+**Acceptance criteria:**
+
+1. New module `hooks/secret_anchor.py` exposes `get_project_secret(root: Path) -> bytes` that resolves the project secret in this order:
+   - (a) `DYNOS_EVENT_SECRET` env var (unchanged from today, preserves Tier 0 escape hatch).
+   - (b) **Tier 1 only**: OS keychain entry under service `"dynos-work-project"`, account `<project-slug>`. Read via:
+     - **macOS**: Keychain Services API via `security find-generic-password` or `keychain` Python binding.
+     - **Linux**: libsecret / Secret Service API via `keyring` Python library (already a common dep). Falls through if no D-Bus session (e.g., headless server) — see R2.
+   - (c) **Tier 1 only**: if no keychain entry exists, generate a 32-byte secret from `secrets.token_bytes(32)` and store it in the keychain. First-run is automatic; no operator gesture required.
+   - (d) **Tier 0 only**: existing 0o600 file at `_persistent_project_dir(root) / "event-secret"`. Behavior unchanged.
+2. `hooks/lib_log.py::_resolve_event_secret` delegates to `secret_anchor.get_project_secret` when `compliance-tier=tier-1`. The deterministic `sha256(f"{root.resolve()}:{platform.node()}")` fallback at lines 192-195 is REMOVED FROM THE TIER 1 PATH (still present in the Tier 0 path because removing it would break existing repos).
+3. Per-task derivation moves from string concatenation to HKDF-SHA256:
+   - Replace `_derive_per_task_secret(secret, task_id)` body with `HKDF(salt=task_id.encode(), info=b"dynos-work/v1/per-task-event-secret", length=32, algorithm=SHA256).derive(secret)`.
+   - The HKDF call lives in `hooks/secret_anchor.py`. `lib_log.py` imports the helper.
+   - Tier 0 path keeps the existing string-concat derivation (mathematical change is breaking; gated by tier).
+4. Adversarial test in `tests/test_secret_anchor_unrecoverable_from_disk.py`:
+   - Under Tier 1, after first run, the persistent project directory contains NO file whose contents reveal the secret.
+   - Test reads every byte of every file under `_persistent_project_dir(root)` and asserts none decode to the active project secret.
+   - Test deletes the on-disk persistent dir, regenerates from keychain, and asserts the secret survives.
+5. Migration: a one-shot CLI `python3 hooks/ctl.py secret-anchor migrate` reads the existing 0o600 file (Tier 0), writes the same value to the keychain, and deletes the file. Operator can roll back by re-flipping `compliance-tier=tier-0`.
+6. Documentation in `docs/secret-anchor.md` covers the threat model (G3), the keychain location per platform, and the migration procedure.
+
+**Out of scope for Phase 2:** TPM/HSM/YubiKey integration (Tier 2). Multi-device anchor with M-of-N recovery (Tier 2). Key rotation procedure (Tier 2 — Tier 1 keys persist for the project's lifetime).
+
+**Audit gate:** Cryptographic review of HKDF parameters and the keychain wrapper. The audit tool from Phase 1 is extended to confirm the post-Tier-1 disk state contains no recoverable secret.
+
+### Phase 3 — Per-task events.jsonl (closes H1 partially)
+
+**Goal:** Close the documented cross-task `eventbus_handler` forgery residual (memory: project_open_trust_residuals.md, finding 1) within OSS scope. The full closure (off-host append-only log) remains Tier 2.
+
+**Acceptance criteria:**
+
+1. New events written by `hooks/lib_log.py::log_event` go to `<task_dir>/events.jsonl` instead of `.dynos/events.jsonl` when `task` is non-None and `compliance-tier=tier-1`. The project-global `.dynos/events.jsonl` continues to exist for non-task events and for cross-task aggregation reads, but is no longer the source of truth for any single task's gates.
+2. `hooks/lib_log.py::iter_events` and every consumer that reads `events.jsonl` for a specific task (search: `policy_engine.py::_build_events_by_task`, `lib_validate.py` retrospective integrity check, `receipts/stage.py::_assert_spawn_log_evidence`) reads from `<task_dir>/events.jsonl` first; falls back to project-global `.dynos/events.jsonl` only at Tier 0.
+3. The per-task HMAC signature on each event (already present in the codebase, derived per-task from the project secret) is now verified at consume time, not just at write time. A consumer reading `<task_dir>/events.jsonl` rejects entries whose signature doesn't verify under the consuming task's HKDF-derived key.
+4. The cross-task forgery scenario from `memory/project_open_trust_residuals.md`: an attacker appending `{"event":"eventbus_handler","task":"task-target","handler":"X"}` to project-global `.dynos/events.jsonl`. Under Tier 1:
+   - The handler-event consumer in `receipt_post_completion` reads `<target_task_dir>/events.jsonl`, not project-global.
+   - The forged event in project-global is invisible to the gate.
+   - Adversarial test in `tests/test_per_task_events_blocks_cross_task_forgery.py` confirms the forged event has no effect on `self_verify`.
+5. Tier 0 path: the project-global file remains the write target for backward compat; the receipt-post-completion gate continues to read it. No behavior change for existing repos.
+6. Migration: existing `.dynos/events.jsonl` is split lazily — when a Tier-1 task's gate first reads its events, the consumer scans project-global once and copies the relevant per-task entries (those whose HMAC verifies under the task's key) into `<task_dir>/events.jsonl`. Subsequent reads skip the project-global scan. CLI `python3 hooks/ctl.py events migrate-task <task_dir>` runs the same migration explicitly.
+
+**Out of scope for Phase 3:** Off-host append-only log shipping (Tier 2). Byzantine fault tolerance for log replication (Tier 3). Real-time intrusion detection on the event stream (Tier 2).
+
+**Audit gate:** The adversarial cross-task forgery test must pass. The H1 residual is then formally closed in `memory/project_open_trust_residuals.md`.
+
+### Phase 4 — Compliance-tier configuration plumbing
+
+**Goal:** Make Tier 1 opt-in with a single config flag.
+
+**Acceptance criteria:**
+
+1. `~/.dynos/projects/<slug>/policy.json` gains a `compliance_tier: "tier-0" | "tier-1"` field. Default when absent: `"tier-0"`.
+2. `hooks/lib_core.py::get_compliance_tier(root: Path) -> str` reads the field, returns `"tier-0"` if absent or invalid. All Tier-1-gated code consults this function — no scattered conditionals.
+3. New CLI `python3 hooks/ctl.py compliance-tier set tier-1` performs the migration end-to-end:
+   - Verifies platform support (Phase 1's `sandbox-test` passes).
+   - Migrates the secret to the keychain (Phase 2).
+   - Splits the events log lazily on next task run (Phase 3).
+   - Writes the policy.json field.
+   - Emits a one-shot summary to stdout: what changed, how to revert.
+4. New CLI `python3 hooks/ctl.py compliance-check` runs all Tier-relevant self-tests (sandbox enforces denials, secret is keychain-anchored, per-task events isolated) and prints a JSON status report. Exit non-zero on any check failing under the active tier.
+5. Reverting from Tier 1 to Tier 0 is supported via `compliance-tier set tier-0`. The keychain entry is left in place (idempotent), the events log is not un-split (existing per-task files remain valid), and the policy.json is updated.
+
+---
+
+## 4. What this spec is NOT
+
+- It is NOT a hardening of dynos-work-as-it-exists for high-assurance contexts. The full program for that is Tier 2/3 (signed artifacts, two-actor approval, off-host append-only log, confidential computing, post-quantum crypto, formal verification, red team). Anything beyond Tier 1 lives in a separate spec for proprietary forks or downstream accreditation work.
+- It does NOT close A4 (supply-chain), A5 (distribution), or A6 (insider). These are explicitly deferred to Tier 2.
+- It does NOT add UX friction to the Tier 0 default. A regular OSS user running `/dynos-work:start` on their laptop sees the same workflow they see today.
+
+---
+
+## 5. Out of Scope (Tier 2+ punt list)
+
+Tracked here so future operators / forks know what's deferred:
+
+- **Signed learned-agents and prevention rules** (closes A4 / audit C3). Requires Ed25519 keypair management + trusted-signers list. Tier 2.
+- **Two-actor approval for cross-task influence** (closes A6 in regulated contexts). Requires hardware-key tap + second human signer. Tier 2.
+- **Off-host append-only log shipping** (closes H1 fully + A6 detection). Requires external log collector (Splunk HEC, S3 with object-lock, ZFS append-only mount). Tier 2.
+- **Hardware-rooted secret** (TPM 2.0 / YubiKey HMAC / HSM-backed PKCS#11). Replaces OS-keychain. Tier 2.
+- **Confidential computing** (Intel TDX / AMD SEV-SNP enclaves for the most sensitive paths). Tier 3.
+- **Post-quantum crypto** (ML-KEM, ML-DSA per NIST PQC). Tier 3.
+- **Formal verification** (TLA+ for the protocol, F* / Coq / Lean for critical functions). Tier 3.
+- **N-version programming** for critical paths. Tier 3.
+- **SBOM, reproducible builds, Sigstore-signed releases** (closes A5). Tier 2 — could ship in OSS later as a separate hardening but not part of this spec.
+
+---
+
+## 6. Migration Path
+
+### For an existing OSS user
+
+1. Pull the latest dynos-work.
+2. No action required. Tier 0 is the default. Existing repos run unchanged.
+
+### For a user opting into Tier 1
+
+1. Run `python3 hooks/ctl.py compliance-tier set tier-1`.
+2. The CLI runs platform support checks and migrates state.
+3. Existing tasks remain readable; their gates continue to work.
+4. New tasks run under the kernel sandbox + keychain secret + per-task events log.
+
+### Reverting
+
+`python3 hooks/ctl.py compliance-tier set tier-0`. State is preserved; behavior reverts.
+
+---
+
+## 7. Risk Notes
+
+- **R1 — macOS sandbox is best-effort.** `sandbox-exec` is deprecated and Apple has not provided a public successor. Tier 1 on macOS uses it anyway because nothing else covers the use case. We document this gap and recommend Linux for the strongest Tier 1 posture. Future: explore Virtualization.framework lightweight VM if `sandbox-exec` is removed in a future macOS release.
+- **R2 — Headless Linux without D-Bus.** Some CI runners and bare-metal servers lack a Secret Service / libsecret backend. Phase 2's keychain resolution falls through; user must either (a) provide `DYNOS_EVENT_SECRET` env var or (b) install `gnome-keyring` headless mode or (c) stay on Tier 0. Documented in `docs/secret-anchor.md`.
+- **R3 — Performance regression on per-task events.** Phase 3's per-task file means N small files instead of one large one. Filesystem seek overhead on cross-task aggregation. Acceptable for OSS workloads (hundreds-to-thousands of tasks per project). Tier 3 will address with an indexed log store; Tier 1 accepts the simple file-per-task design.
+- **R4 — Sandbox false positives.** A Phase 1 sandbox that's too tight will block legitimate executor work (e.g., writing a test file under `tests/`). The role-specific allowlist must be wide enough to cover every legitimate write path documented in `write_policy.py`, OR Tier 1 adoption stalls. Mitigation: the allowlist is materialized from `write_policy.py`, which already has the correct rules; Phase 1 is a translation, not a re-derivation.
+- **R5 — Backward compat is load-bearing.** Tier 0 must keep working for existing repos and existing test suites. Every Tier 1 change is gated by `get_compliance_tier()` checks. A Tier 0 regression in CI is a release blocker.
+- **R6 — A4–A6 still unmitigated at Tier 1.** A user adopting Tier 1 because they "want it secure" may believe they're protected against supply-chain or insider attack. They are not. The README and the `compliance-tier set tier-1` CLI output must explicitly state which threat classes Tier 1 closes (A1–A3) and which it does NOT (A4–A6).
+
+---
+
+## 8. Decomposition into Tasks
+
+| Task | Phase | Effort | Order |
+|------|-------|--------|-------|
+| `phase-1-sandbox` | 1 | High (kernel work, per-platform) | 1 |
+| `phase-2-secret-anchor` | 2 | Medium | 2 |
+| `phase-3-per-task-events` | 3 | Medium | 3 |
+| `phase-4-tier-cli` | 4 | Low | 4 (after 1–3) |
+
+Phase 1 should land first because Phase 2 and 3's adversarial tests rely on the sandbox being mechanically enforced — otherwise the tests can be defeated by the same bypass they're trying to close. Phase 4 wires the user-facing flag last so partial implementations can't be enabled accidentally.
+
+---
+
+*End of Tier 0/1 OSS spec. Tier 2+ specs are produced separately by downstream / proprietary forks who need accreditation.*

--- a/hooks/lib_residuals.py
+++ b/hooks/lib_residuals.py
@@ -149,19 +149,50 @@ def extract_residual_id(raw_input_text: str) -> Optional[str]:
 def select_next_pending(root: Path) -> Optional[dict]:
     """Return the oldest eligible pending row, or ``None``.
 
-    Eligibility: ``status == "pending"`` AND ``attempts < 3``. Ordering is
-    by ``created_at`` ascending (lexicographic on the ISO-8601 string).
-    Missing queue file returns ``None`` without raising.
+    Eligibility:
+      - ``status == "pending"``
+      - ``attempts < 3``
+      - every entry in optional ``depends_on`` (list of residual ids)
+        resolves to a row whose ``status == "done"`` in the same queue.
+        Missing dependency ids are treated as unsatisfied (a typoed dep
+        blocks selection — fail-closed). An empty / absent ``depends_on``
+        list is unconstrained (backward-compatible default).
+
+    Ordering is by ``created_at`` ascending (lexicographic on the ISO-8601
+    string). Missing queue file returns ``None`` without raising.
     """
     qp = queue_path(root)
     q = load_queue(qp)
+    findings = q.get("findings", [])
+
+    # Index ids → status for dependency resolution.
+    status_by_id: dict[str, str] = {}
+    for row in findings:
+        if isinstance(row, dict):
+            rid = row.get("id")
+            st = row.get("status")
+            if isinstance(rid, str) and isinstance(st, str):
+                status_by_id[rid] = st
+
+    def _deps_satisfied(row: dict) -> bool:
+        deps = row.get("depends_on")
+        if not isinstance(deps, list) or not deps:
+            return True
+        for dep_id in deps:
+            if not isinstance(dep_id, str):
+                return False  # malformed dep entry blocks selection
+            if status_by_id.get(dep_id) != "done":
+                return False
+        return True
+
     eligible = [
         row
-        for row in q.get("findings", [])
+        for row in findings
         if isinstance(row, dict)
         and row.get("status") == "pending"
         and isinstance(row.get("attempts"), int)
         and row.get("attempts", 0) < 3
+        and _deps_satisfied(row)
     ]
     if not eligible:
         return None

--- a/tests/test_lib_residuals.py
+++ b/tests/test_lib_residuals.py
@@ -915,3 +915,120 @@ def test_ingest_prevention_rules_skips_malformed(tmp_path: Path):
         _make_rule(rule="Valid rule", enforcement="lint"),
     ]
     assert lib_residuals.ingest_prevention_rules(root, rules) == 1
+
+
+# ---------------------------------------------------------------------------
+# select_next_pending — depends_on dependency gating
+# ---------------------------------------------------------------------------
+
+
+def _make_dep_row(row_id, *, status="pending", attempts=0, depends_on=None,
+                  created_at="2026-05-06T20:00:00Z"):
+    return {
+        "id": row_id,
+        "kind": "residual",
+        "fingerprint": f"fp-{row_id}",
+        "created_at": created_at,
+        "source_task_id": "",
+        "source_auditor": "test",
+        "title": f"row {row_id}",
+        "description": f"desc {row_id}",
+        "location": "",
+        "status": status,
+        "attempts": attempts,
+        "last_attempt_at": None,
+        "depends_on": depends_on if depends_on is not None else [],
+    }
+
+
+def _write_queue(root, rows):
+    qp = queue_path(root)
+    qp.parent.mkdir(parents=True, exist_ok=True)
+    qp.write_text(json.dumps({"findings": rows}, indent=2), encoding="utf-8")
+
+
+def test_select_skips_row_with_unsatisfied_dependency(tmp_path: Path):
+    """A pending row whose dep is still pending must not be selected."""
+    root = tmp_path
+    _write_queue(root, [
+        _make_dep_row("A", created_at="2026-05-06T20:00:00Z"),
+        _make_dep_row("B", depends_on=["A"], created_at="2026-05-06T20:01:00Z"),
+    ])
+    nxt = select_next_pending(root)
+    assert nxt is not None
+    assert nxt["id"] == "A", "A must be selected first; B blocked on A"
+
+
+def test_select_unblocks_dependent_after_dep_done(tmp_path: Path):
+    """After dep is marked done, the dependent row becomes selectable."""
+    root = tmp_path
+    _write_queue(root, [
+        _make_dep_row("A", status="done", created_at="2026-05-06T20:00:00Z"),
+        _make_dep_row("B", depends_on=["A"], created_at="2026-05-06T20:01:00Z"),
+    ])
+    nxt = select_next_pending(root)
+    assert nxt is not None
+    assert nxt["id"] == "B"
+
+
+def test_select_chain_dependency(tmp_path: Path):
+    """Phase 1 → Phase 2 → Phase 3 chain: each unblocks the next."""
+    root = tmp_path
+    rows = [
+        _make_dep_row("p1", created_at="2026-05-06T20:00:00Z"),
+        _make_dep_row("p2", depends_on=["p1"], created_at="2026-05-06T20:01:00Z"),
+        _make_dep_row("p3", depends_on=["p1", "p2"], created_at="2026-05-06T20:02:00Z"),
+    ]
+    _write_queue(root, rows)
+    # All pending → only p1 selectable
+    assert select_next_pending(root)["id"] == "p1"
+    # Mark p1 done → p2 unblocks
+    rows[0]["status"] = "done"
+    _write_queue(root, rows)
+    assert select_next_pending(root)["id"] == "p2"
+    # Mark p2 done → p3 unblocks
+    rows[1]["status"] = "done"
+    _write_queue(root, rows)
+    assert select_next_pending(root)["id"] == "p3"
+
+
+def test_select_dep_failed_blocks_dependent(tmp_path: Path):
+    """A dep with status='failed' (not 'done') keeps the dependent blocked."""
+    root = tmp_path
+    _write_queue(root, [
+        _make_dep_row("A", status="failed", created_at="2026-05-06T20:00:00Z"),
+        _make_dep_row("B", depends_on=["A"], created_at="2026-05-06T20:01:00Z"),
+    ])
+    assert select_next_pending(root) is None, "B blocked because A failed (not done)"
+
+
+def test_select_missing_dep_id_blocks(tmp_path: Path):
+    """A typoed dep id (no matching row) blocks the dependent — fail-closed."""
+    root = tmp_path
+    _write_queue(root, [
+        _make_dep_row("B", depends_on=["NONEXISTENT-ID"],
+                       created_at="2026-05-06T20:00:00Z"),
+    ])
+    assert select_next_pending(root) is None
+
+
+def test_select_empty_depends_on_unconstrained(tmp_path: Path):
+    """An empty depends_on list (or absent) is unconstrained — backward-compat."""
+    root = tmp_path
+    _write_queue(root, [
+        _make_dep_row("A", depends_on=[], created_at="2026-05-06T20:00:00Z"),
+    ])
+    nxt = select_next_pending(root)
+    assert nxt is not None
+    assert nxt["id"] == "A"
+
+
+def test_select_legacy_row_without_depends_on_field(tmp_path: Path):
+    """Rows written before this feature (no depends_on field at all) work unchanged."""
+    root = tmp_path
+    legacy_row = _make_dep_row("legacy", created_at="2026-05-06T20:00:00Z")
+    del legacy_row["depends_on"]
+    _write_queue(root, [legacy_row])
+    nxt = select_next_pending(root)
+    assert nxt is not None
+    assert nxt["id"] == "legacy"


### PR DESCRIPTION
## Summary

- Adds optional `depends_on: list[str]` field to residual queue rows. `select_next_pending` now filters out rows whose `depends_on` entries aren't all `status: "done"`.
- Backward compatible: absent or empty `depends_on` = unconstrained. Legacy rows without the field work unchanged.
- Fail-closed: typoed or missing dep id blocks selection (no matching `done` row → dependent stays pending).
- Lands `docs/foundry-hardening-spec.md` as the OSS Tier 0/1 program spec.

## Motivation

The OSS Tier 0/1 foundry hardening program in `docs/foundry-hardening-spec.md` decomposes into 4 sequential phases:

| Phase | What | Closes |
|---|---|---|
| 1 | Subagent kernel sandbox (Landlock/seccomp/sandbox-exec) | audit C1 |
| 2 | OS-keychain anchored project secret + HKDF derivation | audit C2 |
| 3 | Per-task `events.jsonl` with HMAC-verified consumption | audit H1 |
| 4 | `compliance-tier` config plumbing | gates 1-3 |

Phase ordering is **mandatory**: Phase 2 and 3's adversarial tests are defeatable by the userspace bypass that Phase 1 closes. Without queue-level dep gating, an operator running `/dynos-work:residual run-next` could drain Phase 2 before Phase 1, get a "passing" implementation, and silently regress the threat-model claim.

## Files

- `hooks/lib_residuals.py` (lines 149-198) — `select_next_pending` dep filter (~50 LOC).
- `tests/test_lib_residuals.py` — 7 new regression tests.
- `docs/foundry-hardening-spec.md` (NEW) — program spec the 4 phase residuals reference.

## Test plan

- [x] `python3 -m pytest tests/test_lib_residuals.py` — 51 passed (44 pre-existing + 7 new).
- [x] Manually simulated chain: A→B→C with all pending → only A selectable; mark A done → B selectable; B done → C selectable. Verified via inline simulation script.
- [x] Verified existing `/dynos-work:residual run-next` flow unchanged for rows without `depends_on` (legacy compat test).

## Notable behaviors

- **Fail-closed missing dep**: a typoed `depends_on: ["NONEXISTENT-ID"]` blocks the row forever (until queue is repaired). Surfaced explicitly in the test pack.
- **Failed-dep blocking**: a dep with `status: "failed"` blocks the dependent. Means a poisoned phase blocks the rest of the chain — operator must explicitly unblock by re-running or manually editing the queue.
- **No dependency cycle detection**: cycles would result in deadlock (no row selectable). Acceptable for the OSS feature surface; cycle detection would be additional work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)