### PR TITLE
fix: role-file fallback unreachable for harness subagents

### DIFF
--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -199,7 +199,8 @@ def main() -> int:
 
     # 3-step role resolution chain:
     # (a) env var -- highest priority
-    # (b) role file in task dir -- searched when DYNOS_TASK_DIR is set
+    # (b) role file in task dir -- searched whenever task_dir is known
+    #     (DYNOS_TASK_DIR env OR ancestor-walked discovery)
     # (c) default "execute-inline"
     role_file_searched: bool = False
     role_file_path: Path | None = None
@@ -210,13 +211,16 @@ def main() -> int:
         role = role_from_env
         role_missing = False
     else:
-        # Step (b): check role file when DYNOS_TASK_DIR is set
+        # Step (b): check role file whenever task_dir was resolved (env OR
+        # ancestor walk). Subagents spawned via the harness Agent tool do not
+        # inherit DYNOS_TASK_DIR, so gating this on the env var alone made the
+        # role-file fallback unreachable in real workflows — every spec.md
+        # write from a planning subagent fell to execute-inline and was denied.
         role = "execute-inline"
         role_missing = True
 
-        if task_dir_from_env:
-            resolved_task_dir = Path(task_dir_from_env).resolve()
-            role_file_path = resolved_task_dir / "active-segment-role"
+        if task_dir is not None:
+            role_file_path = task_dir / "active-segment-role"
             role_file_searched = True
             try:
                 if role_file_path.is_file():
@@ -267,14 +271,13 @@ def main() -> int:
 
     # Emit pre_tool_use_role_file_missing when resolution landed on (c) and
     # a role file was searched at (b) but was absent or empty
-    if role_missing and role_file_searched and role_file_reason is not None:
+    if role_missing and role_file_searched and role_file_reason is not None and task_dir is not None:
         try:
             if log_event is not None:
-                resolved_task_dir_str = str(Path(task_dir_from_env).resolve())
                 log_event(
-                    Path(task_dir_from_env).resolve().parent.parent,
+                    task_dir.parent.parent,
                     "pre_tool_use_role_file_missing",
-                    task_dir=resolved_task_dir_str,
+                    task_dir=str(task_dir),
                     path=str(role_file_path),
                     reason=role_file_reason,
                 )

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -169,6 +169,26 @@ This writes to `.dynos/task-{id}/token-usage.json` with a chronological event lo
 
 ---
 
+## MANDATORY: Role Stamping Before Every Agent Spawn
+
+Every Agent tool spawn in this skill (planner, spec-completion-auditor, testing-executor) requires a stamped `active-segment-role` file. The subagent's `pre_tool_use.py` reads this file to resolve its write role; without it the subagent runs as `execute-inline` and `write_policy.decide_write` denies the writes the subagent is trying to make:
+
+- `planning` is the only role that may write `discovery-notes.md`, `design-decisions.md`, `spec.md`, and `plan.md`. Without the stamp, the planner falls to `execute-inline` and **every spec/plan write is denied**.
+- `audit-*` roles are the only roles that may write `audit-reports/`. Without the stamp, the spec-completion-auditor falls to `execute-inline` and its audit report write is denied.
+- `testing-executor` is the only executor role permitted to write `evidence/tdd-tests.md` plus the test files in this stage; without it the spawn falls to `execute-inline` (works for repo files but not for the executor-scoped invariants downstream).
+
+Direct writes to `active-segment-role` are denied by `write_policy.py` — the file is wrapper-required. Always go through ctl:
+
+```bash
+python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "{role}"
+```
+
+The wrapper enforces `_STAMP_ROLE_ALLOWLIST` (`hooks/ctl.py`), which gates the allowed values. Forgery defense for `audit-*` claims is enforced downstream by `receipt_audit_done`, which cross-checks against `spawn-log.jsonl` — stamping a role that no real Agent spawn matches produces an unforgeable audit-trail mismatch at receipt time.
+
+The stamp file is overwritten by each new stamp, so successive phases do not need explicit cleanup between spawns. Step 9 cleans it up before handing off to `/dynos-work:execute`.
+
+---
+
 ## Step 1 — Discovery Intake
 
 1. Build discovery context from:
