### PR TITLE
fix: cmd_backfill_rejected uses atomic write_json (residual 029fd0e6)

### DIFF
--- a/memory/postmortem_analysis.py
+++ b/memory/postmortem_analysis.py
@@ -1089,7 +1089,7 @@ def cmd_backfill_rejected(args: argparse.Namespace) -> int:
     existing_rules.extend(novel)
     existing_doc["rules"] = existing_rules
     rules_path.parent.mkdir(parents=True, exist_ok=True)
-    rules_path.write_text(json.dumps(existing_doc, indent=2), encoding="utf-8")
+    write_json(rules_path, existing_doc)
     print(json.dumps(result, indent=2))
     return 0
 

--- a/tests/test_postmortem_backfill_rejected.py
+++ b/tests/test_postmortem_backfill_rejected.py
@@ -250,3 +250,90 @@ def test_backfill_handles_existing_rules_doc(tmp_path: Path, monkeypatch: pytest
     assert any(r["rule"] == "new rule from backfill" for r in final["rules"])
     # Top-level extra fields preserved
     assert final["extra_field"] == "must be preserved"
+
+
+def test_backfill_writes_atomically(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """``cmd_backfill_rejected`` must persist ``prevention-rules.json``
+    via the atomic ``write_json`` helper (tempfile + fsync + os.rename),
+    not via a raw ``write_text(json.dumps(...))`` call.
+
+    This test pins the observable difference between the two write
+    paths: ``write_json`` appends a trailing ``\\n`` (see
+    ``hooks/lib_core.py:166``), while ``write_text(json.dumps(...))``
+    does not. A single-byte tell that catches a regression of line
+    1092 back to the non-atomic write.
+
+    Covers ACs 3, 4, 5, 6 — and structurally guards AC 7 by ensuring
+    the only call site writing ``rules_path`` is the atomic helper.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("DYNOS_HOME", str(fake_home / ".dynos"))
+
+    # Seed an existing rules doc so the test exercises the merge-and-write
+    # path (existing_doc has both a prior rule and the newly added one).
+    from lib_core import _persistent_project_dir
+    persistent = _persistent_project_dir(tmp_path)
+    persistent.mkdir(parents=True, exist_ok=True)
+    rules_path_seed = persistent / "prevention-rules.json"
+    seed_doc = {
+        "rules": [
+            {
+                "executor": "all",
+                "category": "process",
+                "rule": "seed rule for atomic write regression",
+                "template": "advisory",
+                "params": {},
+            }
+        ],
+    }
+    rules_path_seed.write_text(json.dumps(seed_doc))
+
+    _make_task_with_analysis(tmp_path, "task-atomic", [
+        {
+            "executor": "all",
+            "category": "process",
+            "rule": "atomic write regression rule (novel)",
+        },
+    ])
+
+    result = _run_backfill(tmp_path, dry_run=False)
+    assert result["novel_rules"] == 1
+    rules_path = Path(result["rules_path"])
+    assert rules_path == rules_path_seed
+    assert rules_path.is_file()
+
+    # AC 3 + AC 4: trailing newline byte — the strongest signal that
+    # ``write_json`` (not ``write_text``) was used at line 1092.
+    raw = rules_path.read_bytes()
+    assert raw.endswith(b"\n"), (
+        "prevention-rules.json must end with a trailing newline, which is "
+        "the documented behavior of write_json (lib_core.py:166). A missing "
+        "newline indicates the non-atomic write_text path is still in use."
+    )
+
+    # AC 5: file is parseable as JSON (write_json's append of '\n' is
+    # whitespace, which json.loads tolerates).
+    content = json.loads(rules_path.read_text())  # must not raise
+
+    # AC 6: parsed content matches the in-memory doc that was written —
+    # seed rule preserved, novel rule appended.
+    assert isinstance(content, dict)
+    assert "rules" in content
+    assert len(content["rules"]) == 2, (
+        "expected seed rule + 1 novel rule = 2 total"
+    )
+    rule_texts = {r["rule"] for r in content["rules"]}
+    assert "seed rule for atomic write regression" in rule_texts
+    assert "atomic write regression rule (novel)" in rule_texts
+
+    # Structural guard for AC 7: write_json removes its tempfile via
+    # os.rename on success and unlinks on failure, so no orphan
+    # ``.tmp`` siblings should remain in the rules dir after a clean run.
+    leftover_tmps = [
+        p for p in rules_path.parent.iterdir()
+        if p.name != rules_path.name and p.suffix == ".tmp"
+    ]
+    assert leftover_tmps == [], (
+        f"unexpected tempfile leftovers in {rules_path.parent}: {leftover_tmps}"
+    )


### PR DESCRIPTION
## Summary
- `cmd_backfill_rejected` in `memory/postmortem_analysis.py` wrote the persistent control-plane file `prevention-rules.json` non-atomically via `rules_path.write_text(json.dumps(...))` — no temp file, no rename, no lock.
- The same module's main rule-promotion path at line 922 already uses `lib_core.write_json` (tempfile + LOCK_EX + fsync + os.rename per `lib_core.py:159-176`). The two writers were inconsistent.
- A torn write from SIGKILL (e.g. OOM-killed during a backfill of hundreds of rules) leaves `hooks/rules_engine.py` reading a half-JSON file, trips `_refuse_if_rules_corrupt`, and BLOCKS new tasks until manual recovery.
- This PR is a 1-line swap to `write_json(rules_path, existing_doc)`. `write_json` was already imported at line 28; zero new imports.

## Diff
```diff
-    rules_path.write_text(json.dumps(existing_doc, indent=2), encoding="utf-8")
+    write_json(rules_path, existing_doc)
```

## Observable byte-level difference (intentional, harmless)
`write_json` appends a trailing `\n` after the JSON document (`lib_core.py:166`). All readers use `json.loads`, which ignores trailing whitespace. No consumer breaks. The trailing newline is also the diagnostic the new TDD test asserts to distinguish `write_json` from `write_text`.

## Test plan
- [ ] `python3 -m pytest tests/test_postmortem_backfill_rejected.py -v` — expect 8/8 (7 pre-existing + 1 new test `test_backfill_writes_atomically` committed earlier as `fd6a2b2` "tdd:")
- [ ] Full pytest suite — expect no new failures vs main
- [ ] `grep -c "rules_path.write_text" memory/postmortem_analysis.py` — expect 0

## Out of scope (deferred to a separate code-quality residual)
Lines 1023 and 1049 still use `json.loads(read_text())` inside `try/except (OSError, ValueError): <default>`. Refactoring to `load_json` would change error-path semantics — `load_json` doesn't catch `OSError`/`ValueError`, so a naive swap would propagate exceptions where the current code falls through to defaults. That's a separate, careful refactor and is outside this PR's scope.

Generated with Claude Code