### PR TITLE
fix: caller_count_required scans repo-wide regardless of scope.mode (residual e1d33152)

### DIFF
--- a/hooks/rules_engine.py
+++ b/hooks/rules_engine.py
@@ -792,7 +792,15 @@ def check_signature_lock(rule: Rule, scope: ScanScope) -> list[Violation]:
 
 
 def check_caller_count_required(rule: Rule, scope: ScanScope) -> list[Violation]:
-    """AC 8: sum ast.Call sites for `symbol` across glob ≥ min_count."""
+    """AC 8: sum ast.Call sites for `symbol` across glob ≥ min_count.
+
+    This rule asserts a codebase-wide invariant (symbol X must have at least
+    N call sites across <glob>), so it ALWAYS scans repo-wide regardless of
+    `scope.mode`. In staged mode, `scope.files` is the staged-diff subset and
+    would miss callers outside the diff — using that subset here causes
+    false-positive violations on commits that don't touch the relevant files.
+    The fix mirrors `_resolve_files`'s mode dispatch locally inside the handler.
+    """
     params = rule.params or {}
     symbol = params.get("symbol")
     glob = params.get("scope")
@@ -805,8 +813,13 @@ def check_caller_count_required(rule: Rule, scope: ScanScope) -> list[Violation]
         )
         return []
 
+    if scope.mode == "staged":
+        files = tuple(sorted(_all_tracked_files(scope.root)))
+    else:
+        files = scope.files
+
     total = 0
-    for file in scope.files:
+    for file in files:
         if not _glob_match(file, scope.root, glob):
             continue
         text = _read_text(file)

--- a/tests/test_rules_engine_templates.py
+++ b/tests/test_rules_engine_templates.py
@@ -417,9 +417,8 @@ def test_caller_count_required_sums_across_files(tmp_path):
         f"3 calls summed across both files meets min_count=3; got {out!r}"
     )
 
