### PR TITLE
perf: run_checks_with_stats single read (residual b2910674)

### DIFF
--- a/hooks/rules_engine.py
+++ b/hooks/rules_engine.py
@@ -965,6 +965,8 @@ def run_checks(
     root: Path,
     mode: Literal["staged", "all"],
     rule_filter: Optional[str] = None,
+    *,
+    raw_rules: Optional[list[dict]] = None,
 ) -> list[Violation]:
     """Load prevention-rules.json, dispatch each rule, return sorted violations.
 
@@ -973,9 +975,16 @@ def run_checks(
     logging and moving on.
 
     Output is sorted by (file, line, rule_id) for byte-identical determinism.
+
+    Closes residual b2910674 (perf / TOCTOU defense-in-depth): callers may
+    pass an already-loaded ``raw_rules`` list to avoid a second
+    ``_load_rules_file`` invocation. ``run_checks_with_stats`` uses this to
+    guarantee a single read of ``prevention-rules.json`` per
+    ``rules-check-passed`` receipt write.
     """
     root = Path(root)
-    raw_rules, _ = _load_rules_file(root)
+    if raw_rules is None:
+        raw_rules, _ = _load_rules_file(root)
     if not raw_rules:
         return []
 
@@ -1035,12 +1044,10 @@ def run_checks_with_stats(
         run_checks continue to work unchanged and monkeypatching
         run_checks in tests propagates through this function.
 
-    Implementation note: the loaded/skipped counts are derived from a
-    single read of the rules file inside this function. The violation
-    list comes from run_checks (which does its own read). This design
-    lets receipt_rules_check_passed obtain both counts and violations
-    from one call without a separate file read in the caller
-    (TOCTOU-safe at the caller boundary).
+    Implementation note: the rules file is read EXACTLY ONCE per call.
+    The parsed rule list flows through to run_checks via the new
+    ``raw_rules`` kwarg, eliminating the double-read window that
+    residual b2910674 flagged. Closes that residual.
     """
     root = Path(root)
     raw_rules, _ = _load_rules_file(root)
@@ -1053,10 +1060,11 @@ def run_checks_with_stats(
         else:
             loaded_count += 1
 
-    # Delegate to run_checks so monkeypatching run_checks in tests is
-    # respected (the receipt writer calls run_checks_with_stats, but
-    # test stubs that only patch run_checks still take effect here).
-    violations = run_checks(root, mode)
+    # Pass the pre-loaded rules through so run_checks does NOT re-read
+    # the file. Test code that monkey-patches run_checks still takes
+    # effect because the function lookup happens at the call site, not
+    # at parse time.
+    violations = run_checks(root, mode, raw_rules=raw_rules)
     return violations, loaded_count, skipped_count
 
 

--- a/tests/fixtures/prevention-rules-valid.json
+++ b/tests/fixtures/prevention-rules-valid.json
@@ -38,7 +38,12 @@
       "params": {
         "module": "hooks.rules_engine",
         "function": "run_checks",
-        "expected_params": ["root", "mode", "rule_filter"]
+        "expected_params": [
+          "root",
+          "mode",
+          "rule_filter",
+          "raw_rules"
+        ]
       },
       "enforcement": "static-check",
       "executor": "all",

--- a/tests/test_fail_open_observability.py
+++ b/tests/test_fail_open_observability.py
@@ -84,7 +84,7 @@ def _setup_done_ready(
     receipt_retrospective(td)
     import rules_engine  # noqa: PLC0415
     _orig = rules_engine.run_checks
-    rules_engine.run_checks = lambda root, mode: []
+    rules_engine.run_checks = lambda root, mode, **kw: []
     try:
         receipt_rules_check_passed(td, "all")
     finally:

--- a/tests/test_gate_done.py
+++ b/tests/test_gate_done.py
@@ -43,7 +43,7 @@ def _stub_run_checks(monkeypatch):
     """receipt_rules_check_passed self-computes via rules_engine.run_checks.
     Stub it to return [] so the writer always succeeds in these tests."""
     import rules_engine
-    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode: [])
+    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode, **kw: [])
 
 
 def _setup(tmp_path: Path) -> Path:

--- a/tests/test_receipt_contract_version_bump.py
+++ b/tests/test_receipt_contract_version_bump.py
@@ -157,7 +157,7 @@ def test_every_writer_in_all_embeds_contract_version_five(tmp_path: Path, monkey
     td = _td(tmp_path)
     # receipt_rules_check_passed needs run_checks stubbed.
     import rules_engine
-    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode: [])
+    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode, **kw: [])
     monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
 
     writer_names = [n for n in lib_receipts.__all__ if n.startswith("receipt_")]

--- a/tests/test_receipt_rules_check_passed_self_compute.py
+++ b/tests/test_receipt_rules_check_passed_self_compute.py
@@ -100,7 +100,7 @@ def test_error_violations_positive_refuses(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         rules_engine,
         "run_checks",
-        lambda root, mode: [
+        lambda root, mode, **kw: [
             SimpleNamespace(severity="error", rule_id="r1"),
             SimpleNamespace(severity="warn", rule_id="r2"),
         ],
@@ -122,7 +122,7 @@ def test_zero_errors_records_correct_counts(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         rules_engine,
         "run_checks",
-        lambda root, mode: [
+        lambda root, mode, **kw: [
             SimpleNamespace(severity="warn", rule_id=f"r{i}")
             for i in range(3)
         ],
@@ -142,7 +142,7 @@ def test_rules_file_hash_computed_when_present(tmp_path: Path, monkeypatch):
     and rules_evaluated counts the 'rules' list length."""
     td = _make_task(tmp_path)
     import rules_engine
-    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode: [])
+    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode, **kw: [])
 
     # Create a persistent dir with a prevention-rules.json
     home = tmp_path / "dynos-home"
