### PR TITLE
refactor: hoist ctl.py inline regexes; add postmortem.py source-filter guard

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -75,6 +75,14 @@ _APPROVE_STAGE_MAP: dict[str, tuple[str, str]] = {
 # AC 8: single source of truth for the ctl write role used at all write sites.
 _WRITE_ROLE = "ctl"
 
+# Compiled-once regex constants. Hoisted out of inline call sites so the
+# pattern is the single source of truth and re.compile fires once at
+# module import instead of once per call.
+_FILE_PATH_RE = re.compile(
+    r"\b[\w./-]+\.(py|ts|tsx|js|jsx|go|rb|java|rs|yml|yaml|json|md|sql)\b"
+)
+_URL_SCHEME_RE = re.compile(r"^https?://")
+
 
 def _rules_corrupt_sentinel(root: Path) -> Path:
     """Return sentinel path co-located with daemon.py's writer.
@@ -192,9 +200,7 @@ def _match_terms(text: str, terms: tuple[str, ...]) -> list[str]:
 
 
 def _looks_like_local_file_scoped_task(text: str) -> bool:
-    return bool(
-        re.search(r"\b[\w./-]+\.(py|ts|tsx|js|jsx|go|rb|java|rs|yml|yaml|json|md|sql)\b", text.lower())
-    )
+    return bool(_FILE_PATH_RE.search(text.lower()))
 
 
 def _compute_external_solution_gate(task_dir: Path) -> dict:
@@ -3119,10 +3125,8 @@ def cmd_write_search_receipt(args: argparse.Namespace) -> int:
             return 1
 
         # Validate each URL matches ^https?://
-        import re as _re
-        _url_pattern = _re.compile(r"^https?://")
         for url in urls_consulted:
-            if not _url_pattern.match(url):
+            if not _URL_SCHEME_RE.match(url):
                 print(
                     f"validation error: urls_consulted entry does not match ^https?://: {url}",
                     file=sys.stderr,
@@ -3495,15 +3499,13 @@ def _check_receipt_structure(receipt: dict) -> str | None:
     """Return None if receipt carries valid urls_consulted and findings_summary.
     Return an error string on any violation.
     """
-    import re as _re
     urls = receipt.get("urls_consulted")
     if urls is None:
         return "receipt_structure: urls_consulted is missing from search-conducted receipt"
     if not isinstance(urls, list) or len(urls) == 0:
         return "receipt_structure: urls_consulted must be a non-empty list"
-    _url_pattern = _re.compile(r"^https?://")
     for url in urls:
-        if not isinstance(url, str) or not _url_pattern.match(url):
+        if not isinstance(url, str) or not _URL_SCHEME_RE.match(url):
             return (
                 f"receipt_structure: urls_consulted entry does not match ^https?://: {url!r}"
             )

--- a/tests/test_source_filter_downstream.py
+++ b/tests/test_source_filter_downstream.py
@@ -299,6 +299,27 @@ class TestPostmortemImproveFilter:
 
 
 # ---------------------------------------------------------------------------
+# 4b. TestPostmortemFilter — AST guarantee on memory/postmortem.py.
+# ---------------------------------------------------------------------------
+
+
+class TestPostmortemFilter:
+    """Static guarantee that postmortem never opts into unverified.
+
+    ``memory/postmortem.py`` is the rule-mining sibling of
+    ``postmortem_improve.py`` and consumes ``collect_retrospectives``
+    output to build prevention rules.  Same trust-boundary contract
+    applies: ingesting a ``persistent-unverified`` retro into rule
+    mining would let a tampered/unflushed retro shape future routing
+    decisions, which is precisely the leak this suite closes.
+    """
+
+    def test_postmortem_never_calls_with_include_unverified_true(self) -> None:
+        src = (MEMORY_DIR / "postmortem.py").read_text()
+        _assert_no_include_unverified_true(src, "memory/postmortem.py")
+
+
+# ---------------------------------------------------------------------------
 # 5. TestRegressionSentinel — repo-wide static scan for direct-glob
 #    bypasses of collect_retrospectives.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two small, independent cleanups bundled into one PR — both surfaced during a manual residual sweep on 2026-05-10:

- **`hooks/ctl.py`**: hoist three inline regex sites to module-level constants. The file-extension pattern in `_looks_like_local_file_scoped_task` and the `^https?://` URL-scheme pattern (compiled twice — once in `write-search-receipt` validation, once in `_check_receipt_structure`) are now `_FILE_PATH_RE` and `_URL_SCHEME_RE`. `re.compile` fires once at import; pattern is the single source of truth. Closes the task-009 inline-validation-pattern-duplication residual.

- **`tests/test_source_filter_downstream.py`**: add `TestPostmortemFilter` AST guard mirroring the existing guards for `policy_engine`, `agent_generator`, and `postmortem_improve`. `memory/postmortem.py` is the rule-mining sibling of `postmortem_improve` and is the only `memory/` consumer of `collect_retrospectives` not yet covered by a static guard against `include_unverified=True`. Ingesting a persistent-unverified retro into rule mining would let a tampered/unflushed retro shape future routing decisions; the guard now blocks that statically.

No behavior change in production code; `ctl.py` is a pure refactor.

## Test plan

- [x] `pytest tests/test_source_filter_downstream.py` — 10/10 pass (was 9, added 1)
- [x] `pytest tests/test_dynos_papercut_fixes.py` — 10/10 pass (exercises one of the touched ctl.py paths)
- [x] Smoke: `_looks_like_local_file_scoped_task` and `_check_receipt_structure` both behave identically pre/post hoist
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)