@@ -197,6 +217,14 @@ PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 -c "from pathlib import Pat
 ```
 
 If a non-empty path is returned AND the file exists, read it, strip frontmatter, and append its contents to the planner's instruction below under a `## Learned Planning Rules` heading. This injects project-specific planning patterns (e.g., tighter acceptance criteria, better segment sizing) derived from past task retrospectives. Log: `{timestamp} [ROUTE] plan-skill route={mode} agent={agent_name}`.
+
+**Stamp role BEFORE the spawn (MANDATORY):**
+
+```bash
+python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+```
+
+Without this stamp the planner subagent resolves to `execute-inline` and its writes to `discovery-notes.md` and `design-decisions.md` are denied by `write_policy`.
 
 Spawn the Planner subagent (`dynos-work:planning`) with instruction:
 
@@ -317,7 +345,15 @@ Proceed to Step 3.
 
 **Fast-track combined spawn:** If `manifest.json` has `"fast_track": true`, skip the spawn and the spec validation. Spec is produced in Step 5 by the combined Spec + Plan planner spawn. **Do NOT advance the manifest stage here** — leave it at `SPEC_NORMALIZATION`. Walking the stage forward before `spec.md` exists breaks the artifact invariant in `hooks/lib_validate.py` (`_SPEC_REQUIRED_AFTER` requires `spec.md` once stage is `SPEC_REVIEW` or beyond), and any `/dynos-work:status` or `/dynos-work:resume` invocation in the window between Step 3 and Step 5 completing would observe `stage=PLANNING` with no spec on disk. The stage walk happens in Step 5 after `spec.md` is written. Log: `{timestamp} [SKIP] spec-normalization-spawn — fast_track combined planner (stage walk deferred to Step 5)`. Skip the rest of this step and proceed to Step 4.
 
-**Normal path:** Spawn the Planner subagent with instruction:
+**Normal path:** **Stamp role BEFORE the spawn (MANDATORY):**
+
+```bash
+python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+```
+
+Without this stamp the planner falls to `execute-inline` and the `spec.md` write is denied by `write_policy.decide_write` (the spec.md guard at `hooks/write_policy.py:290-296` denies executor roles outright). This is the failure mode reported in the SPEC_NORMALIZATION block incident.
+
+Spawn the Planner subagent with instruction:
 
 ```text
 Phase: Spec Normalization.
@@ -401,6 +437,14 @@ Use the JSON output as authoritative:
 - `planning_mode == "standard"`: use standard planning
 
 Do NOT re-derive fast-track, risk-based escalation, or acceptance-criteria thresholds in prompt logic.
+
+**Stamp role BEFORE every planner spawn in this step (MANDATORY — applies to all three flows below):**
+
+```bash
+python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+```
+
+For hierarchical flow, stamp once before the Master Planner spawn AND again before each Worker Planner spawn (each spawn reads the file fresh at its first tool call — successive stamps with the same role are idempotent and overwrite cleanly). Without these stamps the planner falls to `execute-inline` and `plan.md` / `execution-graph.json` writes are denied by `write_policy`.
 
 Hierarchical flow:
 1. Spawn Master Planner using the default planning model for this repo.
@@ -522,6 +566,14 @@ The deterministic gap analysis ALWAYS runs. The LLM auditor only runs for high/c
 
 2. **LLM plan auditor (conditional):** Only spawn `spec-completion-auditor` when `risk_level` is `high` or `critical`. For low/medium risk, the deterministic checks (`validate_task_artifacts` for criteria coverage + gap analysis for code/plan alignment) are authoritative — skip the LLM spawn. Log: `{timestamp} [SKIP] plan-audit-llm — risk_level={risk}`.
 
+   **Stamp role BEFORE the spawn (MANDATORY — only when the conditional fires):**
+
+   ```bash
+   python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "audit-spec-completion"
+   ```
+
+   Without this stamp the auditor falls to `execute-inline` and its `audit-reports/spec-completion.json` write is denied by `write_policy.decide_write` (which restricts `audit-reports/` to `audit-*` roles). Forgery defense: `receipt_audit_done` cross-checks the orchestrator-claimed spawn against `spawn-log.jsonl`, so stamping without a real Agent spawn produces an unforgeable mismatch at receipt time.
+
    Additionally, surface any segment where `len(segment.files_expected) >= 10` (computed budget ≥ 35, the `TOOL_BUDGET_ADVISORY` threshold from `hooks/lib_tool_budget.py`) as a non-blocking advisory finding `near-budget-ceiling`. The advisory is informational and does NOT block plan approval; it warns the operator that the segment is approaching the 11-file overflow ceiling and may want decomposition.
 
 3. If gap analysis finds gaps, or (when invoked) the auditor finds gaps, route back to planning, repair, and rerun deterministic artifact validation.
@@ -537,7 +589,15 @@ When `tdd_required` is `false`: tests are written by `testing-executor` after pr
 
 When `tdd_required` is `true`:
 
-1. Spawn `testing-executor` with instruction:
+1. **Stamp role BEFORE the spawn (MANDATORY):**
+
+   ```bash
+   python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "testing-executor"
+   ```
+
+   Without this stamp the testing-executor falls to `execute-inline`. Repo-file writes still work because `write_policy` permits both `execute-inline` and `*-executor` for repo artifacts, but the role file is what every other dynos-work skill in this codebase stamps before an executor spawn — keeping the convention here ensures the spawn-log entry's claimed role matches the runtime role and that downstream receipts identify the spawn correctly.
+
+   Spawn `testing-executor` with instruction:
 
 ```text
 TDD-First Mode.
