### PR TITLE
docs: fix PIPELINES.md policy.json path for ensemble voting config

### DIFF
--- a/PIPELINES.md
+++ b/PIPELINES.md
@@ -138,7 +138,7 @@ Each stage validates its required inputs before proceeding. The runtime (`ctl.py
 | Repair | `repair-coordinator` | single — sonnet |
 | Investigation | `investigator` | single — sonnet |
 
-**Ensemble voting** (`security-auditor` and `db-schema-auditor` always; others sampled): sequential cascade — spawn haiku; if zero findings → spawn sonnet; if sonnet zero → PASS; if sonnet finds issues → escalate to opus; if haiku finds issues → skip sonnet, escalate directly to opus. Opus verdict is final. Configurable via `.dynos/config/policy.json` (`ensemble_auditors`, `ensemble_voting_models`, `ensemble_escalation_model`).
+**Ensemble voting** (`security-auditor` and `db-schema-auditor` always; others sampled): sequential cascade — spawn haiku; if zero findings → spawn sonnet; if sonnet zero → PASS; if sonnet finds issues → escalate to opus; if haiku finds issues → skip sonnet, escalate directly to opus. Opus verdict is final. Configurable via `~/.dynos/projects/{slug}/policy.json` (`ensemble_auditors`, `ensemble_voting_models`, `ensemble_escalation_model`).
 
 The router may further override models based on learned policy and benchmark history.
 


### PR DESCRIPTION
## Summary

`PIPELINES.md:141` pointed ensemble voting config readers at `.dynos/config/policy.json`, which does not exist. The actual path is `~/.dynos/projects/{slug}/policy.json` — the same one PIPELINES.md itself uses on line 347 in the persistent-state section. One-line internal-consistency fix surfaced by a full doc-vs-code scan.

## Test plan

- [x] Confirmed `.dynos/config/` does not exist in the repo
- [x] Confirmed `~/.dynos/projects/{slug}/policy.json` is the path the code actually reads
- [x] Cross-checked against PIPELINES.md:347 which already documents the correct path
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)