### PR TITLE
test: tighten _classify_rhs Pattern B (closes SEAL-001)

### DIFF
--- a/tests/test_receipts_bounds_check_derivation.py
+++ b/tests/test_receipts_bounds_check_derivation.py
@@ -211,6 +211,23 @@ def _collect_derivation_violations(source_text: str, rel_path: str) -> list[str]
     return violations
 
 
+def _is_pattern_b_compliant(node: ast.expr) -> bool:
+    """Return True iff *node* is a direct Call to _persistent_project_dir,
+    or an ast.BinOp whose .left chain (recursing through nested BinOps)
+    terminates in such a Call. Mirrors the canonical
+    _persistent_project_dir(...) / "x" [/ "y" ...] grammar in approval.py.
+    """
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_persistent_project_dir"
+    ):
+        return True
+    if isinstance(node, ast.BinOp):
+        return _is_pattern_b_compliant(node.left)
+    return False
+
+
 def _classify_rhs(rhs: ast.expr) -> bool:
     """Return True if *rhs* matches Pattern A (task_dir-rooted) or Pattern B
     (persistent-dir-rooted).
@@ -222,7 +239,8 @@ def _classify_rhs(rhs: ast.expr) -> bool:
       - rhs.func.value.func is ast.Name with id == "Path"
       - rhs.func.value has exactly one positional arg that is ast.Name id == "task_dir"
 
-    Pattern B: any BinOp or Call subtree containing a Call to _persistent_project_dir
+    Pattern B: direct Call to _persistent_project_dir, OR BinOp whose .left chain
+      (recursing through nested BinOps) terminates in such a Call
     """
     # Pattern A
     if (
@@ -238,15 +256,13 @@ def _classify_rhs(rhs: ast.expr) -> bool:
     ):
         return True
 
-    # Pattern B: depth-first walk for any _persistent_project_dir Call node
-    if isinstance(rhs, (ast.BinOp, ast.Call)):
-        for sub in ast.walk(rhs):
-            if (
-                isinstance(sub, ast.Call)
-                and isinstance(sub.func, ast.Name)
-                and sub.func.id == "_persistent_project_dir"
-            ):
-                return True
+    # Pattern B: direct Call to _persistent_project_dir, OR a BinOp whose
+    # .left chain (recursing through nested BinOps) terminates in such a Call.
+    # Tightened from the prior ast.walk-over-subtree form (which accepted any
+    # descendant Call and was bypassable via wrapper Calls / IfExp / lambda
+    # discards / helper-arg passthrough; see SEAL-001 from task-20260506-005).
+    if _is_pattern_b_compliant(rhs):
+        return True
 
     return False
 
@@ -400,4 +416,72 @@ def no_bounds_check(task_dir, report_path):
     assert violations == [], (
         f"Expected zero violations for a function with no .relative_to() call, "
         f"but got: {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 (AC-6, AC-7): Parametrized negative tests — bypass shapes are flagged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "param_id,source",
+    [
+        (
+            "bypass_max_wrapper",
+            """\
+def bad_checker(task_dir, some_unsafe_path):
+    root = task_dir.parent.parent
+    pm = max(some_unsafe_path, _persistent_project_dir(root))
+    resolved_pm = pm.resolve()
+    x.relative_to(resolved_pm)
+""",
+        ),
+        (
+            "bypass_ifexp",
+            """\
+def bad_checker(task_dir, some_unsafe_path, cond):
+    root = task_dir.parent.parent
+    pm = _persistent_project_dir(root) if cond else some_unsafe_path
+    resolved_pm = pm.resolve()
+    x.relative_to(resolved_pm)
+""",
+        ),
+        (
+            "bypass_lambda",
+            """\
+def bad_checker(task_dir, some_unsafe_path):
+    root = task_dir.parent.parent
+    pm = (lambda p: some_unsafe_path)(_persistent_project_dir(root))
+    resolved_pm = pm.resolve()
+    x.relative_to(resolved_pm)
+""",
+        ),
+        (
+            "bypass_helper_arg",
+            """\
+def bad_checker(task_dir, some_unsafe_path):
+    root = task_dir.parent.parent
+    pm = some_helper(_persistent_project_dir(root))
+    resolved_pm = pm.resolve()
+    x.relative_to(resolved_pm)
+""",
+        ),
+    ],
+    ids=["bypass_max_wrapper", "bypass_ifexp", "bypass_lambda", "bypass_helper_arg"],
+)
+def test_static_check_flags_pattern_b_bypass_shapes(
+    param_id: str, source: str
+) -> None:
+    """Each bypass shape must be flagged as a violation by the tightened
+    Pattern B classifier. The tightened helper (_is_pattern_b_compliant)
+    only accepts a direct Call to _persistent_project_dir or a BinOp whose
+    .left chain terminates in such a Call — rejecting all four bypass shapes.
+    """
+    violations = _collect_derivation_violations(source, "hooks/receipts/fake.py")
+
+    assert violations != [], (
+        f"Expected at least one violation for bypass shape '{param_id}', "
+        f"but the tightened classifier produced no violations. "
+        f"This means the classifier incorrectly accepted a bypass shape as compliant."
     )


### PR DESCRIPTION
## Summary

Closes residual `ce7cb2fe` (postmortem-analysis from prior task's security-auditor SEAL-001).

Tightens Pattern B detection in `tests/test_receipts_bounds_check_derivation.py::_classify_rhs`. Replaces the `ast.walk`-over-RHS-subtree implementation (which accepted any descendant `_persistent_project_dir` Call regardless of where it appeared) with a structural recursive helper `_is_pattern_b_compliant`. The new helper requires the RHS to be either:

- A **direct Call** to `_persistent_project_dir`, OR
- A **BinOp** whose `.left` chain (recursing through nested BinOps) terminates in such a Call

This mirrors the canonical `_persistent_project_dir(...) / "x"` shape used in `approval.py:161`. The 4 named bypass shapes from SEAL-001 are now flagged:

- `max(unsafe, _persistent_project_dir(root))` — wrapper Call
- `_persistent_project_dir(root) if cond else unsafe` — IfExp
- `(lambda p: unsafe)(_persistent_project_dir(root))` — lambda discard
- `helper(_persistent_project_dir(root))` — helper-arg passthrough

A new parametrized test `test_static_check_flags_pattern_b_bypass_shapes` (4 cases) asserts each bypass is now flagged.

## Test plan

- [x] `pytest tests/test_receipts_bounds_check_derivation.py -v` — 9/9 pass (5 existing + 4 new bypass guards)
- [x] `pytest -q` — 2101 passed, 7 skipped, 0 failed
- [x] `approval.py:161` (canonical Pattern B production site) still classified compliant

## Audit

CHECKPOINT_AUDIT passed (0 blockers, 13 advisories). Notable:

- **security-auditor (opus)**: confirms the new structural check rejects the strict superset of the 4 named bypasses. Three minor advisories (none blocking, none active vulnerabilities):
  - `BinOp.right`-rooted shapes are rejected — correct because Path division puts the Path on `.left`
  - Aliased imports (`from lib_core import _persistent_project_dir as _ppd`) would false-positive — accepted limitation, force-toward-canonical-form
  - No explicit recursion depth bound — practically unreachable (ast.parse stack limit fires first)
- **code-quality (sonnet)**: stale `ast.walk` wording at the module docstring (lines 185-190) — not in spec scope, tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)