### PR TITLE
feat: residual queue cleanup — non-finding filter + ctl residual-close

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -5530,6 +5530,79 @@ def cmd_config(args: argparse.Namespace) -> int:
     return 1
 
 
+def cmd_residual_close(args: argparse.Namespace) -> int:
+    """Close a residual without running the full /dynos-work:start lifecycle.
+
+    Use for residuals that are one-liners, registry-only edits, or
+    informational notes that don't need spec/plan/audit/repair. The caller
+    is responsible for actually performing the work; this just marks the
+    queue row as terminal so it stops being eligible for run-next.
+
+    Required: a non-empty --reason describing what was done (or why the
+    row is being closed without code changes — e.g. "duplicate of <id>",
+    "informational; no action").
+    """
+    import json as _json
+
+    root = Path(args.root).resolve()
+    reason = (args.reason or "").strip()
+    if not reason:
+        print("--reason is required and must be non-empty", file=sys.stderr)
+        return 1
+    if len(reason) > 500:
+        print("--reason exceeds 500 chars", file=sys.stderr)
+        return 1
+    target_status = args.status
+    if target_status not in ("done", "wontfix"):
+        print(f"--status must be 'done' or 'wontfix' (got {target_status!r})", file=sys.stderr)
+        return 1
+
+    qpath = lib_residuals.queue_path(root)
+    if not qpath.exists():
+        print(f"residual queue not found at {qpath}", file=sys.stderr)
+        return 1
+
+    import fcntl, os as _os
+    with open(qpath, "r+b") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        raw = fh.read()
+        try:
+            data = _json.loads(raw.decode("utf-8")) if raw.strip() else {"findings": []}
+        except _json.JSONDecodeError as exc:
+            print(f"corrupt queue: {exc}", file=sys.stderr)
+            return 1
+        target = None
+        for r in data.get("findings", []):
+            if r.get("id") == args.residual_id:
+                target = r
+                break
+        if target is None:
+            print(f"residual id not found: {args.residual_id}", file=sys.stderr)
+            return 1
+        if target.get("status") in ("done", "wontfix"):
+            print(_json.dumps({
+                "status": "noop",
+                "residual_id": args.residual_id,
+                "current_status": target.get("status"),
+                "message": "already closed",
+            }, indent=2))
+            return 0
+        target["status"] = target_status
+        target["closed_at"] = lib_residuals._now_iso_z()
+        target["close_reason"] = reason
+        fh.seek(0); fh.truncate()
+        fh.write(_json.dumps(data, indent=2).encode("utf-8"))
+        fh.flush(); _os.fsync(fh.fileno())
+
+    print(_json.dumps({
+        "status": "closed",
+        "residual_id": args.residual_id,
+        "new_status": target_status,
+        "reason": reason,
+    }, indent=2))
+    return 0
+
+
 def cmd_stats_dora(args: argparse.Namespace) -> int:
     """Compute DORA metrics from all retrospectives."""
     import json as _json
@@ -6332,6 +6405,16 @@ def register_meta_parsers(subparsers: argparse._SubParsersAction) -> None:
     cal_json = cal_sub.add_parser("json", help="Dump full registry as JSON")
     cal_json.add_argument("--root", default=".")
     cal_parser.set_defaults(func=cmd_calibration)
+
+    residual_close_parser = subparsers.add_parser(
+        "residual-close",
+        help="Close a residual without running the /dynos-work:start lifecycle (for one-liners or non-actionable rows)",
+    )
+    residual_close_parser.add_argument("residual_id", help="Residual UUID from proactive-findings.json")
+    residual_close_parser.add_argument("--reason", required=True, help="Why this is being closed (1-500 chars)")
+    residual_close_parser.add_argument("--status", default="done", help="Final status: done or wontfix")
+    residual_close_parser.add_argument("--root", default=".", help="Project root")
+    residual_close_parser.set_defaults(func=cmd_residual_close)
 
     config_parser = subparsers.add_parser("config", help="Get or set project policy values")
     config_parser.add_argument("action", choices=["get", "set"], help="Action: get or set")

--- a/hooks/lib_residuals.py
+++ b/hooks/lib_residuals.py
@@ -503,6 +503,16 @@ def _accept_finding(finding: Any, auditor_name: str) -> bool:
     if severity == "info":
         return False
 
