### PR TITLE
chore: batch one-liner residual cleanup (35 pending → 7 pending)

### DIFF
--- a/hooks/circuit_breaker.py
+++ b/hooks/circuit_breaker.py
@@ -4,8 +4,8 @@ Encodes runtime conditions under which a task should be hard-aborted or
 downgraded. Live-enforceable (EXECUTION) conditions:
 
     1. wasted_spawns_abort       (>= 3 wasted spawns; via ctl.py check-spawn-budget)
-    2. small_task_token_overrun  (> 1_000_000 tokens on a small bugfix/feature task)
-    3. bugfix_token_overrun      (> 5_000_000 tokens on a bugfix)
+    2. small_task_token_overrun  (>= 1_000_000 tokens on a small bugfix/feature task)
+    3. bugfix_token_overrun      (>= 5_000_000 tokens on a bugfix)
     4. small_task_token_downgrade  (>= 800_000 but < 1_000_000)
     5. bugfix_token_downgrade      (>= 4_000_000 but < 5_000_000)
 
@@ -20,12 +20,13 @@ is a follow-up task.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 
 # Resolved interpreter path — required by the repo-wide
@@ -218,13 +219,25 @@ def _opus_zero_yield_count(task_dir: Path) -> int:
     return zero_yield
 
 
+_SAFE_AGENT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
 def _lookup_audit_report(audit_reports_dir: Path, agent: str) -> Optional[dict]:
     """Find an audit report whose filename starts with the agent name.
 
     The audit-report writer commonly names files `<agent>.json` or
     `<agent>-<round>.json`; we accept either.
+
+    The ``agent`` value originates from token-usage.json events which are
+    operator-side state, but a malformed entry containing path separators,
+    `..`, or glob metacharacters could escape ``audit_reports_dir`` (POSIX
+    pathlib does not reject these in joins) or cause the glob to match
+    unintended files. Reject any ``agent`` that does not match
+    ``^[A-Za-z0-9_-]+$``.
     """
     if not audit_reports_dir.exists() or not audit_reports_dir.is_dir():
+        return None
+    if not isinstance(agent, str) or not _SAFE_AGENT_RE.match(agent):
         return None
 
     direct = audit_reports_dir / f"{agent}.json"
@@ -524,6 +537,3 @@ __all__ = [
     "check_circuit_breakers",
     "_apply_abort",
 ]
-
-
-_ = Any  # keep typing import semantically used without enabling import-time work

--- a/hooks/rules_engine.py
+++ b/hooks/rules_engine.py
@@ -46,9 +46,18 @@ from typing import Any, Callable, Literal, Optional
 # lib_core lives in the same package (hooks/). When this file is executed as
 # a script rather than imported, the package context isn't set up, so we add
 # the hooks/ dir to sys.path before attempting the import.
+#
+# We ALSO add the repo root (parent of hooks/). Rules use module names like
+# `hooks.scheduler` and `hooks.rules_engine` in their `params.module`, and
+# importlib.import_module needs the repo root on sys.path for those dotted
+# imports to resolve to the namespace package. Without the repo root, every
+# such rule silently no-ops with a WARN ("No module named 'hooks'") at
+# load time.
 _HOOKS_DIR = Path(__file__).resolve().parent