-    # Now bump the threshold so the SAME files now violate — proves the
-    # sum is what's being compared, not just "is symbol present in some
-    # single file".
+    # Bump the threshold so the SAME files now violate — proves the sum
+    # is what's being compared, not just "is symbol present in some file".
     rule_high = Rule(
         rule_id="r-call-sum-fail",
         template="caller_count_required",
@@ -428,6 +427,72 @@ def test_caller_count_required_sums_across_files(tmp_path):
     out2 = check_caller_count_required(rule_high, _make_scope(tmp_path, [a, b]))
     assert len(out2) == 1
     assert "3 time" in out2[0].message
+
+
+def test_caller_count_required_staged_caller_outside_diff_no_violation(
+    tmp_path, monkeypatch
+):
+    """AC-6: staged-mode scope contains zero callers, but a file outside the
+    staged diff has sufficient callers — the fix escalates to repo-wide so the
+    rule does NOT false-fire."""
+    import rules_engine  # noqa: PLC0415
+
+    # File OUTSIDE the staged diff with 3 callers (meets min_count).
+    outside = tmp_path / "library.py"
+    outside.write_text("def _():\n    foo()\n    obj.foo()\n    foo()\n")
+
+    # Staged file has zero callers and a different name (so glob matches both
+    # but only the unstaged file has the symbol).
+    staged = tmp_path / "unrelated.py"
+    staged.write_text("def x():\n    pass\n")
+
+    # Patch _all_tracked_files (object form) so the handler sees the union.
+    monkeypatch.setattr(
+        rules_engine, "_all_tracked_files", lambda root: [outside, staged]
+    )
+
+    rule = Rule(
+        rule_id="r-call-staged-outside",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 3},
+    )
+    # Staged scope only sees the unrelated file.
+    scope = _make_scope(tmp_path, [staged], mode="staged")
+    out = check_caller_count_required(rule, scope)
+    assert out == [], (
+        "staged-mode scope had 0 callers, but _all_tracked_files exposed a "
+        f"file with 3 callers; expected no violation, got {out!r}"
+    )
+
+
+def test_caller_count_required_staged_union_across_staged_and_unstaged(
+    tmp_path, monkeypatch
+):
+    """AC-7: callers are split across a staged file (1) and an unstaged file
+    (2); the union (3) meets min_count and the rule does NOT fire."""
+    import rules_engine  # noqa: PLC0415
+
+    staged = tmp_path / "a.py"
+    staged.write_text("def _():\n    foo()\n")
+    unstaged = tmp_path / "b.py"
+    unstaged.write_text("def _():\n    foo()\n    obj.foo()\n")
+
+    monkeypatch.setattr(
+        rules_engine, "_all_tracked_files", lambda root: [staged, unstaged]
+    )
+
+    rule = Rule(
+        rule_id="r-call-staged-union",
+        template="caller_count_required",
+        params={"symbol": "foo", "scope": "*.py", "min_count": 3},
+    )
+    # Staged scope only sees `a.py` — but the handler must escalate to
+    # repo-wide and find both files via _all_tracked_files.
+    scope = _make_scope(tmp_path, [staged], mode="staged")
+    out = check_caller_count_required(rule, scope)
+    assert out == [], (
+        f"3 calls across staged + unstaged meets min_count=3; got {out!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hooks/rules_engine.py:check_caller_count_required` iterated `scope.files`, which is the staged-diff subset in staged mode. If a rule scoped to `hooks/**/*.py` ran on a commit that did not include any `hooks/` file, the handler counted 0 callers regardless of repo-wide reality and false-fired on unrelated commits.

## The fix

The handler now mirrors `_resolve_files`'s mode dispatch locally:

```python
if scope.mode == "staged":
    files = tuple(sorted(_all_tracked_files(scope.root)))
else:
    files = scope.files
```

`caller_count_required` asserts a codebase-wide invariant ("symbol X has N+ call sites across `<glob>`") — what the staged commit changes is irrelevant to that invariant. Other templates (`pattern_must_not_appear`, `co_modification_required`) intentionally scope to staged files and are unchanged.

## Tests

Two new regression tests in `tests/test_rules_engine_templates.py`:

- `test_caller_count_required_staged_caller_outside_diff_no_violation` — staged scope has 0 callers; `_all_tracked_files` returns a file with 3 callers; result is `[]` (rule does not false-fire).
- `test_caller_count_required_staged_union_across_staged_and_unstaged` — callers split across staged + unstaged; union meets `min_count`.

Both tests use `monkeypatch.setattr(rules_engine, "_all_tracked_files", ...)` (object form, not dotted-path string) so the patch is visible inside the handler's call site. No git-subprocess dependency in the test path.

Full pytest suite: 2297 passed, 8 skipped.

## Pairing

This is paired with PR #193 (fnmatch `**` recursive matching). Together these fix the two rules-engine semantic bugs that caused several false-positive demotions. Re-evaluation of the demoted-rule registry is queued as residual `53274db4`.

## Notable

- **Performance:** staged-mode `caller_count_required` rules now incur a `git ls-files` call (or `os.walk` fallback) per rule invocation. Pre-commit overhead is bounded since `_all_tracked_files` has a 30-second timeout and the call only fires for active `caller_count_required` rules.
- **Pre-existing rules that begin firing correctly** are expected and welcome — those rules were always meant to run repo-wide; they just couldn't because of this bug.

## Test plan

- [x] Full pytest suite green (2297 passed, 8 skipped)
- [x] Existing `mode="all"` tests pass without modification
- [x] New `mode="staged"` tests confirm caller-outside-diff and union-count behaviors
- [ ] Reviewer verifies the mode dispatch matches `_resolve_files`'s pattern (hooks/rules_engine.py:360)
- [ ] Reviewer skims first post-merge commits for any genuinely over-broad `caller_count_required` rule that should be re-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)