### PR TITLE
fix: route aggregate-trend prevention rules to auditors, not executors

### DIFF
--- a/hooks/router.py
+++ b/hooks/router.py
@@ -1083,9 +1083,13 @@ def build_executor_plan(
         route_decision = resolve_route(root, executor, task_type, ctx=ctx)
 
         # Step 1: filter to rules that target this executor (or all).
+        # `auditor-only` rules (aggregate category-trend signals) are
+        # excluded — executors cannot act on cross-task category warnings
+        # the way auditors reviewing code can.
         executor_scoped: list[dict] = [
             r for r in all_rules
             if isinstance(r, dict) and r.get("rule")
+            and r.get("executor") != "auditor-only"
             and (not r.get("executor") or r.get("executor") == executor)
         ]
 
@@ -1792,6 +1796,26 @@ def cmd_audit_inject_prompt(args: argparse.Namespace) -> int:
     agent_path = target.get("agent_path")
 
     final_text = base_prompt
+
+    # Inject aggregate category-trend prevention rules (executor="auditor-only").
+    # These are cross-task signals that auditors can act on when reviewing
+    # code; executors writing code cannot. They are excluded from every
+    # executor prompt by build_executor_plan and surface here instead.
+    aggregate_rules = [
+        r for r in load_prevention_rules(root)
+        if isinstance(r, dict) and r.get("rule")
+        and r.get("executor") == "auditor-only"
+    ]
+    if aggregate_rules:
+        aggregate_block = "\n\n## Aggregate Findings Trends\n"
+        aggregate_block += (
+            "Cross-task signals to scrutinize during this audit. Each entry "
+            "names a category whose finding count has crossed the learned "
+            "threshold across recent tasks.\n\n"
+        )
+        for r in aggregate_rules:
+            aggregate_block += f"- {r['rule']}\n"
+        final_text = final_text.rstrip() + aggregate_block
 
     if route_mode in ("replace", "alongside") and agent_path:
         try:

--- a/memory/agent_generator.py
+++ b/memory/agent_generator.py
@@ -100,13 +100,18 @@ def _build_agent_content(
     finding_categories = _aggregate_finding_categories(matched_retros)
 
     prevention_rules = _load_prevention_rules(root)
-    # Filter rules: category must match AND executor must be this role or "all"
+    # Filter rules: category must match AND executor must be this role or "all".
+    # `auditor-only` rules (aggregate category-trend signals from
+    # memory/postmortem_improve.py) are excluded from every executor agent
+    # file — they are audit-review signals, not per-line code constraints.
     relevant_rules: dict[str, list[dict]] = {}
     for r in prevention_rules:
         cat = r.get("category")
         if cat not in finding_categories:
             continue
         rule_executor = r.get("executor", "all")
+        if rule_executor == "auditor-only":
+            continue
         if rule_executor not in (role, "all"):
             continue
         relevant_rules.setdefault(cat, []).append(r)

--- a/memory/postmortem_improve.py
+++ b/memory/postmortem_improve.py
@@ -250,9 +250,16 @@ def apply_improvement(root: Path, proposal: dict) -> dict:
         category = proposal.get("category", "")
         existing_cats = {r.get("category") for r in rules}
         if category and category not in existing_cats:
+            # Aggregate category-trend rules are audit-time signals: they
+            # describe cross-task patterns useful when reviewing code, not
+            # actionable per-line constraints for the executor writing it.
+            # Tag them `executor="auditor-only"` so the executor-facing
+            # filters in agent_generator and router exclude them.
             rules.append({
                 "category": category,
                 "rule": f"Category '{category}' has {proposal.get('total_occurrences', 0)} findings across tasks. Add extra scrutiny for {category}-class issues.",
+                "executor": "auditor-only",
+                "template": "advisory",
                 "added_at": now_iso(),
             })
             write_json(rules_path, {"rules": rules, "updated_at": now_iso()})


### PR DESCRIPTION
## Summary

Auto-generated prevention rules from `memory/postmortem_improve.py` (e.g. `Category 'SEC' has 32 findings across tasks. Add extra scrutiny for SEC-class issues.`) are cross-task category-trend signals — useful when **reviewing** code (auditors), unactionable when **writing** code (executors). Prior behavior leaked them into every executor's learned-agent prompt and never delivered them to auditors. This fix inverts the routing back to its intended direction.

## Mechanism (verified via /dynos-work:investigate INV-20260510182402)

| Step | File:line | Behavior |
|---|---|---|
| 1 | `postmortem_improve.py:253` | Wrote aggregate rules with no `executor`, no `template`, no `rule_id` |
| 2 | `agent_generator.py:109` | `r.get("executor", "all")` → "all" → rule landed in every executor agent file |
| 3 | `router.py:1089` | `not r.get("executor")` truthy → passed executor filter |
| 4 | `router.py:1105` | `tmpl is None` → kept as backward-compat advisory → reached `build_executor_prompt` |
| 5 | `router.py:1739-1834` | `cmd_audit_inject_prompt` never called `load_prevention_rules` → auditors received nothing |

## Fix

- **`postmortem_improve.py:253`** — tag aggregate rules with `executor: "auditor-only"`, `template: "advisory"`
- **`agent_generator.py:109`** — exclude `auditor-only` from every executor learned-agent file
- **`router.py:1086-1090`** — exclude `auditor-only` from executor prompt injection
- **`router.py:~1794`** — new injection in `cmd_audit_inject_prompt`: `auditor-only` rules surface in auditor prompts under `## Aggregate Findings Trends`

Reuses the existing `executor` field with a reserved sentinel value (`"auditor-only"`). No schema changes, no migration needed.

## Test plan

- [x] `pytest tests/ -q -k "prevention_rule or postmortem_improve or router or agent_generator or learned_agent"` — 80 passed
- [x] Pre-existing 4 failures unchanged (verified via stash-and-rerun on baseline): `test_validate_rules_live_registry` (live-registry data issue from task-20260508-009), `test_register_and_promote_learned_agent`, two `test_router_executor_plan_cache` tests — none touch the code paths changed here
- [ ] CI green

## Scope

Honest framing per the user who reported it: low-magnitude pipeline misrouting. Not a security bug or correctness regression. Existing executors get ~50 fewer inert tokens per prompt; auditors gain a small but real cross-task signal they didn't have before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)