@@ -166,7 +166,7 @@ def test_rules_file_absent_uses_none_sentinel(tmp_path: Path, monkeypatch):
     """AC 1: when no rules file, rules_file_sha256 literal 'none' and count=0."""
     td = _make_task(tmp_path)
     import rules_engine
-    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode: [])
+    monkeypatch.setattr(rules_engine, "run_checks", lambda root, mode, **kw: [])
     monkeypatch.setenv("DYNOS_HOME", str(tmp_path / "dynos-home"))
 
     out = receipt_rules_check_passed(td, "all")

--- a/tests/test_retrospective_flush.py
+++ b/tests/test_retrospective_flush.py
@@ -84,7 +84,7 @@ def _setup_done_ready(tmp_path: Path, slug: str = "RF",
     # callers pass only (task_dir, mode). Stub run_checks to a clean pass.
     import rules_engine
     _orig_run_checks = rules_engine.run_checks
-    rules_engine.run_checks = lambda root, mode: []
+    rules_engine.run_checks = lambda root, mode, **kw: []
     try:
         receipt_rules_check_passed(td, "all")
     finally:

--- a/tests/test_rules_engine_dispatch.py
+++ b/tests/test_rules_engine_dispatch.py
@@ -232,3 +232,50 @@ def test_rules_engine_puts_repo_root_on_sys_path() -> None:
     # Confirm the canonical 'hooks.rules_engine' import path resolves.
     mod = importlib.import_module("hooks.rules_engine")
     assert hasattr(mod, "run_checks")
+
+
+def test_run_checks_with_stats_reads_rules_file_once(tmp_path: Path, monkeypatch) -> None:
+    """Closes residual b2910674: run_checks_with_stats must read
+    prevention-rules.json EXACTLY ONCE per call. Pre-fix the function
+    called _load_rules_file for stats then delegated to run_checks
+    which re-read the file. After the fix, the parsed list flows
+    through to run_checks via the raw_rules kwarg.
+
+    Seal: count _load_rules_file invocations during one
+    run_checks_with_stats call. Must be exactly 1.
+    """
+    import rules_engine
+    from rules_engine import run_checks_with_stats  # noqa: PLC0415
+
+    persistent = tmp_path / ".dynos" / "projects" / "p"
+    persistent.mkdir(parents=True)
+    rules_file = persistent / "prevention-rules.json"
+    rules_file.write_text(
+        json.dumps(
+            {
+                "rules": [
+                    {"rule_id": "r1", "template": "advisory", "params": {}, "rule": "x"},
+                    {"rule_id": "r2", "template": "advisory", "params": {}, "rule": "y"},
+                    {"rule": "missing template — skipped"},
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(rules_engine, "_persistent_project_dir", lambda root: persistent)
+
+    counter = {"calls": 0}
+    original_load = rules_engine._load_rules_file
+
+    def counting_load(root, rules_path=None):  # type: ignore[no-untyped-def]
+        counter["calls"] += 1
+        return original_load(root, rules_path=rules_path)
+
+    monkeypatch.setattr(rules_engine, "_load_rules_file", counting_load)
+
+    violations, loaded, skipped = run_checks_with_stats(tmp_path, mode="all")
+    assert counter["calls"] == 1, (
+        f"Expected exactly 1 _load_rules_file call but got {counter['calls']}. "
+        f"residual b2910674 regression — run_checks_with_stats double-read "
+        f"prevention-rules.json (once for counts, once via run_checks)."
+    )
+    assert loaded == 2 and skipped == 1

--- a/tests/test_transition_done_deferred_findings.py
+++ b/tests/test_transition_done_deferred_findings.py
@@ -94,7 +94,7 @@ def _setup_done_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # callers pass only (task_dir, mode). Stub run_checks to a clean pass.
     import rules_engine
     _orig_run_checks = rules_engine.run_checks
-    rules_engine.run_checks = lambda root, mode: []
+    rules_engine.run_checks = lambda root, mode, **kw: []
     try:
         receipt_rules_check_passed(td, "all")
     finally:


### PR DESCRIPTION
## Summary

Closes residual `b2910674`. `run_checks_with_stats` previously read `prevention-rules.json` twice — once via `_load_rules_file` to count loaded/skipped entries, then via `run_checks` which re-read the file to evaluate. The exposure was bounded (microseconds TOCTOU on an atomic-replace surface, single-host single-user, no privilege escalation), but a count/violation skew was still possible if a concurrent writer slipped between the two reads.

## Fix

- `run_checks` gains an optional `raw_rules` kwarg. When provided, skips the file read and uses the supplied list. Existing callers (no kwarg) unaffected.
- `run_checks_with_stats` reads the file ONCE, computes loaded/skipped counts, passes the parsed list through to `run_checks` via the new kwarg.

## Tests

- New seal: `test_run_checks_with_stats_reads_rules_file_once` counts `_load_rules_file` invocations during one `run_checks_with_stats` call. Asserts exactly 1.
- 5 unrelated test files updated their `run_checks` monkeypatch lambdas from `lambda root, mode: []` to `lambda root, mode, **kw: []` to accept the new optional kwarg. No behavior change.

**Full suite: 2266 passed** (was 2265, +1 perf seal), 8 skipped.

## Bonus

- Rule `perf-893df9055be0` (signature_lock for `run_checks`) updated: expected params from `[root, mode, rule_filter]` to `[root, mode, rule_filter, raw_rules]`. Fixture in `tests/fixtures/prevention-rules-valid.json` updated to match.

## Queue impact

This was the last "real" perf residual. After merge, queue is **1 pending** (`a1c4a97c` — wire the breaker into the lifecycle, queued in PR #189). That one needs the full lifecycle (threshold calibration + integration spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)