+    # Drop "no-change-required" findings: an auditor recorded its review of a
+    # subsystem but found nothing actionable. These slip past the severity
+    # filter as severity:minor + blocking:false, then bloat the residual
+    # queue with non-actionable rows. Detect by remediation text.
+    remediation = finding.get("remediation")
+    if isinstance(remediation, str):
+        rem_lower = remediation.strip().lower()
+        if rem_lower.startswith(("no change required", "no action required", "no fix required")):
+            return False
+
     category = finding.get("category")
     if not isinstance(category, str):
         return False

--- a/tests/test_residual_cleanup_tools.py
+++ b/tests/test_residual_cleanup_tools.py
@@ -1,0 +1,184 @@
+"""Tests for the two residual-cleanup tools added to drain queue bloat:
+
+1. ``_accept_finding`` filter: drops minor findings whose ``remediation``
+   says "no change required" / "no action required" / "no fix required".
+   These were leaking into the residual queue from auditors that record
+   their reviews of subsystems where nothing actionable was found.
+
+2. ``ctl residual-close``: closes a queue row to ``done`` or ``wontfix``
+   without invoking ``/dynos-work:start``. For one-liners, registry-only
+   edits, or informational notes that don't need the full lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import lib_residuals  # noqa: E402
+
+
+def _make_finding(remediation: str, **overrides: object) -> dict:
+    base = {
+        "id": "X-001",
+        "category": "security",
+        "severity": "minor",
+        "blocking": False,
+        "title": "Reviewed X; no exploit",
+        "description": "Detailed review of X surface; no actionable issue.",
+        "location": "hooks/foo.py",
+        "remediation": remediation,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- _accept_finding remediation filter ------------------------------------
+
+
+def test_accept_finding_drops_no_change_required():
+    f = _make_finding("No change required.")
+    assert lib_residuals._accept_finding(f, "security-auditor") is False
+
+
+def test_accept_finding_drops_no_action_required():
+    f = _make_finding("No action required. Optionally consider...")
+    assert lib_residuals._accept_finding(f, "security-auditor") is False
+
+
+def test_accept_finding_drops_no_fix_required():
+    f = _make_finding("No fix required.")
+    assert lib_residuals._accept_finding(f, "security-auditor") is False
+
+
+def test_accept_finding_drops_case_insensitive():
+    f = _make_finding("NO CHANGE REQUIRED")
+    assert lib_residuals._accept_finding(f, "security-auditor") is False
+
+
+def test_accept_finding_admits_real_remediation():
+    f = _make_finding(
+        "Validate agent against allowlist regex r'^[A-Za-z0-9_-]+$' "
+        "before path/glob join."
+    )
+    assert lib_residuals._accept_finding(f, "security-auditor") is True
+
+
+def test_accept_finding_admits_when_remediation_missing():
+    f = _make_finding("")  # empty remediation
+    f.pop("remediation")
+    assert lib_residuals._accept_finding(f, "security-auditor") is True
+
+
+def test_accept_finding_admits_when_remediation_not_a_string():
+    f = _make_finding("")
+    f["remediation"] = None
+    assert lib_residuals._accept_finding(f, "security-auditor") is True
+
+
+# ---- ctl residual-close ----------------------------------------------------
+
+
+def _write_queue(root: Path, rows: list[dict]) -> Path:
+    qd = root / ".dynos"
+    qd.mkdir(parents=True, exist_ok=True)
+    p = qd / "proactive-findings.json"
+    p.write_text(json.dumps({"findings": rows}, indent=2))
+    return p
+
+
+def _row(rid: str, status: str = "pending") -> dict:
+    return {
+        "id": rid,
+        "kind": "residual",
+        "fingerprint": f"fp-{rid}",
+        "created_at": "2026-05-07T18:00:00Z",
+        "source_task_id": "manual",
+        "source_auditor": "security-auditor",
+        "title": f"row {rid}",
+        "description": f"desc {rid}",
+        "location": "(repo-wide)",
+        "status": status,
+        "attempts": 0,
+        "last_attempt_at": None,
+    }
+
+
+def _ctl(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(ROOT / "hooks" / "ctl.py"), *args]
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def test_residual_close_marks_done(tmp_path: Path):
+    qpath = _write_queue(tmp_path, [_row("R-1")])
+    res = _ctl("residual-close", "R-1", "--reason", "trivial registry edit; one-liner", "--root", str(tmp_path), cwd=tmp_path)
+    assert res.returncode == 0, res.stderr
+    payload = json.loads(res.stdout)
+    assert payload["status"] == "closed"
+    assert payload["new_status"] == "done"
+
+    data = json.loads(qpath.read_text())
+    row = next(r for r in data["findings"] if r["id"] == "R-1")
+    assert row["status"] == "done"
+    assert row["close_reason"] == "trivial registry edit; one-liner"
+    assert "closed_at" in row
+
+
+def test_residual_close_wontfix(tmp_path: Path):
+    qpath = _write_queue(tmp_path, [_row("R-2")])
+    res = _ctl(
+        "residual-close", "R-2",
+        "--reason", "duplicate of R-1",
+        "--status", "wontfix",
+        "--root", str(tmp_path),
+        cwd=tmp_path,
+    )
+    assert res.returncode == 0, res.stderr
+    data = json.loads(qpath.read_text())
+    row = next(r for r in data["findings"] if r["id"] == "R-2")
+    assert row["status"] == "wontfix"
+
+
+def test_residual_close_rejects_empty_reason(tmp_path: Path):
+    _write_queue(tmp_path, [_row("R-3")])
+    res = _ctl("residual-close", "R-3", "--reason", "   ", "--root", str(tmp_path), cwd=tmp_path)
+    assert res.returncode == 1
+    assert "reason" in res.stderr.lower()
+
+
+def test_residual_close_unknown_id(tmp_path: Path):
+    _write_queue(tmp_path, [_row("R-1")])
+    res = _ctl("residual-close", "DOES-NOT-EXIST", "--reason", "nothing to do", "--root", str(tmp_path), cwd=tmp_path)
+    assert res.returncode == 1
+    assert "not found" in res.stderr.lower()
+
+
+def test_residual_close_idempotent_on_already_closed(tmp_path: Path):
+    qpath = _write_queue(tmp_path, [_row("R-4", status="done")])
+    res = _ctl("residual-close", "R-4", "--reason", "second call", "--root", str(tmp_path), cwd=tmp_path)
+    assert res.returncode == 0, res.stderr
+    payload = json.loads(res.stdout)
+    assert payload["status"] == "noop"
+    # On-disk row not modified by the noop
+    data = json.loads(qpath.read_text())
+    row = next(r for r in data["findings"] if r["id"] == "R-4")
+    assert "close_reason" not in row
+
+
+def test_residual_close_rejects_invalid_status(tmp_path: Path):
+    _write_queue(tmp_path, [_row("R-5")])
+    res = _ctl(
+        "residual-close", "R-5",
+        "--reason", "ok",
+        "--status", "garbage",
+        "--root", str(tmp_path),
+        cwd=tmp_path,
+    )
+    assert res.returncode == 1


### PR DESCRIPTION
## Summary

Stops the residual queue from growing faster than it drains. Two small tools, no /dynos-work:start lifecycle (intentionally — proving the point).

**Observation that drove this:** queue grew from 24 → 35 pending across one task. Audit of those 35 showed:
- ~7 informational/non-actionable review notes from security-auditor (e.g. "Subprocess invocations are safe today; no fix required")
- ~17 postmortem-derived rule additions that are one-liners but ran/will run through the full lifecycle (~400K tokens each)

## Changes

**`hooks/lib_residuals.py`** — `_accept_finding` drops findings whose `remediation` field starts with "no change required" / "no action required" / "no fix required" (case-insensitive). Auditors will keep emitting review notes; they just stop polluting the queue.

**`hooks/ctl.py`** — new subcommand:
```
ctl residual-close <id> --reason <text> [--status done|wontfix]
```
Closes a queue row to a terminal status without `/dynos-work:start`. For one-liners, dupes, or informational rows.

**`tests/test_residual_cleanup_tools.py`** — 13 tests covering both surfaces.

## Demonstrated

Closed 5 informational rows from the live queue: **35 → 30 pending**.

## Test plan

- [x] `pytest -q tests/test_residual_cleanup_tools.py` — 13 passed
- [x] `pytest -q tests/test_lib_residuals.py` — 51 passed (no regressions to existing residual logic)
- [x] Live queue cleanup actually performed via the new command

## Out of scope

- A `/dynos-work:residual-quick` skill that wraps the close + edit flow. The `residual-close` primitive enables that skill, but shipping it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)