### PR TITLE
fix: SEC-001 path-traversal bounds check in receipt_postmortem_generated + AST static check

### DIFF
--- a/hooks/receipts/approval.py
+++ b/hooks/receipts/approval.py
@@ -149,6 +149,21 @@ def receipt_postmortem_generated(
             "postmortem_json_path"
         )
     json_path = Path(postmortem_json_path)
+    # SEC-001 (task-20260506-003): bounds-check the postmortem JSON path.
+    # The postmortem JSON canonically lives at _persistent_project_dir(root)
+    # / "postmortems" / <task-id>.json (OUTSIDE task_dir). A compromised
+    # caller could otherwise point postmortem_json_path at arbitrary files.
+    # Mirrors the SEC-004 defense in stage.py::_build_audit_receipt_payload.
+    safe_postmortems_dir = _persistent_project_dir(task_dir.parent.parent) / "postmortems"
+    try:
+        resolved_json = Path(json_path).resolve()
+        resolved_safe = safe_postmortems_dir.resolve()
+        resolved_json.relative_to(resolved_safe)
+    except ValueError as exc:
+        raise ValueError(
+            f"receipt_postmortem_generated: postmortem_json_path must be "
+            f"inside {resolved_safe}; got {resolved_json}"
+        ) from exc
     if not json_path.exists():
         raise ValueError(
             f"postmortem JSON missing at {json_path}"

--- a/tests/test_gate_done_postmortem.py
+++ b/tests/test_gate_done_postmortem.py
@@ -46,8 +46,21 @@ def _setup(tmp_path: Path, *, quality: float | None = None) -> Path:
 
 
 def _write_postmortem_fixture(td: Path, anomaly_count: int, pattern_count: int) -> Path:
-    """v4 self-compute contract: counts come from the on-disk postmortem JSON."""
-    pm_json = td / "postmortem.json"
+    """v4 self-compute contract: counts come from the on-disk postmortem JSON.
+
+    task-20260506-003 (SEC-001): postmortem JSON must live under
+    ``_persistent_project_dir(root) / "postmortems"`` to satisfy the
+    bounds-check in ``receipt_postmortem_generated``. Constructing the
+    fixture under ``td/postmortem.json`` (inside task_dir) trips the
+    ValueError. ``td`` is ``.dynos/task-{id}`` whose parent.parent is the
+    project root; ``_persistent_project_dir`` derives the persistent dir
+    from that root.
+    """
+    from lib_core import _persistent_project_dir  # noqa: PLC0415
+    root = td.parent.parent
+    postmortems_dir = _persistent_project_dir(root) / "postmortems"
+    postmortems_dir.mkdir(parents=True, exist_ok=True)
+    pm_json = postmortems_dir / f"{td.name}.json"
     pm_json.write_text(json.dumps({
         "anomalies": [{"idx": i} for i in range(anomaly_count)],
         "recurring_patterns": [{"idx": i} for i in range(pattern_count)],

--- a/tests/test_receipt_contract_version_bump.py
+++ b/tests/test_receipt_contract_version_bump.py
@@ -73,7 +73,12 @@ def _exercise_writer(name: str, td: Path, tmp_path: Path | None = None):
         "## Dependency Graph\n\nt\n## Open Questions\n\nt\n"
     )
     (td / "execution-graph.json").write_text('{"task_id":"test","segments":[]}')
-    pm_json = td / "postmortem.json"
+    # task-20260506-003 (SEC-001): postmortem JSON must live under
+    # _persistent_project_dir(root) / "postmortems" to satisfy the bounds-check.
+    from lib_core import _persistent_project_dir
+    pm_dir = _persistent_project_dir(td.parent.parent) / "postmortems"
+    pm_dir.mkdir(parents=True, exist_ok=True)
+    pm_json = pm_dir / f"{td.name}.json"
     pm_json.write_text('{"anomalies":[],"recurring_patterns":[]}')
 
     if name == "receipt_human_approval":

--- a/tests/test_receipts_report_path_bounds_check.py
+++ b/tests/test_receipts_report_path_bounds_check.py
@@ -1,0 +1,325 @@
+"""Static analysis tests enforcing the SEC-004 bounds-check pattern in hooks/receipts/*.py.
+
+For every function that calls .open() on a report-path-like variable, the same
+function body must also contain either a .relative_to(...) call or a call to
+ensure_within_task_dir(...). This prevents path-traversal attacks where a
+compromised orchestrator supplies a report path that escapes the expected
+directory.
+
+## Tracked variable names (AC-3)
+
+Primary tracked names (direct parameter references):
+    report_path, report_file, postmortem_json_path
+
+Aliases are tracked at SINGLE LEVEL only. Examples that ARE caught:
+    json_path = Path(postmortem_json_path)   # caught
+    report_file = Path(report_path)          # caught
+    report_file = report_path                # caught
+
+Alias chains that are NOT caught (accepted limitation):
+    a = report_path; b = a; b.open(...)      # b is not tracked
+
+## Detection permissiveness (accepted limitation per design-decisions.md)
+
+The .relative_to() detection checks for ANY .relative_to() call anywhere in the
+function body, not specifically against task_dir. A function containing a
+.relative_to() call on an unrelated object would satisfy the check (false
+negative). This is accepted as sufficient given the narrow scope of
+hooks/receipts/*.py.
+
+## Negative-case verification (AC-9)
+
+test_static_check_detects_synthetic_unguarded_open uses ast.parse() on a
+synthetic Python source string with an unguarded open() on a tracked variable,
+feeds it through the same checker logic, and asserts a violation is returned.
+This is the chosen approach (option a from AC-9).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared checker implementation
+# ---------------------------------------------------------------------------
+
+# Names that are tracked as "report-path-like" when seen as function parameters.
+_TRACKED_PARAM_NAMES = frozenset({"report_path", "report_file", "postmortem_json_path"})
+
+
+def _collect_violations(source_text: str, rel_path: str) -> list[str]:
+    """Parse *source_text* and return a list of violation strings.
+
+    Each violation has the form:
+        "hooks/receipts/approval.py:157 — open() on report-path variable
+         'json_path' (alias of 'postmortem_json_path') has no adjacent
+         .relative_to(task_dir) bounds-check"
+
+    *rel_path* is used verbatim as the file prefix in the message.
+    """
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return []
+
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        # ------------------------------------------------------------------
+        # Step 1: seed tracked names from parameters.
+        # tracked maps variable_name -> source_name (the original param name)
+        # ------------------------------------------------------------------
+        tracked: dict[str, str] = {}
+        for arg in node.args.args + node.args.posonlyargs + node.args.kwonlyargs:
+            if arg.arg in _TRACKED_PARAM_NAMES:
+                tracked[arg.arg] = arg.arg
+
+        # ------------------------------------------------------------------
+        # Step 2: walk assignments in the function body to pick up single-level
+        # aliases: `<name> = <tracked>` or `<name> = Path(<tracked>)`.
+        # ------------------------------------------------------------------
+        for stmt in ast.walk(node):
+            if not isinstance(stmt, ast.Assign):
+                continue
+            # RHS: bare name or Path(<name>)
+            rhs_source: str | None = None
+            rhs = stmt.value
+            if isinstance(rhs, ast.Name) and rhs.id in tracked:
+                rhs_source = tracked[rhs.id]
+            elif (
+                isinstance(rhs, ast.Call)
+                and isinstance(rhs.func, ast.Name)
+                and rhs.func.id == "Path"
+                and len(rhs.args) == 1
+                and isinstance(rhs.args[0], ast.Name)
+                and rhs.args[0].id in tracked
+            ):
+                rhs_source = tracked[rhs.args[0].id]
+
+            if rhs_source is None:
+                continue
+
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    tracked[target.id] = rhs_source
+
+        if not tracked:
+            continue
+
+        # ------------------------------------------------------------------
+        # Step 3: determine whether the function body contains a compliant
+        # bounds check: any .relative_to(...) call OR any call to
+        # ensure_within_task_dir(...).
+        # ------------------------------------------------------------------
+        has_bounds_check = False
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call):
+                func = inner.func
+                # .relative_to(...)
+                if isinstance(func, ast.Attribute) and func.attr == "relative_to":
+                    has_bounds_check = True
+                    break
+                # ensure_within_task_dir(...)
+                if isinstance(func, ast.Name) and func.id == "ensure_within_task_dir":
+                    has_bounds_check = True
+                    break
+
+        if has_bounds_check:
+            continue
+
+        # ------------------------------------------------------------------
+        # Step 4: look for .open() calls on tracked names; each is a violation.
+        # ------------------------------------------------------------------
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            func = inner.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "open"
+                and isinstance(func.value, ast.Name)
+                and func.value.id in tracked
+            ):
+                var_name = func.value.id
+                source_name = tracked[var_name]
+                lineno = inner.lineno
+                if var_name == source_name:
+                    alias_clause = f"'{var_name}'"
+                else:
+                    alias_clause = f"'{var_name}' (alias of '{source_name}')"
+                msg = (
+                    f"{rel_path}:{lineno} — open() on report-path variable "
+                    f"{alias_clause} has no adjacent .relative_to(task_dir) bounds-check"
+                )
+                violations.append(msg)
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Test 1 (AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-8):
+# Real AST scan of hooks/receipts/*.py
+# ---------------------------------------------------------------------------
+
+def test_receipts_open_calls_have_adjacent_bounds_check() -> None:
+    """Scan hooks/receipts/*.py and assert every .open() on a report-path-like
+    variable in the same function scope that contains a .relative_to(...) or
+    ensure_within_task_dir(...) call.
+
+    Per AC-3, tracked names are: report_path, report_file, postmortem_json_path
+    plus single-level aliases (x = Path(name) or x = name).
+
+    On approval.py:157 BEFORE the seg-1 fix, this test FAILS — that is the
+    expected TDD-First contract. After the fix is applied this test must pass.
+    """
+    receipts_dir = Path(__file__).parent.parent / "hooks" / "receipts"
+    py_files = sorted(receipts_dir.glob("*.py"))
+
+    assert py_files, f"No .py files found under {receipts_dir}"
+
+    all_violations: list[str] = []
+
+    repo_root = Path(__file__).parent.parent
+
+    for py_file in py_files:
+        source = py_file.read_text(encoding="utf-8")
+        rel_path = str(py_file.relative_to(repo_root))
+        violations = _collect_violations(source, rel_path)
+        all_violations.extend(violations)
+
+    if all_violations:
+        bullet_list = "\n".join(f"  • {v}" for v in all_violations)
+        pytest.fail(
+            f"Found {len(all_violations)} unguarded report-path open() site(s):\n"
+            f"{bullet_list}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 (AC-9): Negative case — checker detects synthetic unguarded open()
+# ---------------------------------------------------------------------------
+
+def test_static_check_detects_synthetic_unguarded_open() -> None:
+    """Feed a synthetic Python source with an unguarded open() on a tracked
+    variable through the same checker function and assert at least one violation
+    is returned.
+
+    This does NOT modify any real production file. The violation is detected on
+    the synthetic string only.
+    """
+    synthetic_source = """
+def fake_writer(task_dir, postmortem_json_path):
+    json_path = Path(postmortem_json_path)
+    with json_path.open("r", encoding="utf-8") as f:
+        data = f.read()
+"""
+    violations = _collect_violations(synthetic_source, "hooks/receipts/approval.py")
+    assert violations, (
+        "Expected at least one violation for the synthetic unguarded open() "
+        "on 'json_path' (alias of 'postmortem_json_path'), but the checker "
+        "returned no violations."
+    )
+    # The violation message must name the variable and its source.
+    combined = "\n".join(violations)
+    assert "json_path" in combined, (
+        f"Expected 'json_path' in violation message, got: {combined!r}"
+    )
+    assert "postmortem_json_path" in combined, (
+        f"Expected 'postmortem_json_path' in violation message, got: {combined!r}"
+    )
+    assert "open() on report-path variable" in combined, (
+        f"Expected standard violation phrasing in message, got: {combined!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 (AC-8): Compliant stage.py pattern produces no violations
+# ---------------------------------------------------------------------------
+
+def test_static_check_passes_on_compliant_site() -> None:
+    """A function that calls .relative_to() before .open() on a tracked variable
+    must produce zero violations — this verifies no false positives on the
+    two stage.py compliant sites.
+    """
+    compliant_source = """
+def receipt_audit_final_envelope(task_dir, report_path):
+    report_file = Path(report_path)
+    resolved_report = report_file.resolve()
+    resolved_task = Path(task_dir).resolve()
+    resolved_report.relative_to(resolved_task)
+    with report_file.open("r", encoding="utf-8") as fh:
+        data = fh.read()
+"""
+    violations = _collect_violations(compliant_source, "hooks/receipts/stage.py")
+    assert not violations, (
+        f"Expected zero violations for a compliant (guarded) open() site, "
+        f"but got: {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Direct parameter reference (no alias) is also tracked
+# ---------------------------------------------------------------------------
+
+def test_static_check_tracks_direct_param_open() -> None:
+    """Verify that .open() directly on a tracked parameter name (not via alias)
+    is caught when no bounds check is present.
+    """
+    synthetic_source = """
+def bad_writer(task_dir, report_path):
+    with report_path.open("r") as f:
+        data = f.read()
+"""
+    violations = _collect_violations(synthetic_source, "hooks/receipts/fake.py")
+    assert violations, (
+        "Expected a violation for direct open() on 'report_path' parameter "
+        "with no .relative_to() guard."
+    )
+    assert "report_path" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 5: ensure_within_task_dir(...) satisfies the bounds-check requirement
+# ---------------------------------------------------------------------------
+
+def test_static_check_accepts_ensure_within_task_dir_helper() -> None:
+    """A function that calls ensure_within_task_dir() instead of .relative_to()
+    must also be classified as compliant (no violation).
+    """
+    synthetic_source = """
+def safe_writer(task_dir, postmortem_json_path):
+    json_path = Path(postmortem_json_path)
+    ensure_within_task_dir(json_path, task_dir)
+    with json_path.open("r", encoding="utf-8") as f:
+        data = f.read()
+"""
+    violations = _collect_violations(synthetic_source, "hooks/receipts/approval.py")
+    assert not violations, (
+        f"Expected zero violations when ensure_within_task_dir() is present, "
+        f"but got: {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Non-tracked variable open() does NOT trigger a violation
+# ---------------------------------------------------------------------------
+
+def test_static_check_ignores_non_tracked_variables() -> None:
+    """An .open() call on a variable that is NOT derived from a tracked param
+    must not produce a violation (no false positives on arbitrary open() calls).
+    """
+    synthetic_source = """
+def reader(task_dir, config_path):
+    cfg = Path(config_path)
+    with cfg.open("r") as f:
+        data = f.read()
+"""
+    violations = _collect_violations(synthetic_source, "hooks/receipts/core.py")
+    assert not violations, (
+        f"Expected zero violations for open() on non-tracked variable 'cfg', "
+        f"but got: {violations}"
+    )


### PR DESCRIPTION
## Summary

Closes residual `4a4cd9b2` (from PR #167's postmortem-analysis): "Never open report_path in hooks/receipts/* without an adjacent task_dir bounds check."

- **Production fix** in `hooks/receipts/approval.py::receipt_postmortem_generated`: bounds-check the postmortem JSON path before opening. Safe-bounds directory is `_persistent_project_dir(task_dir.parent.parent) / "postmortems"` (NOT task_dir — the postmortem JSON canonically lives in the persistent project dir, OUTSIDE task_dir). Mirrors SEC-004 in `stage.py::_build_audit_receipt_payload`. Raises ValueError chained from `relative_to()` with both resolved paths.
- **AST-based static check** in `tests/test_receipts_report_path_bounds_check.py` (NEW, 325 lines): scans every `*.py` under `hooks/receipts/` for `open()` calls on report-path-like variables without an adjacent `.relative_to(...)`. 6 test functions including a synthetic-negative case (AC-9 coverage).

## Threat model

A compromised orchestrator passing a crafted `postmortem_json_path` could otherwise turn `receipt_postmortem_generated` into a filesystem read primitive: the writer would `open()` the path, parse it as JSON, and hash its bytes into the receipt. The bounds check reduces the attack surface to files within the persistent postmortems dir.

## Files

- `hooks/receipts/approval.py` (+15 lines) — bounds check at lines 152-166.
- `tests/test_receipts_report_path_bounds_check.py` (NEW, 325 lines, committed via TDD-First on snapshot branch then cherry-picked).
- `tests/test_gate_done_postmortem.py` (fixture fix) — pre-existing test constructed fake postmortem JSON inside `task_dir`; updated to use canonical persistent dir.
- `tests/test_receipt_contract_version_bump.py` (fixture fix) — same pattern as above.

The fixture fixes were uncovered by the new bounds check correctly rejecting non-canonical paths. Inline `task-20260506-003 (SEC-001)` comments at the modification sites.

## TDD-First contract

The static-check test file was committed BEFORE production code (Step 8 of `/dynos-work:start`). On commit, 1 of 6 tests failed naming `approval.py:157` as the unguarded site. After the production fix, all 6 pass.

## Test plan

- [x] `python3 -m pytest tests/test_receipts_report_path_bounds_check.py -v` — 6/6 pass
- [x] `python3 -m pytest tests/ -k "postmortem or receipt" --no-header -q` — 375 passed, 3 pre-existing skips
- [x] Fixture-test failures verified: tests fail BEFORE the fixture path fixes; pass AFTER

## Foundry pipeline

- Stage: DONE
- Audit: 4 auditors (spec-completion, security, claude-md, code-quality) all PASS, 0 blocking, 25 non-blocking findings
- TDD-First: 6 tests pre-committed; production made them pass
- Postmortem: 1 anomaly (token_overrun consistent with this codebase's adaptive-budget feature), 5 prevention rules generated, 3 ingested as new residuals

## Notable observations

1. **Spec amendment mid-flight**: planner correctly flagged `needs confirmation` for the bounds-check target — the naive translation of SEC-004's `relative_to(task_dir)` would have always failed for legitimate postmortem paths. Spec amended to use `_persistent_project_dir(task_dir.parent.parent) / "postmortems"` as the actual safe-bounds dir before execute. Postmortem rule added: "SEC-class spec must enumerate write-target's persistence dir before reuse-of-pattern is approved."

2. **Recurring auditor pattern**: code-quality-auditor at haiku again returned text-only output without writing the report. Same as task-20260506-001's audit cycle. Postmortem rule: promote code-quality-auditor off haiku or wrap in structured-output schema.

3. **2 pre-existing fixture drifts uncovered**: the new bounds check's strictness surfaced 2 fixture tests that were writing JSON in the wrong location for years. Both fixed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)