@@ -597,6 +657,12 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
 # Phase 6: Handoff
 
 ## Step 9 — Done
+
+**Role file cleanup (MANDATORY — BEFORE the handoff transition):** Delete `.dynos/task-{id}/active-segment-role` so `/dynos-work:execute` starts each segment with a clean slate. Deletion is permitted by `write_policy` (only the *write* path is wrapper-required); leaving the file in place is benign because every executor stamp overwrites it, but cleaning up keeps the spawn-log → role file relationship one-to-one for the next phase.
+
+```bash
+rm -f .dynos/task-{id}/active-segment-role
+```
 
 Transition the stage by running:
 

--- a/tests/test_role_file_fallback.py
+++ b/tests/test_role_file_fallback.py
@@ -465,6 +465,84 @@ class TestRoleResolutionChain:
             f"reason must be 'empty'; got: {missing_events[0]!r}"
         )
 
+    # Regression: env unset, DYNOS_TASK_DIR unset, but cwd is inside .dynos/task-XXX/
+    # → ancestor-walk discovers task_dir → role file MUST be consulted.
+    #
+    # This is the production path for harness-spawned subagents (e.g., the
+    # planning subagent invoked via the Agent tool). Subagents do not inherit
+    # DYNOS_TASK_DIR, so gating the role-file lookup on the env var alone left
+    # the active-segment-role mechanism unreachable and forced spec.md writes
+    # to fall through to execute-inline (denied).
+    def test_role_file_resolved_via_ancestor_walk_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: ancestor-walked task_dir must consult the role file.
+
+        When DYNOS_TASK_DIR is not set but cwd lives inside a .dynos/task-*
+        directory containing a valid active-segment-role, the role file must
+        still be honored. Without this, harness subagents (which don't inherit
+        DYNOS_TASK_DIR) can never elevate above execute-inline.
+        """
+        _, task_dir = _make_task_dir(tmp_path, "task-RR-ancestor")
+        role_file = task_dir / "active-segment-role"
+        role_file.write_text("planning")
+
+        monkeypatch.delenv("DYNOS_ROLE", raising=False)
+        monkeypatch.delenv("DYNOS_TASK_DIR", raising=False)
+        monkeypatch.delenv("DYNOS_EVENT_SECRET", raising=False)
+
+        resolved_role = None
+        logged: list[dict] = []
+
+        def _capture_log(root: Any, event_type: str, **kw: Any) -> None:
+            logged.append({"event": event_type, **kw})
+
+        def _capture_decide(attempt: Any) -> Any:
+            nonlocal resolved_role
+            resolved_role = attempt.role
+            dec = MagicMock()
+            dec.allowed = True
+            dec.mode = "direct"
+            dec.reason = "test"
+            dec.wrapper_command = None
+            return dec
+
+        import io
+        # cwd is inside the task dir so _find_task_dir_from_ancestors discovers it.
+        fake_stdin = json.dumps({
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hi > /tmp/role-fallback-probe.txt"},
+            "cwd": str(task_dir),
+        })
+        old_stdin = sys.stdin
+        old_argv = sys.argv[:]
+        sys.stdin = io.StringIO(fake_stdin)
+        sys.argv = ["pre_tool_use.py"]
+        try:
+            with (
+                patch("pre_tool_use.decide_write", side_effect=_capture_decide),
+                patch("pre_tool_use.log_event", side_effect=_capture_log),
+            ):
+                try:
+                    _pre_tool_use.main()
+                except SystemExit:
+                    pass
+        finally:
+            sys.stdin = old_stdin
+            sys.argv = old_argv
+
+        assert resolved_role == "planning", (
+            f"Role file must be consulted via ancestor-walked task_dir even when "
+            f"DYNOS_TASK_DIR is unset; got {resolved_role!r}"
+        )
+        role_missing_events = [
+            e for e in logged if e.get("event") == "pre_tool_use_role_missing"
+        ]
+        assert not role_missing_events, (
+            f"pre_tool_use_role_missing must NOT be emitted when role resolved from file: "
+            f"{role_missing_events}"
+        )
+
     # AC 7(ii) — when file resolves role, event 'pre_tool_use_role_missing' must NOT fire
     def test_no_role_missing_event_when_file_resolves_role(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- **Hook fix:** `hooks/pre_tool_use.py` gated the `active-segment-role` file lookup on the `DYNOS_TASK_DIR` env string instead of the resolved `task_dir` variable. Subagents spawned via the harness `Agent` tool don't inherit `DYNOS_TASK_DIR`, so the role file was never consulted — every planning subagent fell to `execute-inline` and `write_policy` denied its `spec.md` / `plan.md` writes.
- **Skill fix:** `skills/start/SKILL.md` never called `ctl.py stamp-role` before any of its planner / auditor / testing-executor spawns. Without the stamp the role file is empty even with the hook fix, so the layer-1 fix alone left the foundry half-broken end-to-end.
- **Test:** Added a regression covering the exact production path (env unset, cwd inside `.dynos/task-XXX/`, role file present, must resolve to `planning`).

## Failure mode this fixes

`/dynos-work:start` reliably blocked at `SPEC_NORMALIZATION` with `write-policy: spec.md is a human-approved artifact; executor roles may not write it after PLAN_REVIEW`. The planner subagent had no way to elevate above `execute-inline`. The user-facing report described it as "the dynos-work foundry blocked at SPEC_NORMALIZATION."

## Layered diagnosis

| Layer | Bug | Fix |
|---|---|---|
| Hook gate | `if task_dir_from_env:` ignored ancestor-walked task_dir | gate on resolved `task_dir` |
| Skill prose | `start` skill never stamped any role | 6 stamp-role calls + Step 9 cleanup |

`agent_spawn_log.py` was checked and is correct — it already falls back to ancestor walk. No change there.

## What changed

**`hooks/pre_tool_use.py`**
- Role-file lookup now runs whenever `task_dir is not None` (env OR ancestor walk).
- `pre_tool_use_role_file_missing` emitter uses the resolved task_dir instead of re-deriving from env.

**`skills/start/SKILL.md`**
- New top-level **MANDATORY: Role Stamping Before Every Agent Spawn** section, mirroring `execute/SKILL.md` and `audit/SKILL.md` conventions.
- Inline `stamp-role` Bash commands before each spawn:
  - Step 2 (Discovery + Design + Classification): `--role planning`
  - Step 3 (Spec Normalization, normal path): `--role planning`
  - Step 5 (all three flows): `--role planning`
  - Step 7 (conditional spec-completion-auditor): `--role audit-spec-completion`
  - Step 8 (TDD-First testing-executor): `--role testing-executor`
- Step 9 cleanup (`rm -f active-segment-role`) before handoff to `/dynos-work:execute`.

**`tests/test_role_file_fallback.py`**
- New `test_role_file_resolved_via_ancestor_walk_when_env_unset` exercises the production path — would have failed before the fix.

## Why one PR not two

Either layer alone leaves the foundry broken:
- Hook-only: role file still never written → planner still falls to `execute-inline`.
- Skill-only: role file written but hook never reads it without `DYNOS_TASK_DIR` → planner still falls to `execute-inline`.

Shipping them together is the only configuration that works end-to-end.

## Test plan

- [x] `pytest tests/test_role_file_fallback.py tests/test_write_policy_hook.py tests/test_active_segment_role_lock.py tests/test_agent_spawn_log_hook.py tests/test_read_policy.py` → 44/44 passing
- [x] All 4 stamped roles verified against `_STAMP_ROLE_ALLOWLIST` in `hooks/ctl.py`
- [ ] Manual: run `/dynos-work:start` in a fresh repo, confirm SPEC_NORMALIZATION → SPEC_REVIEW transitions cleanly without operator-side `export DYNOS_TASK_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)