### PR TITLE
feat: residual list default-excludes done; --all opt-in (residual cfff6f1a)

### DIFF
--- a/skills/residual/SKILL.md
+++ b/skills/residual/SKILL.md
@@ -29,15 +29,33 @@ are supported: `list` and `run-next`.
 
 ## Subcommand: `list`
 
-Invoked as `/dynos-work:residual list`.
+Invoked in two forms:
+
+- `/dynos-work:residual list` — default view, excludes `done` rows.
+- `/dynos-work:residual list --all` — includes all rows (including `done`).
 
 ### What you do
 
 1. Resolve `{root}` — the current project root (the directory containing
    `.dynos/`). If running from a repo subdirectory, walk upward until
    `.dynos/` is found.
-2. Run the following Python snippet (adjust `ROOT` to the resolved
-   project root):
+2. Run the following Python snippet. To include `done` rows, pass `--all`
+   as a positional argument to the heredoc process — bash makes it visible
+   to the snippet via `sys.argv`:
+
+   ```bash
+   # Default (excludes done rows):
+   python3 - <<'PY'
+   ...
+   PY
+
+   # Include all rows (including done):
+   python3 - --all <<'PY'
+   ...
+   PY
+   ```
+
+   The shared snippet body:
 
    ```bash
    python3 - <<'PY'
@@ -49,8 +67,14 @@ Invoked as `/dynos-work:residual list`.
    queue = lib_residuals.queue_path(root)
    data = lib_residuals.load_queue(queue)
    findings = data.get("findings", [])
+   raw_count = len(findings)
+   include_done = "--all" in sys.argv
+   findings = [r for r in findings if include_done or r.get("status") != "done"]
    if not findings:
-       print("dynos-work: no residuals queued")
+       if raw_count == 0:
+           print("dynos-work: no residuals queued")
+       else:
+           print("dynos-work: no active residuals (use --all to show done rows)")
        sys.exit(0)
    # Sort oldest first by created_at
    findings_sorted = sorted(findings, key=lambda r: r.get("created_at", ""))
@@ -74,12 +98,17 @@ Invoked as `/dynos-work:residual list`.
      `dynos-work: no residuals queued` and exit 0.
    - If the file exists but `findings` is `[]`, print exactly
      `dynos-work: no residuals queued` and exit 0.
+   - If the file has rows but every row is `done` and `--all` was not
+     passed, print exactly
+     `dynos-work: no active residuals (use --all to show done rows)`
+     and exit 0.
    - Otherwise print one tab-separated line per row containing, in
      order: `id`, `status`, `attempts`, `source_auditor`,
      `title` (truncated to 60 chars), `created_at`. All six fields must
      appear on every row.
-   - Do NOT filter by status. `pending`, `in_progress`, `done`, and
-     `failed` rows all appear.
+   - Default behavior excludes `done` rows. Pass `--all` to include them.
+     `pending`, `in_progress`, `wontfix`, and `failed` rows always appear
+     regardless of `--all`.
    - Plain text only. No JSON, no ANSI colour codes, no header row
      decoration that would break the six-field shape.
 
@@ -339,6 +368,7 @@ lib_residuals.update_row_status(root, residual_id, "pending")
 | Condition | Output (exact) | Exit |
 |---|---|---|
 | `list`: queue file missing or `findings == []` | `dynos-work: no residuals queued` | 0 |
+| `list`: queue file has rows but all are `done` (default view) | `dynos-work: no active residuals (use --all to show done rows)` | 0 |
 | `list`: rows present | one tab-separated line per row (id, status, attempts, source_auditor, title[60], created_at) | 0 |
 | `run-next`: queue file missing or `findings == []` or no eligible row | `dynos-work: residual queue empty` | 0 |
 | `run-next`: another row already `in_progress` | `dynos-work: residual in_progress — run-next already active` | 0 |


### PR DESCRIPTION
## Summary
- Tightens `/dynos-work:residual list` so the default invocation excludes `done` rows. Pass `--all` to re-include them. `pending`, `in_progress`, `wontfix`, and `failed` always appear.
- Patches `skills/residual/SKILL.md` only — `lib_residuals.py`, `select_next_pending`, and `run-next` semantics unchanged.
- Reduces default `list` output from 66 rows to 9 against the current queue state.

## What changed in `skills/residual/SKILL.md`
1. `## Subcommand: list` invocation prose now documents both forms (`/dynos-work:residual list` and `/dynos-work:residual list --all`) and explains the `python3 - --all <<'PY'` heredoc passthrough.
2. Inline Python snippet adds `import sys`, `include_done = "--all" in sys.argv`, and a filter `[r for r in findings if include_done or r.get("status") != "done"]` before the empty check.
3. Empty-result handling splits into two cases: truly empty queue keeps `dynos-work: no residuals queued`; queue with only `done` rows under the default view emits `dynos-work: no active residuals (use --all to show done rows)`.
4. Output rules bullet "Do NOT filter by status" is replaced with the new default-excludes-done semantics.
5. Output contract summary table at the bottom of the file adds the new edge-case row.

## Why wontfix stays visible by default
Today's audit caught a mis-classified wontfix row (`d6db5334` — "Flip BREAKER_ACTIVE False → True"). It was wontfix'd while waiting on prerequisites that have since landed (PR #191 + PR #192 / commit b883d47), but the row was never re-evaluated. Wontfix visibility is exactly what surfaces this class of drift. `done` rows are noise; `wontfix` rows occasionally need attention.

## Side-effect: d6db5334 wontfix_reason was sharpened (in the gitignored queue file)
The mutation lives in `.dynos/proactive-findings.json` (gitignored) and the audit doc lives in `.dynos/task-20260508-008/wontfix-triage.md`. Both are task-internal evidence and are not included in this PR. The replacement text records that PR #192 (calibration) landed, that the observation-period prerequisite (5–10 unattended tasks since PR #191) is unverified, and that re-queueing should happen via a fresh residual rather than un-wontfixing this row.

## Test plan
- [ ] Run `/dynos-work:residual list` (no args) — expect ~9 rows (pending/in_progress/wontfix/failed only); no `done` rows in output
- [ ] Run `/dynos-work:residual list --all` — expect total queue row count (66 against current state)
- [ ] Verify `select_next_pending` still returns the oldest pending row (no regression in run-next)
- [ ] Verify `lib_residuals.load_queue` still parses the queue and `validate-rules` still passes
- [ ] Verify `wontfix` rows ARE visible in the default view (the rationale above depends on this)

## Out of scope
- Archive policy for old `done` rows (no rows >90 days old today; deferred until the queue actually accumulates aging done rows).
- Auto-flipping wontfix rows back to pending when prerequisites land (operator's manual call).
- The over-broad `_RISK_KEYWORD_PATTERN` issue surfaced in residual `fae506ff` (separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)