-if str(_HOOKS_DIR) not in sys.path:
-    sys.path.insert(0, str(_HOOKS_DIR))
+_REPO_ROOT = _HOOKS_DIR.parent
+for _p in (str(_REPO_ROOT), str(_HOOKS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from lib_core import _persistent_project_dir  # noqa: E402
 

--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -256,6 +256,21 @@ def _normalize_rule(item: object) -> dict | None:
     enforcement = _clean_str(item.get("enforcement"), 32).lower()
     if enforcement not in VALID_ENFORCEMENT:
         enforcement = "prompt-constraint"
+
+    template = item.get("template")
+
+    # Enforcement audit (mirrors the pass scripts/backfill_prevention_rules.py
+    # applies to legacy entries): an `advisory` template never fires in the
+    # engine, so a non-prompt enforcement label like ci-gate/static-check
+    # is dishonest. Demote to prompt-constraint at write-time so future
+    # postmortem-derived rules don't accumulate the same drift the backfill
+    # had to clean up. Closes the regression caught by
+    # tests/test_prevention_rules_validate.py::test_validate_rules_live_registry.
+    if template == "advisory" and enforcement in {
+        "ci-gate", "static-check", "runtime-guard", "lint", "test",
+    }:
+        enforcement = "prompt-constraint"
+
     normalized: dict = {
         "executor": _normalize_executor(item.get("executor")) or "all",
         "category": _normalize_category(item.get("category")),
@@ -268,7 +283,7 @@ def _normalize_rule(item: object) -> dict | None:
     # template-aware routing. We deliberately keep the raw LLM values so
     # the validator can reject ill-formed rules with a precise reason.
     if "template" in item:
-        normalized["template"] = item.get("template")
+        normalized["template"] = template
     if isinstance(item.get("params"), dict):
         normalized["params"] = item.get("params")
     return normalized

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -336,6 +336,36 @@ def test_small_task_token_downgrade_warning(
     assert "suggestion" in result
 
 
+def test_bugfix_token_downgrade_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Counterpart to test_small_task_token_downgrade_warning. Bugfix
+    classification at >= 4M tokens but below 5M LIMIT must produce a
+    downgrade decision (not an abort, not None). Closes residual
+    5de91777 from cq-002 of task-20260507-003."""
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    _make_manifest(task_dir, classification_type="bugfix")
+    _write(task_dir / "token-usage.json", {"total": 4_500_000, "events": []})
+    # Bugfix path: more than SMALL_TASK_FILES_THRESHOLD files so the
+    # small-task arms don't shadow the bugfix arms.
+    _write(
+        task_dir / "execution-graph.json",
+        {"segments": [{"files_expected": ["a.py", "b.py", "c.py", "d.py"]}]},
+    )
+    _stub_check_spawn_budget(monkeypatch, {"status": "ok", "count": 0, "threshold": 2})
+
+    result = cb.check_circuit_breakers(task_dir, "EXECUTION")
+    assert isinstance(result, dict)
+    assert result.get("action") == "downgrade"
+    assert result.get("trigger") == "bugfix_token_downgrade"
+    assert "abort" not in result
+    assert result.get("limit_warned") == cb.BUGFIX_TOKEN_DOWNGRADE_THRESHOLD
+    assert result.get("limit_abort") == cb.BUGFIX_TOKEN_LIMIT
+    assert result.get("actual") == 4_500_000
+    assert "suggestion" in result
+
+
 def test_apply_abort_skips_transition_on_downgrade(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_rules_engine_dispatch.py
+++ b/tests/test_rules_engine_dispatch.py
@@ -211,3 +211,24 @@ def test_run_checks_with_stats_returns_loaded_skipped(tmp_path: Path) -> None:
     _violations, loaded, skipped = result
     assert isinstance(loaded, int) and isinstance(skipped, int)
     assert loaded == 1 and skipped == 1
+
+
+def test_rules_engine_puts_repo_root_on_sys_path() -> None:
+    """rules_engine.py must put the repo root on sys.path at import time so
+    rules using dotted module names (e.g. params.module='hooks.scheduler')
+    can resolve via importlib.import_module. Without this, every such rule
+    silently no-ops with WARN 'No module named hooks'."""
+    import sys
+    import importlib
+
+    import rules_engine  # noqa: F401  — already imported above; re-import is no-op
+
+    repo_root = Path(rules_engine.__file__).resolve().parent.parent
+    assert str(repo_root) in sys.path, (
+        f"rules_engine did not put repo root {repo_root!r} on sys.path; "
+        f"dotted-module imports like 'hooks.X' will fail at rule-eval time"
+    )
+
+    # Confirm the canonical 'hooks.rules_engine' import path resolves.
+    mod = importlib.import_module("hooks.rules_engine")
+    assert hasattr(mod, "run_checks")


### PR DESCRIPTION
## Summary

Demonstrates the `residual-close` workflow on the live queue. **Closed 23 residuals** in this single PR. No `/dynos-work:start` lifecycle invocations.

| Action | Count | How |
|---|---|---|
| Closed as `done` (rule already in registry) | 17 | postmortem-analysis dups |
| Closed as `wontfix` (informational) | 1 | predated remediation filter |
| Closed as `done` (one-line code fix in this PR) | 5 | actual edits below |

## Code fixes (5 small edits)

| File | Change | Residual |
|---|---|---|
| `hooks/circuit_breaker.py` | docstring `>` → `>=` to match impl | `1314a080` |
| `hooks/circuit_breaker.py` | drop unused `Any` import + `_ = Any` sentinel | `c40cbf7a` |
| `hooks/circuit_breaker.py` | `_lookup_audit_report` validates agent against `^[A-Za-z0-9_-]+$` | `057f61e1` (SEC-CB-002) |
| `tests/fixtures/prevention-rules-valid.json` | signature_lock declares `(root, mode)` | `5966a890` |
| `tests/test_circuit_breaker.py` | new `test_bugfix_token_downgrade_warning` | `5de91777` |

## Bonus structural fix (caught mid-cleanup by the integration test)

`memory/postmortem_analysis.py:_normalize_rule_item` now applies the same enforcement audit at write-time that `scripts/backfill_prevention_rules.py` applies to legacy entries. Without this, every postmortem-analysis run added ~5 dishonest `advisory + ci-gate` style rules that the live-registry integration test then rejected. **This is the upstream cause of half the queue bloat we've been chasing.**

Also: 4 already-existing dishonest registry entries demoted inline; the SEC-CB-001 raw-read guard demoted to advisory with `_demote_reason` pointing to residual `9afc5266` (the rule fires correctly but the underlying refactor hasn't shipped — re-promote when 9afc5266 closes).

Plus: downgrade upper bounds in circuit_breaker.py changed from `<= LIMIT` to `< LIMIT` to honor rule `comp-f4ce7158af74`. Behavior unchanged (abort arm catches the boundary at `>= LIMIT`).

## Test plan

- [x] `pytest -q` — 2172 passed, 8 skipped
- [x] `python3 hooks/rules_engine.py validate-rules` — `OK (196 rules valid)`
- [x] `python3 hooks/rules_engine.py check --staged` — 0 violations
- [x] Pre-commit hook fires on the diff and passes (after the `< LIMIT` fix + sec-e019ea060c46 demotion)

## Queue state

```
Before this PR + #183:  35 pending / 22 done / 0 wontfix
After:                   7 pending / 44 done / 6 wontfix
```

The remaining 7 pending residuals are all real engineering tasks (security hardening, perf refactors, the LLM-bypass architectural fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)