### PR TITLE
fix: close audit C2 — replace predictable HMAC derivation with HKDF + secrets.token_hex

### DIFF
--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -12,7 +12,7 @@ import hashlib
 import hmac
 import json
 import os
-import platform
+import secrets
 import sys
 import tempfile
 from pathlib import Path
@@ -144,12 +144,23 @@ _EVENT_SECRET_CACHE: dict[str, str] = {}
 
 
 def _derive_per_task_secret(project_secret: str, task_id: str) -> str:
-    """Derive a per-task HMAC secret from project secret + task_id."""
-    return hmac.new(
-        project_secret.encode(),
-        task_id.encode(),
+    """Derive a per-task HMAC secret via RFC 5869 HKDF-SHA256.
+
+    Salt is the task_id; info is a versioned domain-separation label.
+    Single expand block since output length (32 bytes) equals SHA256
+    digest size.
+    """
+    prk = hmac.new(
+        task_id.encode("utf-8"),
+        project_secret.encode("utf-8"),
         hashlib.sha256,
-    ).hexdigest()[:32]
+    ).digest()
+    okm = hmac.new(
+        prk,
+        b"dynos-work/v1/per-task-event-secret" + b"\x01",
+        hashlib.sha256,
+    ).digest()
+    return okm.hex()
 
 
 def _resolve_event_secret(root: Path, *, task_id: str | None = None) -> str:
@@ -160,9 +171,9 @@ def _resolve_event_secret(root: Path, *, task_id: str | None = None) -> str:
     (b) In-process cache keyed on str(root.resolve()).
     (c) Cache file at _persistent_project_dir(root)/'event-secret' with strict
         0o600 permission check.
-    (d) Derive from sha256(f'{root.resolve()}:{platform.node()}')[:32], write
-        atomically via os.open(O_WRONLY|O_CREAT|O_EXCL, 0o600), handle
-        FileExistsError by re-reading (branch c).
+    (d) Generate a fresh secrets.token_hex(32) and write atomically via
+        os.open(O_WRONLY|O_CREAT|O_EXCL, 0o600), handle FileExistsError by
+        re-reading (branch c).
 
     When ``task_id`` is a non-empty string the resolved project secret is
     further derived via :func:`_derive_per_task_secret` so each task's events
@@ -197,10 +208,10 @@ def _resolve_event_secret(root: Path, *, task_id: str | None = None) -> str:
             return _derive_per_task_secret(secret, task_id)
         return secret
 
-    # Derive a deterministic secret for this project+host combination.
-    secret = hashlib.sha256(
-        f"{root.resolve()}:{platform.node()}".encode("utf-8")
-    ).hexdigest()[:32]
+    # Generate a fresh random secret for this project. The atomic O_EXCL
+    # write below ensures only one process wins on first-run; concurrent
+    # processes fall through the FileExistsError path and re-read.
+    secret = secrets.token_hex(32)
 
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     try:

--- a/tests/test_event_secret.py
+++ b/tests/test_event_secret.py
@@ -98,7 +98,7 @@ def test_env_var_present_returned_no_file_created(
 def test_no_env_no_file_creates_secret_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No env var, no file → creates event-secret at persistent dir with mode 0o600; value is 32 hex chars."""
+    """No env var, no file → creates event-secret at persistent dir with mode 0o600; value is 64 hex chars."""
     dynos_home = tmp_path / "dynos-home"
     dynos_home.mkdir()
     monkeypatch.setenv("DYNOS_HOME", str(dynos_home))
@@ -108,8 +108,8 @@ def test_no_env_no_file_creates_secret_file(
 
     result = lib_log._resolve_event_secret(root)
 
-    # Must be 32 hex chars
-    assert len(result) == 32, f"Expected 32-char derived secret, got {len(result)!r}"
+    # Must be 64 hex chars
+    assert len(result) == 64, f"Expected 64-char derived secret, got {len(result)!r}"
     int(result, 16)  # raises if not valid hex
 
     # File must exist somewhere under dynos-home

--- a/tests/test_event_secret_unpredictable.py
+++ b/tests/test_event_secret_unpredictable.py
@@ -1,0 +1,172 @@
+"""Tests for task-20260507-001: unpredictable secret derivation hardening.
+
+Verifies the two cryptographic changes made to hooks/lib_log.py:
+1. Branch (d) of _resolve_event_secret now uses secrets.token_hex(32)
+   instead of the deterministic sha256-path-hostname derivation.
+2. _derive_per_task_secret now uses RFC 5869 HKDF-SHA256 producing
+   a 64-char hex string with proper domain separation.
+
+ACs covered: 11, 12, 13, 14, 15, 16.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import platform
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = ROOT / "hooks"
+
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+lib_log = importlib.import_module("lib_log")
+
+_resolve_event_secret = lib_log._resolve_event_secret
+_derive_per_task_secret = lib_log._derive_per_task_secret
+_EVENT_SECRET_CACHE = lib_log._EVENT_SECRET_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Fixture: per-test cache isolation (self-contained; does not import from
+# test_event_secret.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def isolate_cache() -> None:
+    """Clear _EVENT_SECRET_CACHE before and after every test."""
+    lib_log._EVENT_SECRET_CACHE.clear()
+    yield
+    lib_log._EVENT_SECRET_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# AC 12: two fresh project roots produce distinct secrets
+# ---------------------------------------------------------------------------
+
+def test_fresh_project_root_secrets_differ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two separate fresh project roots (no pre-existing secret file, no env var)
+    must produce different project secrets. Each call uses its own DYNOS_HOME to
+    prevent cross-call filesystem collision. Proves secrets.token_hex(32) is used
+    rather than any deterministic derivation.
+
+    Probability of collision: 2^-256 — negligibly small.
+    """
+    monkeypatch.delenv("DYNOS_EVENT_SECRET", raising=False)
+
+    # --- call A ---
+    home_a = tmp_path / "dynos-home-a"
+    home_a.mkdir()
+    root_a = tmp_path / "project-a"
+    root_a.mkdir()
+
+    monkeypatch.setenv("DYNOS_HOME", str(home_a))
+    lib_log._EVENT_SECRET_CACHE.clear()
+    secret_a = _resolve_event_secret(root_a)
+
+    # --- call B ---
+    home_b = tmp_path / "dynos-home-b"
+    home_b.mkdir()
+    root_b = tmp_path / "project-b"
+    root_b.mkdir()
+
+    monkeypatch.setenv("DYNOS_HOME", str(home_b))
+    lib_log._EVENT_SECRET_CACHE.clear()
+    secret_b = _resolve_event_secret(root_b)
+
+    # Both must be valid 64-char hex strings (entropy seal).
+    assert len(secret_a) == 64, f"secret_a must be 64 hex chars; got {len(secret_a)}"
+    assert len(secret_b) == 64, f"secret_b must be 64 hex chars; got {len(secret_b)}"
+    int(secret_a, 16)  # raises if not valid hex
+    int(secret_b, 16)
+
+    # The two secrets must differ (deterministic derivation would make them equal
+    # if they hashed the same path+hostname, but random token_hex ensures they differ).
+    assert secret_a != secret_b, (
+        "Two fresh project roots must produce different secrets. "
+        "If equal, the old deterministic sha256-path-hostname derivation may still be active."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 13: per-task derivation is deterministic
+# ---------------------------------------------------------------------------
+
+def test_per_task_derivation_is_deterministic() -> None:
+    """_derive_per_task_secret("project-secret", "task-A") called twice must return
+    the same 64-character hex string. Proves HKDF is a pure function."""
+    r1 = _derive_per_task_secret("project-secret", "task-A")
+    r2 = _derive_per_task_secret("project-secret", "task-A")
+
+    assert r1 == r2, (
+        "_derive_per_task_secret must be deterministic; two calls with identical "
+        f"arguments returned different values: {r1!r} vs {r2!r}"
+    )
+    assert len(r1) == 64, (
+        f"_derive_per_task_secret must return a 64-char hex string; got len={len(r1)}"
+    )
+    int(r1, 16)  # raises ValueError if not valid hex
+
+
+# ---------------------------------------------------------------------------
+# AC 14: per-task derivation salt isolation
+# ---------------------------------------------------------------------------
+
+def test_per_task_derivation_salt_isolation() -> None:
+    """_derive_per_task_secret with the same project_secret but distinct task_ids
+    must produce distinct outputs. Proves the task_id is used as the HKDF salt
+    (different salt → different PRK → different OKM)."""
+    result_a = _derive_per_task_secret("project-secret", "task-A")
+    result_b = _derive_per_task_secret("project-secret", "task-B")
+
+    assert result_a != result_b, (
+        "_derive_per_task_secret must produce distinct secrets for distinct task IDs. "
+        f"task-A → {result_a!r}, task-B → {result_b!r}. "
+        "Salt isolation is broken — task_id is not being used as the HKDF salt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 15: old deterministic derivation is NOT used
+# ---------------------------------------------------------------------------
+
+def test_old_deterministic_derivation_not_used(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_resolve_event_secret on a fresh root must NOT return the old
+    sha256(root+hostname)[:32] value. Negative seal: proves the deterministic
+    path-hostname derivation was fully removed from branch (d).
+
+    The old derivation was:
+        hashlib.sha256(f"{root.resolve()}:{platform.node()}".encode()).hexdigest()[:32]
+    """
+    monkeypatch.delenv("DYNOS_EVENT_SECRET", raising=False)
+
+    dynos_home = tmp_path / "dynos-home-neg"
+    dynos_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(dynos_home))
+
+    root = tmp_path / "project-neg"
+    root.mkdir()
+
+    lib_log._EVENT_SECRET_CACHE.clear()
+    result = _resolve_event_secret(root)
+
+    # Compute what the old derivation would have produced.
+    old = hashlib.sha256(
+        f"{root.resolve()}:{platform.node()}".encode("utf-8")
+    ).hexdigest()[:32]
+
+    assert result != old, (
+        f"_resolve_event_secret returned the old deterministic sha256-path-hostname "
+        f"value ({old!r}). The old branch (d) derivation has NOT been removed. "
+        "Expected a fresh secrets.token_hex(32) value instead."
+    )

--- a/tests/test_event_signing.py
+++ b/tests/test_event_signing.py
@@ -326,7 +326,7 @@ def test_empty_secret_nonstrict_returns_records_and_logs_event(
 # AC 1: _derive_per_task_secret — pure derivation helper
 # ---------------------------------------------------------------------------
 def test_derive_per_task_secret_deterministic() -> None:
-    """_derive_per_task_secret(project_secret, task_id) returns a stable 32-char
+    """_derive_per_task_secret(project_secret, task_id) returns a stable 64-char
     hex string. A hardcoded expected value catches wrong HMAC argument order."""
     fn = getattr(lib_log, "_derive_per_task_secret", None)
     assert fn is not None, (
@@ -337,21 +337,20 @@ def test_derive_per_task_secret_deterministic() -> None:
     result1 = fn("project-secret", "task-A")
     result2 = fn("project-secret", "task-A")
 
-    # Must be a 32-character lowercase hex string.
+    # Must be a 64-character lowercase hex string.
     assert isinstance(result1, str), "return type must be str"
-    assert len(result1) == 32, f"expected 32-char hex string, got len={len(result1)}"
+    assert len(result1) == 64, f"expected 64-char hex string, got len={len(result1)}"
     int(result1, 16)  # raises ValueError if not valid hex
 
     # Must be stable across two calls (pure function, no randomness).
     assert result1 == result2, "_derive_per_task_secret must be deterministic"
 
-    # Must match a manually computed HMAC-SHA256[:32] — catches wrong arg order.
-    # If project_secret and task_id are swapped the digest differs.
-    expected = hmac.new(
-        b"project-secret",
-        b"task-A",
-        hashlib.sha256,
-    ).hexdigest()[:32]
+    # Must match the HKDF-SHA256 expected value — catches wrong construction.
+    # extract PRK: HMAC-SHA256(salt=task_id, IKM=project_secret)
+    # expand: HMAC-SHA256(PRK, info + b"\x01")
+    prk = hmac.new(b"task-A", b"project-secret", hashlib.sha256).digest()
+    okm = hmac.new(prk, b"dynos-work/v1/per-task-event-secret" + b"\x01", hashlib.sha256).digest()
+    expected = okm.hex()
     assert result1 == expected, (
         f"_derive_per_task_secret returned wrong digest; "
         f"got {result1!r}, expected {expected!r}. "
@@ -394,7 +393,7 @@ def test_resolve_event_secret_with_task_id(
     assert result != proj_secret, (
         "_resolve_event_secret with task_id must NOT return the raw project secret"
     )
-    assert len(result) == 32, "per-task secret must be 32 hex chars"
+    assert len(result) == 64, "per-task secret must be 64 hex chars"
 
 
 def test_resolve_event_secret_no_task_id(

--- a/tests/test_receipts_bounds_check_derivation.py
+++ b/tests/test_receipts_bounds_check_derivation.py
@@ -59,6 +59,10 @@ source:
   The "must have a bounds check" rule is owned by PR #171 / PR #175; this
   check only validates derivation quality when a .relative_to() call is
   present.
+- Branch-unaware binding resolution. An unsafe binding in one branch of an
+  if/elif/else that coexists with a compliant binding in another branch will
+  suppress the violation (LAST-match-wins returns whichever binding appears
+  last in source order). Branch-level control-flow analysis is out of scope.
 
 ## Negative-case approach
 
@@ -71,6 +75,7 @@ PR #171 and PR #175.
 """
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -87,10 +92,44 @@ _TRACKED_ROOTS: frozenset[str] = frozenset({
     "_persistent_project_dir(...) — Pattern B: persistent-dir-rooted derivation",
 })
 
+_SCOPE_BOUNDARY: frozenset[type] = frozenset({
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.Lambda,
+    ast.ClassDef,
+})
+
 
 # ---------------------------------------------------------------------------
 # Shared checker implementation
 # ---------------------------------------------------------------------------
+
+
+def _iter_function_body(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterator[ast.AST]:
+    """Yield all descendant AST nodes within *func_node*'s lexical scope.
+
+    Iterative stack-based DFS that visits every node reachable from
+    func_node.body, INCLUDING the descendants of compound statements
+    (If/For/While/With/Try blocks). Stops at nested function-like
+    boundaries: FunctionDef / AsyncFunctionDef / Lambda / ClassDef nodes
+    are yielded (so a callsite can still see them) but their children
+    are NOT pushed onto the stack — preventing inner-scope assignments
+    from leaking into outer-scope binding resolution.
+
+    Children are pushed in REVERSE order so that LIFO popping yields
+    them in forward source order; this preserves LAST-match-wins
+    correctness in _collect_derivation_violations's caller.
+    """
+    stack: list[ast.AST] = list(reversed(list(func_node.body)))
+    while stack:
+        node = stack.pop()
+        yield node
+        if type(node) in _SCOPE_BOUNDARY:
+            continue  # yielded but do NOT recurse into nested scope
+        for child in reversed(list(ast.iter_child_nodes(node))):
+            stack.append(child)
 
 
 def _collect_derivation_violations(source_text: str, rel_path: str) -> list[str]:
@@ -121,7 +160,7 @@ def _collect_derivation_violations(source_text: str, rel_path: str) -> list[str]
 
         # Step 3: collect .relative_to() call nodes in this function
         relative_to_calls: list[ast.Call] = []
-        for inner in ast.walk(node):
+        for inner in _iter_function_body(node):
             if (
                 isinstance(inner, ast.Call)
                 and isinstance(inner.func, ast.Attribute)
@@ -135,7 +174,7 @@ def _collect_derivation_violations(source_text: str, rel_path: str) -> list[str]
 
         # Pre-collect all Assign / AnnAssign / AugAssign statements in this function body
         assign_stmts: list[ast.Assign | ast.AnnAssign | ast.AugAssign] = []
-        for inner in ast.walk(node):
+        for inner in _iter_function_body(node):
             if isinstance(inner, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
                 assign_stmts.append(inner)
 
@@ -495,8 +534,29 @@ def bad_checker(task_dir, some_unsafe_path):
     x.relative_to(resolved_pm)
 """,
         ),
+        (
+            "bypass_nested_funcdef",
+            """\
+def outer(task_dir, some_unsafe_path):
+    root = task_dir.parent.parent
+    pm = some_unsafe_path
+    def inner():
+        pm = _persistent_project_dir(root)
+    x.relative_to(pm)
+""",
+        ),
+        (
+            "bypass_lambda_walrus",
+            """\
+def outer(task_dir, some_unsafe_path):
+    root = task_dir.parent.parent
+    pm = some_unsafe_path
+    fn = lambda: (pm := _persistent_project_dir(root))
+    x.relative_to(pm)
+""",
+        ),
     ],
-    ids=["bypass_max_wrapper", "bypass_ifexp", "bypass_lambda", "bypass_helper_arg"],
+    ids=["bypass_max_wrapper", "bypass_ifexp", "bypass_lambda", "bypass_helper_arg", "bypass_nested_funcdef", "bypass_lambda_walrus"],
 )
 def test_static_check_flags_pattern_b_bypass_shapes(
     param_id: str, source: str

--- a/tests/test_task_receipt_chain.py
+++ b/tests/test_task_receipt_chain.py
@@ -50,22 +50,27 @@ def _project_secret(monkeypatch) -> str:
 def test_hmac_arg_order_canary():
     """AC 14: hardcoded expected hex catches HMAC key/message swap.
 
-    Computed at spec time:
-      hmac.new(b"fixed-project-secret", b"task-20260503-001",
-               hashlib.sha256).hexdigest()[:32]
+    Updated for task-20260507-001: _derive_per_task_secret now uses
+    RFC 5869 HKDF-SHA256. The pinned vector is:
+      prk = hmac.new(b"task-20260503-001", b"fixed-project-secret",
+                     hashlib.sha256).digest()
+      okm = hmac.new(prk, b"dynos-work/v1/per-task-event-secret" + b"\x01",
+                     hashlib.sha256).digest()
+      expected = okm.hex()  # 64-char hex string
     """
     from lib_log import _derive_per_task_secret
 
-    expected = "4b8b355f91d44cc282a1c48777424d17"
+    # Compute HKDF expected value inline so the canary stays self-verifying.
+    prk = hmac.new(
+        b"task-20260503-001", b"fixed-project-secret", hashlib.sha256
+    ).digest()
+    expected = hmac.new(
+        prk, b"dynos-work/v1/per-task-event-secret" + b"\x01", hashlib.sha256
+    ).hexdigest()
+
     actual = _derive_per_task_secret("fixed-project-secret", "task-20260503-001")
     assert actual == expected, f"HMAC arg-order swap detected: got {actual!r}"
-
-    # Also verify the actual computation matches (confirms our hardcoded
-    # value isn't drifting from the formula).
-    formula = hmac.new(
-        b"fixed-project-secret", b"task-20260503-001", hashlib.sha256
-    ).hexdigest()[:32]
-    assert formula == expected
+    assert len(actual) == 64, f"HKDF output must be 64 hex chars; got {len(actual)}"
 
 
 # --- AC 1: module public API ---


### PR DESCRIPTION
## Summary

Closes residual `eff23cb6` (operator-foundry-hardening Phase 2, scoped down). Closes audit C2: predictable HMAC derivation in `hooks/lib_log.py:192-195` was computable by any same-UID attacker.

Two surgical changes to `hooks/lib_log.py`:

1. **`_resolve_event_secret` fallback** — replaces deterministic `sha256(f"{root.resolve()}:{platform.node()}").hexdigest()[:32]` with `secrets.token_hex(32)`. Existing repos with a cached secret are unaffected (fallback only fires on fresh first-run). Drops the now-unused `import platform`.

2. **`_derive_per_task_secret`** — replaces truncated HMAC string-concat with stdlib RFC 5869 HKDF-SHA256: extract PRK with `salt=task_id`, single-block expand with `info=b"dynos-work/v1/per-task-event-secret"`. Output is now 64 hex chars (was 32). No new dependency — stdlib `hmac` + `hashlib` only.

The full Phase 2 keychain-anchor design from `docs/foundry-hardening-spec.md` was descoped — this PR closes the predictable-derivation gap (audit C2) only. Operator does not have Linux access for the broader sandbox threat model that the keychain anchor was designed against.

**Note:** Old per-task signatures will not validate post-fix; this is intentional and is what closes audit C2.

## Test plan

- [x] `pytest tests/test_event_signing.py tests/test_event_secret.py tests/test_event_secret_unpredictable.py tests/test_task_receipt_chain.py -v` — 60/60 pass
- [x] `pytest -q` — 2111 passed, 7 skipped, 0 failed

## Audit

CHECKPOINT_AUDIT passed (0 blockers). security-auditor (opus) independently reproduced RFC 5869 Appendix A.1 official test vector against the implementation and confirmed:
- HKDF extract argument ordering is correct (`hmac.new(salt_as_key, IKM_as_msg, sha256).digest()`)
- Single-block expand is sufficient since output length (32 bytes) equals SHA256 digest size
- `secrets.token_hex(32)` provides 256 bits CSPRNG entropy via `os.urandom`
- Domain-separation label `b"dynos-work/v1/per-task-event-secret"` is versioned for future rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)