### PR TITLE
test: receipts .relative_to() derivation seal (GREEN-at-write)

### DIFF
--- a/tests/test_receipts_bounds_check_derivation.py
+++ b/tests/test_receipts_bounds_check_derivation.py
@@ -1,0 +1,403 @@
+"""Static analysis regression seal enforcing derivation-quality of every
+.relative_to() call site in hooks/receipts/*.py.
+
+## SEC-001 lineage
+
+This check is a follow-on to PR #171 (task-20260506-003), which introduced
+the path-traversal bounds-check pattern in hooks/receipts/approval.py, and
+PR #175, which extended it to fixture detection. The residual trust item
+`1616a422` noted that derivation quality of .relative_to() arguments was
+not statically verified — any argument whose root was not a canonical helper
+would slip through undetected. This file closes that gap.
+
+## Six-step detection algorithm
+
+The shared checker function _collect_derivation_violations() applies the
+following six steps to every FunctionDef / AsyncFunctionDef in the parsed
+source:
+
+  Step 1: ast.parse(source_text); on SyntaxError return [].
+  Step 2: Walk all nodes; for each FunctionDef or AsyncFunctionDef, inspect
+          that function body in isolation.
+  Step 3: Inside each function, collect all Call nodes whose func is an
+          Attribute with attr == "relative_to". If none are found, skip the
+          function entirely (no violation emitted for that function).
+  Step 4: For each .relative_to() call found, take the first positional
+          argument as arg_node. Resolve arg_name:
+            - If arg_node is a Call whose func is an Attribute with
+              attr == "resolve" and value is a bare Name, peel one level:
+              arg_name = arg_node.func.value.id.
+            - If arg_node is a bare Name, arg_name = arg_node.id.
+            - Otherwise skip this call site (cannot analyze non-name args).
+  Step 5: Walk Assign statements in the same function body to find the
+          assignment whose target name == arg_name. Take its RHS. Apply one
+          optional intermediate peel: if RHS is <name2>.resolve() (an
+          Attribute call with attr == "resolve" on a bare Name value), set
+          arg_name = name2 and find name2's assignment instead. Classify the
+          (possibly peeled) RHS:
+            - Pattern A (task_dir-rooted): RHS is Path(<Name id="task_dir">).resolve().
+            - Pattern B (persistent-dir-rooted): RHS is a BinOp or Call whose
+              depth-first subtree contains any Call whose func is a Name with
+              id == "_persistent_project_dir".
+            - Anything else: violation.
+  Step 6: If no compliant assignment is found for arg_name in the function
+          scope, emit a violation string with the exact format:
+            {rel_path}:{lineno} — .relative_to() called with argument
+            '{arg_name}' whose derivation root is unclassified
+            (not task_dir or _persistent_project_dir)
+          where lineno is the .relative_to() Call node's lineno and arg_name
+          is the Step-4 name (before any Step-5 intermediate peel).
+
+## Accepted limitations
+
+- Single-level alias chains only. If arg_name is a multi-hop alias
+  (e.g. a = _persistent_project_dir(...); b = a; x.relative_to(b)), the
+  checker will flag it even though it is semantically compliant. Engineers
+  adding new .relative_to() sites must use the canonical two-hop pattern
+  (BinOp assignment directly from _persistent_project_dir, then .resolve()).
+- Functions without any .relative_to() call are invisible to this check.
+  The "must have a bounds check" rule is owned by PR #171 / PR #175; this
+  check only validates derivation quality when a .relative_to() call is
+  present.
+
+## Negative-case approach
+
+test_static_check_detects_unclassified_root feeds a synthetic Python source
+string (containing a .relative_to() call whose argument traces to
+some_config_path.resolve(), an unclassified root) through
+_collect_derivation_violations() via ast.parse() and asserts that a
+violation is returned. This matches the negative-case approach used by
+PR #171 and PR #175.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level constant documenting the two compliant derivation patterns.
+# Each entry is a human-readable description of the pattern; the canonical
+# AST structure is enforced by _collect_derivation_violations() below.
+# Presence of this constant is structurally verifiable by inspection (AC-3).
+# ---------------------------------------------------------------------------
+
+_TRACKED_ROOTS: frozenset[str] = frozenset({
+    "Path(task_dir).resolve() — Pattern A: task_dir-rooted derivation",
+    "_persistent_project_dir(...) — Pattern B: persistent-dir-rooted derivation",
+})
+
+
+# ---------------------------------------------------------------------------
+# Shared checker implementation
+# ---------------------------------------------------------------------------
+
+
+def _collect_derivation_violations(source_text: str, rel_path: str) -> list[str]:
+    """Parse *source_text* and return a list of violation strings.
+
+    Each violation has the exact form (AC-14):
+        {rel_path}:{lineno} — .relative_to() called with argument '{arg_name}'
+        whose derivation root is unclassified (not task_dir or _persistent_project_dir)
+
+    *rel_path* is used verbatim as the file prefix. *arg_name* is the Step-4
+    name (pre-peel), *lineno* is the integer line number of the .relative_to()
+    Call node.
+
+    On SyntaxError from ast.parse, returns [] (Step 1 safety requirement).
+    """
+    # Step 1: parse
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return []
+
+    violations: list[str] = []
+
+    # Step 2: walk all function definitions in isolation
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        # Step 3: collect .relative_to() call nodes in this function
+        relative_to_calls: list[ast.Call] = []
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Attribute)
+                and inner.func.attr == "relative_to"
+            ):
+                relative_to_calls.append(inner)
+
+        # Skip functions with no .relative_to() calls
+        if not relative_to_calls:
+            continue
+
+        # Pre-collect all Assign statements in this function body once
+        assign_stmts: list[ast.Assign] = []
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Assign):
+                assign_stmts.append(inner)
+
+        for call in relative_to_calls:
+            # Step 4: resolve arg_name from the first positional argument
+            if not call.args:
+                continue
+            arg_node = call.args[0]
+
+            # Step-4 peel: <name>.resolve() -> arg_name = name
+            if (
+                isinstance(arg_node, ast.Call)
+                and isinstance(arg_node.func, ast.Attribute)
+                and arg_node.func.attr == "resolve"
+                and isinstance(arg_node.func.value, ast.Name)
+            ):
+                arg_name = arg_node.func.value.id
+            elif isinstance(arg_node, ast.Name):
+                arg_name = arg_node.id
+            else:
+                # Cannot analyze non-name arguments — skip
+                continue
+
+            # Step-4 name is fixed; used for violation message and Step-5 lookup
+            step4_arg_name = arg_name
+            lineno = call.lineno
+
+            # Step 5: find the assignment for arg_name in this function scope
+            def _find_rhs(name: str) -> ast.expr | None:
+                """Return the RHS of the first Assign that sets *name*, or None."""
+                for stmt in assign_stmts:
+                    for target in stmt.targets:
+                        if isinstance(target, ast.Name) and target.id == name:
+                            return stmt.value
+                return None
+
+            rhs = _find_rhs(arg_name)
+
+            if rhs is None:
+                # No assignment found for arg_name — unclassified
+                violations.append(
+                    f"{rel_path}:{lineno} — .relative_to() called with argument "
+                    f"'{step4_arg_name}' whose derivation root is unclassified "
+                    f"(not task_dir or _persistent_project_dir)"
+                )
+                continue
+
+            # Step-5 optional intermediate peel: if RHS is <name2>.resolve(),
+            # reassign arg_name = name2 and look up name2's assignment instead.
+            # This handles: resolved_safe = safe_postmortems_dir.resolve()
+            if (
+                isinstance(rhs, ast.Call)
+                and isinstance(rhs.func, ast.Attribute)
+                and rhs.func.attr == "resolve"
+                and isinstance(rhs.func.value, ast.Name)
+            ):
+                peeled_name = rhs.func.value.id
+                peeled_rhs = _find_rhs(peeled_name)
+                if peeled_rhs is not None:
+                    # Use the peeled RHS for classification
+                    rhs = peeled_rhs
+
+            # Step-5 classification
+            compliant = _classify_rhs(rhs)
+
+            if not compliant:
+                violations.append(
+                    f"{rel_path}:{lineno} — .relative_to() called with argument "
+                    f"'{step4_arg_name}' whose derivation root is unclassified "
+                    f"(not task_dir or _persistent_project_dir)"
+                )
+
+    return violations
+
+
+def _classify_rhs(rhs: ast.expr) -> bool:
+    """Return True if *rhs* matches Pattern A (task_dir-rooted) or Pattern B
+    (persistent-dir-rooted).
+
+    Pattern A: Path(task_dir).resolve()
+      - rhs is ast.Call
+      - rhs.func is ast.Attribute with attr == "resolve"
+      - rhs.func.value is ast.Call
+      - rhs.func.value.func is ast.Name with id == "Path"
+      - rhs.func.value has exactly one positional arg that is ast.Name id == "task_dir"
+
+    Pattern B: any BinOp or Call subtree containing a Call to _persistent_project_dir
+    """
+    # Pattern A
+    if (
+        isinstance(rhs, ast.Call)
+        and isinstance(rhs.func, ast.Attribute)
+        and rhs.func.attr == "resolve"
+        and isinstance(rhs.func.value, ast.Call)
+        and isinstance(rhs.func.value.func, ast.Name)
+        and rhs.func.value.func.id == "Path"
+        and len(rhs.func.value.args) == 1
+        and isinstance(rhs.func.value.args[0], ast.Name)
+        and rhs.func.value.args[0].id == "task_dir"
+    ):
+        return True
+
+    # Pattern B: depth-first walk for any _persistent_project_dir Call node
+    if isinstance(rhs, (ast.BinOp, ast.Call)):
+        for sub in ast.walk(rhs):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Name)
+                and sub.func.id == "_persistent_project_dir"
+            ):
+                return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1 (AC-7, AC-8, AC-13): Real scan of hooks/receipts/*.py
+# ---------------------------------------------------------------------------
+
+
+def test_receipts_relative_to_args_have_compliant_derivation() -> None:
+    """Scan hooks/receipts/*.py and assert that every .relative_to() call
+    derives its argument from either Path(task_dir).resolve() (Pattern A)
+    or _persistent_project_dir(...) (Pattern B).
+
+    Asserts at least one .py file was found (catches misconfigured paths).
+    On any violation calls pytest.fail() with a bullet-list message.
+
+    Against the current codebase (all three existing sites compliant), this
+    test passes with zero violations (GREEN-at-write).
+    """
+    receipts_dir = Path(__file__).parent.parent / "hooks" / "receipts"
+    py_files = sorted(receipts_dir.glob("*.py"))
+
+    assert py_files, f"No .py files found under {receipts_dir}"
+
+    repo_root = Path(__file__).parent.parent
+    all_violations: list[str] = []
+
+    for py_file in py_files:
+        source = py_file.read_text(encoding="utf-8")
+        rel_path = str(py_file.relative_to(repo_root))
+        violations = _collect_derivation_violations(source, rel_path)
+        all_violations.extend(violations)
+
+    if all_violations:
+        bullet_list = "\n".join(f"  • {v}" for v in all_violations)
+        pytest.fail(
+            f"Found {len(all_violations)} .relative_to() site(s) with "
+            f"unclassified derivation root:\n{bullet_list}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 (AC-9): Negative case — checker detects unclassified derivation root
+# ---------------------------------------------------------------------------
+
+
+def test_static_check_detects_unclassified_root() -> None:
+    """Feed a synthetic source with a .relative_to() argument derived from
+    some_config_path.resolve() — an unclassified root — and assert that at
+    least one violation is returned naming 'resolved_config' and 'unclassified'.
+    """
+    source = """\
+def bad_checker(task_dir, some_config_path):
+    resolved_config = some_config_path.resolve()
+    x.relative_to(resolved_config)
+"""
+    violations = _collect_derivation_violations(source, "hooks/receipts/fake.py")
+
+    assert violations, (
+        "Expected at least one violation for the synthetic source whose "
+        ".relative_to() argument traces to some_config_path.resolve() "
+        "(unclassified root), but the checker returned no violations."
+    )
+
+    combined = "\n".join(violations)
+    assert "resolved_config" in combined, (
+        f"Expected 'resolved_config' in violation message, got: {combined!r}"
+    )
+    assert "unclassified" in combined, (
+        f"Expected 'unclassified' in violation message, got: {combined!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 (AC-10): False-positive guard — Pattern A (task_dir-rooted)
+# ---------------------------------------------------------------------------
+
+
+def test_static_check_passes_on_task_dir_rooted_relative_to() -> None:
+    """A function whose .relative_to() argument traces to Path(task_dir).resolve()
+    must produce zero violations (Pattern A compliant).
+
+    This guards against the checker regressing and falsely flagging the two
+    existing stage.py sites.
+    """
+    source = """\
+def good_checker(task_dir, report_path):
+    report_file = Path(report_path)
+    resolved_report = report_file.resolve()
+    resolved_task = Path(task_dir).resolve()
+    resolved_report.relative_to(resolved_task)
+"""
+    violations = _collect_derivation_violations(source, "hooks/receipts/stage.py")
+
+    assert violations == [], (
+        f"Expected zero violations for Pattern A (task_dir-rooted) .relative_to() "
+        f"site, but got: {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 (AC-11): False-positive guard — Pattern B (persistent-dir-rooted)
+# ---------------------------------------------------------------------------
+
+
+def test_static_check_passes_on_persistent_dir_rooted_relative_to() -> None:
+    """A function whose .relative_to() argument traces to
+    _persistent_project_dir(...) / "postmortems" via a two-hop chain
+    (BinOp assignment -> .resolve() assignment -> .relative_to() argument)
+    must produce zero violations (Pattern B compliant via intermediate peel).
+
+    This is the load-bearing test for the Step-5 intermediate peel in the
+    checker. Without the peel, the approval.py site would be falsely flagged.
+    """
+    source = """\
+def good_checker(task_dir, postmortem_json_path):
+    root = task_dir.parent.parent
+    safe_postmortems_dir = _persistent_project_dir(root) / "postmortems"
+    json_path = Path(postmortem_json_path)
+    resolved_json = json_path.resolve()
+    resolved_safe = safe_postmortems_dir.resolve()
+    resolved_json.relative_to(resolved_safe)
+"""
+    violations = _collect_derivation_violations(source, "hooks/receipts/approval.py")
+
+    assert violations == [], (
+        f"Expected zero violations for Pattern B (persistent-dir-rooted) "
+        f".relative_to() site, but got: {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 (AC-12): False-positive guard — function with no .relative_to() call
+# ---------------------------------------------------------------------------
+
+
+def test_static_check_passes_on_function_without_relative_to() -> None:
+    """A function that contains no .relative_to() call must produce zero
+    violations. The derivation-quality check is invisible to such functions;
+    the 'must have a bounds check' rule is owned by PR #171.
+    """
+    source = """\
+def no_bounds_check(task_dir, report_path):
+    report_file = Path(report_path)
+    with report_file.open("r", encoding="utf-8") as fh:
+        data = fh.read()
+"""
+    violations = _collect_derivation_violations(source, "hooks/receipts/fake.py")
+
+    assert violations == [], (
+        f"Expected zero violations for a function with no .relative_to() call, "
+        f"but got: {violations}"
+    )


### PR DESCRIPTION
## Summary

Closes residual `1616a422` (postmortem-analysis from prior SEC-001 work).

Adds `tests/test_receipts_bounds_check_derivation.py` — an AST static check that scans `hooks/receipts/*.py` for every `.relative_to(...)` call and verifies its argument derives from one of two canonical roots:

- **Pattern A** (in-task-dir bounds): `Path(task_dir).resolve()`
- **Pattern B** (outside-task-dir bounds): any descendant `_persistent_project_dir(...)` Call

Anything else gets flagged with the spec'd violation message format. **No production code change** — all 3 existing prod sites (`approval.py:161`, `stage.py:737`, `stage.py:825`) are already compliant; the test lands GREEN immediately. Forward-looking regression seal only.

5 tests: real-scan + 1 synthetic negative + 3 false-positive guards (Pattern A, Pattern B with intermediate-resolve peel, no-`relative_to` invisibility).

## Test plan

- [x] `pytest tests/test_receipts_bounds_check_derivation.py -v` — 5/5 passed
- [x] `pytest -q` — 2097 passed, 7 skipped, 0 failed

## Audit

CHECKPOINT_AUDIT passed (0 blockers, 24 advisories). Notable advisories surfaced by security-auditor (opus) — none are active vulnerabilities since the prod surface is already compliant; they are forward-looking seal-quality gaps for future engineers to harden. They have been added to the residual queue and prevention rules:

- Pattern B classifier accepts any RHS subtree containing `_persistent_project_dir` (wrapper Calls / IfExp / lambda discards bypass)
- `_find_rhs` returns first matching assignment, not last (reassignment masks unsafe value)
- `assign_stmts` collection misses `ast.AnnAssign` / `ast.AugAssign` / tuple unpacking
- Nested-`FunctionDef` walk leaks scope (inner helper's assignment misclassifies outer's `.relative_to()`)
- Pattern A pins on the literal string `task_dir` for the inner Name id (rename triggers FP)

Process advisory: spec ACs naming exact identifiers should be reproduced verbatim in plan.md (an initial PLAN_AUDIT pass blocked on this; resolved on reaudit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)