### PR TITLE
fix: atomic JSON writes for 6 cache + dashboard sites

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -3796,7 +3796,7 @@ def cmd_run_audit_setup(args: argparse.Namespace) -> int:
             diff_files=diff_files if (diff_base is not None and diff_error is None) else None,
         )
         audit_plan_path = task_dir / "audit-plan.json"
-        audit_plan_path.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+        write_json(audit_plan_path, plan)
 
         print(json.dumps({
             "status": "audit_setup_ready",

--- a/hooks/daemon.py
+++ b/hooks/daemon.py
@@ -265,7 +265,7 @@ def maintainer_policy(root: Path) -> dict:
         path.parent.mkdir(parents=True, exist_ok=True)
         write_json(path, merged)
     if merged != data:
-        path.write_text(json.dumps({**data, **merged}, indent=2) + "\n")
+        write_json(path, {**data, **merged})
     return merged
 
 
@@ -291,7 +291,7 @@ def current_pid(root: Path) -> int | None:
 def write_status(root: Path, payload: dict) -> None:
     path = status_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n")
+    write_json(path, payload)
 
 
 def run_python(root: Path, script_name: str, *args: str) -> tuple[subprocess.CompletedProcess[str], dict | None]:

--- a/hooks/plan_gap_analysis.py
+++ b/hooks/plan_gap_analysis.py
@@ -25,6 +25,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from lib_core import write_json
+
 # ---------------------------------------------------------------------------
 # Route pattern detection — covers major frameworks across ecosystems
 # ---------------------------------------------------------------------------
@@ -519,10 +521,7 @@ def _write_cache(task_dir: Path, fingerprint: str, report: dict[str, Any]) -> No
     """Persist gap-analysis report keyed by fingerprint. Best-effort."""
     cache_path = _cache_path(task_dir)
     try:
-        cache_path.write_text(json.dumps({
-            "fingerprint": fingerprint,
-            "report": report,
-        }))
+        write_json(cache_path, {"fingerprint": fingerprint, "report": report})
     except OSError:
         pass  # Cache failure must not break gap analysis
 

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -30,6 +30,7 @@ from lib_core import (
     load_json,
     now_iso,
     project_policy,
+    write_json,
 )
 from lib_defaults import (
     DEFAULT_MODEL as _DEFAULT_MODEL_CONST,
@@ -1353,7 +1354,7 @@ def _write_executor_plan_cache(
         "graph_path": str(graph_path),
         "plan": plan,
     }
-    cache_path.write_text(json.dumps(record, indent=2) + "\n")
+    write_json(cache_path, record)
     return cache_path
 
 

--- a/telemetry/dashboard.py
+++ b/telemetry/dashboard.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse, parse_qs
 
 from lineage import build_lineage
 from report import build_report
+from lib_core import write_json
 from lib_validate import validate_generated_html
 
 
@@ -2602,7 +2603,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
 
     data_path = dynos_dir / "dashboard-data.json"
     html_path = dynos_dir / "dashboard.html"
-    data_path.write_text(json.dumps(payload, indent=2) + "\n")
+    write_json(data_path, payload)
     html_path.write_text(_REDIRECT_HTML)
 
     validation_errors = validate_generated_html(html_path)


### PR DESCRIPTION
## Summary

Replaces six non-atomic `path.write_text(json.dumps(...))` calls across `hooks/` and `telemetry/` with the existing atomic `write_json` helper from `hooks/lib_core.py` (tempfile + LOCK_EX + fsync + os.rename). Closes the torn-write race window that concurrent workers across worktrees could observe.

Sites:
- `hooks/router.py:1356` — `_write_executor_plan_cache`
- `hooks/ctl.py:3799` — audit-plan write
- `hooks/plan_gap_analysis.py:522` — `_write_cache` (try/except OSError preserved)
- `hooks/daemon.py:268` — merge update branch
- `hooks/daemon.py:294` — `write_status`
- `telemetry/dashboard.py:2605` — dashboard payload write

No new helper introduced. `memory/postmortem_analysis.py:1092` was already atomic and left untouched.

## Test plan

- [x] `pytest tests/` — 2348 passed, 8 skipped
- [x] `grep -rn "write_text(json.dumps" hooks/ telemetry/ memory/` — only the explicitly out-of-scope sites remain (`hooks/session-start:37`, `telemetry/dashboard.py:2534`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)