### PR TITLE
fix: permissions-ON pipeline — per-actor roles, dynos funnel, verification evidence (7.4.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,27 @@
 {
   "name": "dynos-work",
-  "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.4.0",
+  "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs \u2014 calibrates to your project over time.",
+  "version": "7.4.1",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"
   },
   "homepage": "https://github.com/dynos-fit/dynos-work",
   "license": "MIT",
-  "keywords": ["audit", "autonomous", "engineering", "agents", "planning", "repair", "self-learning", "reinforcement-learning", "mcts", "decision-transformer", "foundry", "human-in-the-loop"],
+  "keywords": [
+    "audit",
+    "autonomous",
+    "engineering",
+    "agents",
+    "planning",
+    "repair",
+    "self-learning",
+    "reinforcement-learning",
+    "mcts",
+    "decision-transformer",
+    "foundry",
+    "human-in-the-loop"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.4.1] - 2026-06-11
+### "Permissions-ON": The Plugin Stops Denying Its Own Pipeline
+
+A real permissions-on run (no `--dangerously-skip-permissions`, no blanket allow) showed the plugin denying actions its own skills prescribe: `/tmp` payload staging, `2>/dev/null` redirects, `rm active-segment-role`, orchestrator writes blocked by whatever role was last stamped for a subagent, and `run-execution-verify-evidence` hard-erroring after `run-execution-finish`. 7.4.1 fixes the causes per `docs/permissions-on-design.md` while tightening every guardrail it touches. Design doc: `docs/permissions-on-design.md`; spec addendum: `docs/write-boundary-spec.md`.
+
+### Added
+- **Per-actor role resolution (D3):** SessionStart pins the orchestrator session (`.dynos/orchestrator-session.json`, hook-owned); the main session always resolves to the new `orchestrator` role and never reads role files. Subagents consume single-use grants (`ctl grant-role`, ledger at `role-grants.json`, wrapper-required) bound immutably per session (`role-bindings.json`, hook-owned). `ctl clear-role` replaces the policy-denied `rm active-segment-role`. Legacy role-file resolution is preserved for unpinned sessions.
+- **Verification-evidence runner (D6):** execution-graph segments may declare `verify_commands`; `ctl run-verification-evidence` executes them and captures exit codes + output into ctl-owned `evidence/verification/{seg}.json` (executors are policy-denied from writing it), hash-bound by a receipt. `run-execution-finish` requires a passing record for every declaring segment; the spec-completion auditor cites the record instead of trusting executor narrative — execution-based acceptance criteria are now machine-verified.
+- **Task scratch namespace (D2):** `.dynos/task-*/_scratch/` is sanctioned temp space for recognized actor roles; CI asserts no gate/receipt/validator ever reads it.
+- **stdin payloads (D1):** `write-classification` / `write-execution-graph` / `write-repair-log` accept `--from -`; skills pipe LLM-returned payloads via heredoc instead of staging files.
+- **`ctl run-start-init`** replaces start Step 0's six hand-run actions (manifest moves from agent-write to ctl-write); **`ctl tdd-receipt`** replaces the inline-python receipt snippet; **`dynos hook <script>`** funnels helper scripts without `PYTHONPATH=` incantations.
+- **Self-modification guard (H1):** agent roles (including executors) can no longer write the installed plugin directory, `~/.claude/plugins/`, `~/.claude/settings*.json`, or `~/.dynos/` — closing the "agent edits its own guardrails" hole. Developer mode (plugin source repo) exempts the plugin-root check only.
+- **Prose↔policy contract test** (`tests/test_skill_prose_policy_contract.py`): extracts every fenced command block from the pipeline skills, runs the production destination extractor + `decide_write`, and fails CI on any prescribed-but-denied write, forbidden token (`/tmp`, `PYTHONPATH=`, `rm active-segment-role`, repo-relative hook calls), unregistered ctl subcommand, or read-only agent instructed to write files.
+- **Investigator dossier-only enforcement (D7-3):** the pre-tool-use hook denies investigator Grep/Glob and restricts Read to `.dynos/investigations/` + dossier-referenced files; `triage.py finalize` validates structure + citations and persists report + markdown (the read-only agent now RETURNS its JSON). Classifier gains `ci-failure` / `config-error` types.
+
+### Changed
+- **Bash write detection is quote-aware (D5):** shlex tokenization with heredoc stripping replaces raw-string regexes — `>` inside quoted prompts/JSON no longer produces false write destinations; `/dev/null` and friends are recognized sinks. Legacy regexes remain only as the fail-closed fallback for unparseable commands.
+- **Denials are self-explaining:** every write-policy denial names itself as a plugin guardrail (not a Claude Code permission), the role, the path, and the sanctioned alternative (wrapper command or `_scratch/`), with a degraded-actor diagnostic when relevant.
+- **`run-execution-finish` verifies evidence inside the stage gate** (evidence files, `files_expected`, declared verifications); `run-execution-verify-evidence` is legal at EXECUTION *and* TEST_EXECUTION (it previously hard-errored after finish — the execute Step 5 dead-end).
+- **`files_expected` supports directories (`src/pkg/`) and path-aware globs (`src/**/*.py`)** across the diff-membership check, evidence existence, ownership, and the cross-segment exclusivity rule (which got stricter: containment counts as overlap).
+- **Validator errors are self-correcting:** enum violations name the valid set with did-you-mean hints (`'ci'` → `'infra'` — `ci` is intentionally NOT a domain; `'backend'` → `'backend-executor'`). Plan Reference-Code checks only slash-containing tokens and honors a "Files to be created" section.
+- **Skill prose rewritten to the `bin/dynos` funnel:** all `python3 hooks/ctl.py` / `PYTHONPATH=...` invocations in the pipeline skills route through `"$DYNOS" ctl` / `"$DYNOS" hook`; a permissions-ON user can allow the single `<plugin-root>/bin/dynos` prefix once. `hooks.json` SessionStart matcher gains `resume` so the pin survives resumed sessions.
+- Conformance fixes: `execute/SKILL.md`'s false "audit-* roles cannot be stamped" claim corrected; repair-coordinator (no Write/Bash) now returns its payload for the orchestrator to persist via stdin; security-auditor description no longer claims "Read-only" while prescribing its report write.
+
+### Plugin / Distribution
+- Bump `.claude-plugin/plugin.json` and `package.json` to `7.4.1`.
+
+---
+
 ## [7.4.0] - 2026-05-05
 ### "Wider Drain": Residual Queue Captures More Sources
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ After the task, it learns from what went wrong and builds prevention rules for n
 
 Just Claude Code.
 
+## Running with permissions ON
+
+The pipeline works without `--dangerously-skip-permissions`. Every deterministic step funnels through one binary — `<plugin-root>/bin/dynos` — so you can allow that single command prefix once (via the permission prompt's "don't ask again" or a `Bash(<plugin-root>/bin/dynos ...)` allow rule in your settings) and then you only interact with the decisions that are actually yours: discovery questions, spec approval, plan approval, and TDD review. Plugin guardrail denials are not Claude Code permission errors — they say so explicitly and name the sanctioned alternative. Details: `docs/write-boundary-spec.md`.
+
 ## Links
 
 - [Changelog](CHANGELOG.md)

--- a/agents/investigator.md
+++ b/agents/investigator.md
@@ -16,7 +16,7 @@ CONTRACT
 6. Output JSON conforming to debug-module/schemas/bug_report.schema.json. Do not invent fields.
 7. Do NOT read files not referenced in the evidence_dossier. Your tools are Read and Grep only.
 
-INPUT: path to evidence_dossier.json
-OUTPUT: JSON object matching bug_report.schema.json — no prose, no markdown wrapping.
+INPUT: path to evidence_dossier.json (under .dynos/investigations/)
+OUTPUT: your FINAL MESSAGE is the JSON object matching bug_report.schema.json — no prose, no markdown wrapping, nothing before or after it. Do NOT attempt to write the report to a file: you have no Write tool, and the orchestrator pipes your returned JSON into the deterministic `triage.py finalize` step, which validates every citation against the dossier before anything is persisted.
 
-Every evidence_ids field in the output MUST be populated with at least one ID drawn from the dossier. An empty evidence_ids array is a contract violation and the report will be rejected.
+Every evidence_ids field in the output MUST be populated with at least one ID drawn from the dossier. An empty evidence_ids array is a contract violation and the report will be rejected by finalize.

--- a/agents/planning.md
+++ b/agents/planning.md
@@ -147,7 +147,7 @@ Your spec must be hostile to sloppy implementation. It should leave no room for 
 
 ## Phase: Spec + Plan (combined, fast-track only)
 
-When given this phase, produce BOTH `spec.md` AND `plan.md` AND an execution-graph payload in a single pass. Persist `plan.md` directly, but persist the final `execution-graph.json` ONLY through `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`. This phase is only used for fast-track tasks (low risk, single domain) where the spec and plan are tightly coupled and the overhead of two separate spawns dominates the actual work.
+When given this phase, produce BOTH `spec.md` AND `plan.md` AND an execution-graph payload in a single pass. Persist `plan.md` directly, but persist the final `execution-graph.json` ONLY through `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-execution-graph .dynos/task-{id} --from -`, piping the payload over stdin with a heredoc. This phase is only used for fast-track tasks (low risk, single domain) where the spec and plan are tightly coupled and the overhead of two separate spawns dominates the actual work.
 
 Read `raw-input.md`, `discovery-notes.md`, `design-decisions.md`, AND the actual implementation files referenced in the task. Verify runtime semantics directly — do not assume.
 
@@ -170,7 +170,7 @@ Before classifying or writing anything, answer these silently:
 
 ### Step 2 — Classify
 
-Produce a JSON classification payload with this shape, write it to `/tmp/classification-{id}.json`, then persist the final normalized classification ONLY through `python3 hooks/ctl.py write-classification .dynos/task-{id} --from /tmp/classification-{id}.json`:
+Produce a JSON classification payload with this shape and persist the final normalized classification ONLY through the ctl wrapper, piping the payload over stdin with a heredoc (`"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-classification .dynos/task-{id} --from - <<'JSON' ... JSON`) — never stage it at /tmp or any raw path:
 
 ```json
 {
@@ -237,7 +237,7 @@ Write to `.dynos/task-{id}/spec.md`:
 
 ## Phase: Implementation Planning (+ Execution Graph)
 
-When given this phase, generate BOTH the implementation plan (`plan.md`) AND the execution graph payload. Persist `plan.md` directly, but persist the final `execution-graph.json` ONLY through `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`. This eliminates the need for a separate execution-coordinator spawn.
+When given this phase, generate BOTH the implementation plan (`plan.md`) AND the execution graph payload. Persist `plan.md` directly, but persist the final `execution-graph.json` ONLY through `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-execution-graph .dynos/task-{id} --from -` (payload over stdin via heredoc). This eliminates the need for a separate execution-coordinator spawn.
 
 If `.dynos/task-{id}/design-doc.md` exists, its §11 lists the intended segments — your execution graph MUST match that segment shape (count, executor type, depends_on edges). If you must diverge, justify the divergence in `plan.md` under Open Questions; the plan-audit will flag silent drift.
 
@@ -320,7 +320,7 @@ For ORMs: name the model class and its location. For raw SQL: name the migration
 [Any unresolved decisions executor subagents should be aware of. For each: state the question, the options considered, and a recommended default if the executor needs to proceed without an answer.]
 ```
 
-Write the execution graph payload to `/tmp/execution-graph-{id}.json` with this shape, then run `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`:
+Build the execution graph payload with this shape and persist it by piping it to `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-execution-graph .dynos/task-{id} --from -` over stdin with a heredoc:
 
 ```json
 {
@@ -375,7 +375,7 @@ When given this phase, you act as the **Project Lead for a specific subsystem**.
 - **Do not write the `stage` field to manifest.json** — do not touch it.
 - **Do not hand-write `.dynos/task-{id}/classification.json` or mutate `manifest.json` directly during CLASSIFY_AND_SPEC.**
 - **During CLASSIFY_AND_SPEC you may write** `spec.md` directly, and you may persist classification only via `write-classification`.
-- **Do not hand-write `.dynos/task-{id}/execution-graph.json`.** Write the payload to `/tmp/execution-graph-{id}.json` and call the ctl wrapper.
+- **Do not hand-write `.dynos/task-{id}/execution-graph.json`.** Pipe the payload to the ctl wrapper over stdin (`--from -` with a heredoc); never stage it at /tmp or any raw path.
 - **Do not advance lifecycle stages.**
 - **Do not spawn other agents.**
 - **Every ambiguity must be resolved or flagged.** If you encounter something unclear, do not silently pick an interpretation and move on. Either resolve it by reading more code, or flag it explicitly in Assumptions with "needs confirmation."

--- a/agents/repair-coordinator.md
+++ b/agents/repair-coordinator.md
@@ -41,7 +41,7 @@ You are the Repair Coordinator. You receive audit findings and produce a precise
    - **Default (no policy match or cold-start)**: do not set `model_override` — the executor runs on its frontmatter default. Log: `{timestamp} [MODEL] {finding-id} executor {executor} using default (source: default)`
    - If `project_rules.md` is missing, unreadable, or the `## Model Policy` table is absent or malformed, skip the policy lookup entirely and fall back to default. Log: `{timestamp} [WARN] policy table missing/corrupt -- using defaults`
 5. Group findings into parallel-safe batches (no overlapping files = can run simultaneously). Set `parallel: true` on batches that have no file overlap with other batches. Set `parallel: false` on batches that share files with a preceding batch
-6. Write the updated repair-log payload to `/tmp/repair-log-{id}.json`, then persist the final `repair-log.json` ONLY via `python3 hooks/ctl.py write-repair-log .dynos/task-{id} --from /tmp/repair-log-{id}.json`
+6. **Return the complete repair-log payload as your FINAL MESSAGE** — a single JSON object in the format below, no prose, no markdown fences. You have no Write or Bash tool: do NOT attempt to write any file or run any command. The orchestrator persists your payload via `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-repair-log .dynos/task-{id} --from -` (stdin), which validates and normalizes it before anything lands on disk
 
 ## Executor assignment
 
@@ -100,8 +100,8 @@ Every instruction must also make it difficult for the executor to satisfy the wo
 - Every instruction must be precise and actionable
 - Two tasks that touch the same file must be in different batches
 - Do not re-add a finding that has already been resolved in a prior cycle
-- Do not fix anything yourself — write the plan only
-- Always produce a repair-log payload and persist the final file via `write-repair-log`
+- Do not fix anything yourself — produce the plan only
+- Always return the complete repair-log payload as your final message; the orchestrator persists it via `write-repair-log --from -`
 - Do not reset retry counts across phases — retry counts are continuous from phase 1 through phase 2. The `max_retries` limit (3) applies across both phases combined for a given finding
 - Do not add new top-level fields to `repair-log.json` — `model_override` is a task-level field only
 - Do not hand-write `.dynos/task-{id}/repair-log.json`

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: "Internal dynos-work agent. Adversarial security review and compliance audit of all changed code. Runs on every task. Always blocks completion. Read-only."
+description: "Internal dynos-work agent. Adversarial security review and compliance audit of all changed code. Runs on every task. Always blocks completion. Does not modify code; its only write is its own audit-report file (via Bash heredoc, policy-scoped to audit-reports/)."
 model: opus
 tools: [Read, Grep, Glob, Bash]
 maxTurns: 20

--- a/agents/spec-completion-auditor.md
+++ b/agents/spec-completion-auditor.md
@@ -27,7 +27,17 @@ You are the Spec-Completion Auditor. Your job is to verify that the implementati
 - `.dynos/task-{id}/spec.md` — the normalized spec with numbered acceptance criteria
 - `.dynos/task-{id}/plan.md` — the implementation plan
 - `.dynos/task-{id}/evidence/` — executor evidence files
+- `.dynos/task-{id}/evidence/verification/{segment-id}.json` — **machine-captured verification records**: exit codes and output of the plan-declared `verify_commands`, executed by deterministic ctl code (`run-verification-evidence`), not by the executor. Executors cannot write or alter these files.
 - **Diff-scoped file list** — only files changed by this task (from `git diff --name-only {snapshot_head_sha}`). Focus your audit on THESE files only, not the entire codebase.
+
+## Execution-based criteria
+
+For an acceptance criterion that requires RUNNING something (e.g. "ruff check src exits 0", "pytest passes", "the build succeeds"):
+
+1. Find the verification record whose `criteria_ids` includes the criterion (match the segment's `verify_commands` in `execution-graph.json`).
+2. `covered` requires a record with `exit_code: 0` for a command that actually proves the criterion. Cite it as evidence: `evidence/verification/{segment-id}.json — {command} — exit {exit_code}`.
+3. A record with non-zero `exit_code` is proof of FAILURE — cite it the same way.
+4. If NO verification record covers the criterion, mark it `missing` exactly as before. Do NOT accept the executor's narrative claim, do NOT run the command yourself (you have no Bash), and do NOT downgrade to `partial` because "it probably passes." The absence of machine evidence is the finding.
 
 ## Read Budget (HARD CAP)
 

--- a/bin/dynos
+++ b/bin/dynos
@@ -155,6 +155,24 @@ sys.exit(0 if pid else 1)
     ;;
 
   # --- Internals ---
+  hook)
+    # Generic passthrough for plugin helper scripts (router, lib_tokens,
+    # build_prompt_context, ...). Lets skill prose use ONE allowlistable
+    # command prefix instead of PYTHONPATH=... python3 incantations.
+    if [ $# -lt 1 ]; then
+      echo "usage: dynos hook <script-name> [args...]" >&2
+      exit 2
+    fi
+    script="$1"; shift
+    case "$script" in
+      */*|*..*) echo "dynos hook: invalid script name: $script" >&2; exit 2 ;;
+    esac
+    if [ ! -f "${HOOKS_DIR}/${script}.py" ]; then
+      echo "dynos hook: no such helper: ${script}" >&2
+      exit 2
+    fi
+    exec python3 "${HOOKS_DIR}/${script}.py" "$@"
+    ;;
   route)      exec python3 "${HOOKS_DIR}/router.py" "$@" ;;
   plan)       exec python3 "${HOOKS_DIR}/planner.py" "$@" ;;
   patterns)   exec python3 "${HOOKS_DIR}/patterns.py" "$@" ;;

--- a/cli/assets/templates/base/agents/investigator.md
+++ b/cli/assets/templates/base/agents/investigator.md
@@ -16,7 +16,7 @@ CONTRACT
 6. Output JSON conforming to debug-module/schemas/bug_report.schema.json. Do not invent fields.
 7. Do NOT read files not referenced in the evidence_dossier. Your tools are Read and Grep only.
 
-INPUT: path to evidence_dossier.json
-OUTPUT: JSON object matching bug_report.schema.json — no prose, no markdown wrapping.
+INPUT: path to evidence_dossier.json (under .dynos/investigations/)
+OUTPUT: your FINAL MESSAGE is the JSON object matching bug_report.schema.json — no prose, no markdown wrapping, nothing before or after it. Do NOT attempt to write the report to a file: you have no Write tool, and the orchestrator pipes your returned JSON into the deterministic `triage.py finalize` step, which validates every citation against the dossier before anything is persisted.
 
-Every evidence_ids field in the output MUST be populated with at least one ID drawn from the dossier. An empty evidence_ids array is a contract violation and the report will be rejected.
+Every evidence_ids field in the output MUST be populated with at least one ID drawn from the dossier. An empty evidence_ids array is a contract violation and the report will be rejected by finalize.

--- a/debug-module/lib/bug_classifier.py
+++ b/debug-module/lib/bug_classifier.py
@@ -29,6 +29,8 @@ ALLOWED_BUG_TYPES: tuple[str, ...] = (
     "performance",
     "data-corruption",
     "schema-drift",
+    "ci-failure",
+    "config-error",
     "unknown",
 )
 
@@ -125,6 +127,26 @@ _PATTERNS: dict[str, list[re.Pattern[str]]] = {
                    r"should\s*(?:return|be|equal)|"
                    r"expected\s+.+\s+but\s+got)\b", re.I),
     ],
+    # CI/pipeline failures — process-shaped, not code-shaped. Checked BEFORE
+    # test-failure so "the CI job fails" doesn't collapse into test-failure.
+    "ci-failure": [
+        re.compile(r"\b(ci|cd|ci/cd)\s*(?:job|run|pipeline|workflow|build|check|stage)s?\s*"
+                   r"(?:fail(?:ed|ing|s|ure)?|brok(?:e|en)|red|stuck|hang(?:s|ing)?)\b", re.I),
+        re.compile(r"\b(github\s*actions?|gitlab\s*ci|jenkins|circleci|buildkite|"
+                   r"travis|azure\s*pipelines?|teamcity)\b", re.I),
+        re.compile(r"\b(pipeline|workflow)\s+(?:is\s+)?(?:fail(?:ed|ing|s)?|broken|red)\b", re.I),
+        re.compile(r"\bfail(?:s|ed|ing)?\s+(?:only\s+)?(?:in|on)\s+ci\b", re.I),
+        re.compile(r"\bworks\s+locally\b.{0,40}\bfails?\b", re.I),
+    ],
+    # Configuration / environment errors — also process-shaped.
+    "config-error": [
+        re.compile(r"\b(misconfigur(?:ed|ation)|configuration\s*(?:error|issue|problem)|"
+                   r"wrong\s*config(?:uration)?|bad\s*config(?:uration)?|"
+                   r"missing\s*(?:env(?:ironment)?\s*var(?:iable)?s?|secret|api\s*key|credential)s?|"
+                   r"env(?:ironment)?\s*var(?:iable)?s?\s*(?:not\s*set|missing|unset|undefined)|"
+                   r"\.env\s*(?:file\s*)?(?:missing|not\s*loaded|ignored)|"
+                   r"invalid\s*(?:yaml|toml|ini|json)\s*config)\b", re.I),
+    ],
 }
 
 # Priority of detection — first match wins.
@@ -134,6 +156,8 @@ CLASSIFICATION_PRIORITY: tuple[str, ...] = (
     "data-corruption",
     "race-condition",
     "resource-leak",
+    "ci-failure",
+    "config-error",
     "performance",
     "runtime-error",
     "test-failure",

--- a/debug-module/lib/render_report.py
+++ b/debug-module/lib/render_report.py
@@ -115,7 +115,14 @@ def render(bug_report_json: dict, dossier: dict) -> str:
         or "INV-unknown"
     )
     bug_text = dossier.get("bug_text") or ""
-    bug_type = dossier.get("bug_type") or "unknown"
+    # bug_type lives canonically in the dossier (triage classification); the
+    # bug report may refine it. Prefer the report's value when present so the
+    # rendered header reflects the investigator's conclusion.
+    bug_type = (
+        bug_report_json.get("bug_type")
+        or dossier.get("bug_type")
+        or "unknown"
+    )
     repo_path = dossier.get("repo_path") or ""
     languages = dossier.get("languages_detected") or []
     pipeline_errors = dossier.get("pipeline_errors") or []

--- a/debug-module/triage.py
+++ b/debug-module/triage.py
@@ -386,10 +386,166 @@ def run_pipeline(
 
 
 # ---------------------------------------------------------------------------
+# finalize — deterministic persistence of the investigator's returned JSON
+# ---------------------------------------------------------------------------
+# The @investigator agent is read-only (tools: Read, Grep) and RETURNS its
+# bug-report JSON as its final message; it never writes a file. The
+# orchestrator pipes that JSON here. This step owns schema validation,
+# citation validation (every cited evidence ID must exist in the dossier),
+# and persistence of both the JSON and the rendered Markdown — so the
+# "citation validation third" guarantee is unskippable: it sits inside the
+# only sanctioned persistence path.
+
+def _strip_markdown_fences(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        first_newline = stripped.find("\n")
+        if first_newline != -1:
+            stripped = stripped[first_newline + 1:]
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    return stripped.strip()
+
+
+def _validate_bug_report_structure(report: Any) -> list[str]:
+    """Minimal structural validation of bug_report.schema.json invariants."""
+    errors: list[str] = []
+    if not isinstance(report, dict):
+        return ["bug report must be a JSON object"]
+    for key in ("investigation_id", "causal_chain", "root_cause", "recommended_fix"):
+        if key not in report:
+            errors.append(f"missing required field: {key}")
+    chain = report.get("causal_chain")
+    if not isinstance(chain, list) or not chain:
+        errors.append("causal_chain must be a non-empty array")
+    else:
+        for idx, step in enumerate(chain):
+            if not isinstance(step, dict):
+                errors.append(f"causal_chain[{idx}] must be an object")
+                continue
+            if not str(step.get("description", "")).strip():
+                errors.append(f"causal_chain[{idx}].description must be non-empty")
+            ids = step.get("evidence_ids")
+            if not isinstance(ids, list) or not ids:
+                errors.append(
+                    f"causal_chain[{idx}].evidence_ids must be non-empty "
+                    "(an uncited claim is a contract violation)"
+                )
+    for section in ("root_cause", "recommended_fix"):
+        block = report.get(section)
+        if not isinstance(block, dict):
+            errors.append(f"{section} must be an object")
+            continue
+        if not str(block.get("description", "")).strip():
+            errors.append(f"{section}.description must be non-empty")
+        ids = block.get("evidence_ids")
+        if not isinstance(ids, list) or not ids:
+            errors.append(f"{section}.evidence_ids must be non-empty")
+    return errors
+
+
+def _collect_all_cited_ids(report: dict) -> list[str]:
+    cited: list[str] = []
+    for step in report.get("causal_chain") or []:
+        if isinstance(step, dict):
+            cited.extend(str(x) for x in (step.get("evidence_ids") or []))
+    for section in ("root_cause", "recommended_fix"):
+        block = report.get(section)
+        if isinstance(block, dict):
+            cited.extend(str(x) for x in (block.get("evidence_ids") or []))
+    return cited
+
+
+def _finalize_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="triage.py finalize",
+        description=(
+            "Validate the investigator's returned bug-report JSON against the "
+            "dossier and persist report + rendered Markdown."
+        ),
+    )
+    parser.add_argument(
+        "--report", required=True,
+        help="Bug-report JSON file path, or '-' to read from stdin",
+    )
+    parser.add_argument("--dossier", required=True, help="Evidence dossier JSON path")
+    parser.add_argument(
+        "--out-dir", default=None,
+        help="Output directory (default: the dossier's directory)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.report == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            with open(args.report, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            sys.stderr.write(f"finalize: cannot read report: {exc}\n")
+            return 2
+    try:
+        report = json.loads(_strip_markdown_fences(raw))
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"finalize: report is not valid JSON: {exc}\n")
+        return 1
+
+    try:
+        with open(args.dossier, "r", encoding="utf-8") as fh:
+            dossier_data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"finalize: cannot load dossier: {exc}\n")
+        return 2
+
+    structural = _validate_bug_report_structure(report)
+    if structural:
+        sys.stderr.write(
+            "finalize: bug report rejected (structural violations):\n"
+            + "".join(f"  - {e}\n" for e in structural)
+        )
+        return 1
+
+    evidence_index = dossier_data.get("evidence_index") or {}
+    known_ids = {str(k) for k in evidence_index.keys()} if isinstance(evidence_index, dict) else set()
+    unknown = sorted({eid for eid in _collect_all_cited_ids(report) if eid not in known_ids})
+    if unknown:
+        sys.stderr.write(
+            "finalize: bug report rejected — citations not present in the "
+            f"dossier: {', '.join(unknown)}\n"
+            "The investigator may only cite pre-minted evidence IDs.\n"
+        )
+        return 1
+
+    out_dir = args.out_dir or os.path.dirname(os.path.abspath(args.dossier))
+    os.makedirs(out_dir, exist_ok=True)
+    report_path = os.path.join(out_dir, "bug_report.json")
+    _atomic_write_json(report_path, report)
+
+    from lib import render_report as _render_report  # noqa: PLC0415
+    markdown = _render_report.render(report, dossier_data)
+    md_path = os.path.join(out_dir, "report.md")
+    tmp_md = md_path + ".tmp"
+    with open(tmp_md, "w", encoding="utf-8") as fh:
+        fh.write(markdown)
+    os.replace(tmp_md, md_path)
+
+    print(json.dumps({
+        "status": "report_finalized",
+        "report_path": report_path,
+        "markdown_path": md_path,
+        "citations_validated": len(set(_collect_all_cited_ids(report))),
+    }, indent=2))
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 
 def main(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    if raw_argv and raw_argv[0] == "finalize":
+        return _finalize_main(raw_argv[1:])
     parser = _build_parser()
     args = parser.parse_args(argv)
 

--- a/docs/permissions-on-design.md
+++ b/docs/permissions-on-design.md
@@ -1,0 +1,427 @@
+# Design: Permissions-ON Usability Without Weakening Guardrails
+
+Status: IMPLEMENTED in v7.4.1 (2026-06-11) — kept as the design rationale record.
+See CHANGELOG.md [7.4.1] and the addendum in docs/write-boundary-spec.md.
+Scope: make `start → execute → audit` runnable by a user with Claude Code permissions ON
+(no `--dangerously-skip-permissions`, no blanket allow) such that the plugin never denies
+an action the plugin itself prescribed — while preserving every anti-hallucination /
+anti-overstep / anti-false-completion invariant.
+
+---
+
+## 0. Verified findings (corrections to the problem statement first)
+
+Every problem below was confirmed against the code. Three claims needed correction, and
+two new holes were found during analysis.
+
+### Corrections
+
+1. **"write_policy is non-deterministic" — it is deterministic, but state-dependent and
+   opaque.** Two mechanisms make identical-looking commands diverge:
+   - The role used for *every* orchestrator tool call is read fresh from the single
+     mutable file `active-segment-role` (`hooks/pre_tool_use.py:222-244`). Stamping a
+     role for a subagent silently changes the orchestrator's own write rights between
+     two otherwise-identical commands.
+   - Per-role allowlists differ per file, not per directory: role `planning` may write
+     `spec.md` but not `execution-log.md` in the *same* task dir
+     (`hooks/write_policy.py:327-330`). So "same role, same dir, one write passes one
+     fails" is correct policy behavior with an unreadable error.
+   Additionally the Bash pre-filter regex `>>?\s*([^\s;|&>]+)`
+   (`hooks/pre_tool_use.py:74`) matches `>` *inside quoted strings*, so any prompt text
+   piped via `echo "...">"` patterns trips it — the "path-like tokens in prompt
+   arguments" report.
+
+2. **"run-execution-verify-evidence is stage-gated to EXECUTION" — true, but
+   transitively.** The command has no explicit gate; it calls
+   `_compute_execution_batch_payload` which raises on `stage != "EXECUTION"`
+   (`hooks/ctl.py:2661-2665`, called at `ctl.py:4854`). `run-execution-finish`
+   advances EXECUTION → TEST_EXECUTION (`ctl.py:4813`), and the execute skill orders
+   finish (SKILL.md:298, end of Step 3) *before* verify-evidence (SKILL.md:323,
+   Step 5). Hard error confirmed; the fix is ordering + gate-widening, not gate removal.
+
+3. **`stamp-role` prose contradicts itself about audit roles.**
+   `skills/execute/SKILL.md:164` claims "audit-* roles cannot be stamped"; the actual
+   allowlist *includes* all audit-* roles (`hooks/ctl.py:2202-2209`) and
+   `skills/audit/SKILL.md:145-151` explicitly instructs stamping them. The real forgery
+   defense is the spawn-log cross-check at receipt time, not the stamp allowlist.
+
+### New holes found during analysis (must fix; both strengthen invariants)
+
+- **H1 — executor roles may write the plugin's own code.** `decide_write` allows any
+  out-of-task path for executor roles ("repo work artifact allowed",
+  `hooks/write_policy.py:292-293`) with **no containment to the project root**. In a
+  normal user repo the plugin lives under `~/.claude/plugins/...`; an executor (or the
+  orchestrator falling back to `execute-inline`) can edit `hooks.json`,
+  `write_policy.py`, or `ctl.py` there — the exact self-disable primitive the mission
+  forbids. Fix in §D6.
+
+- **H2 — Bash-level enforcement is heuristic in both directions.** Besides the false
+  positives above, `python3 -c "open(p,'w')"` and helper scripts that write internally
+  (`build_prompt_context.py --sidecar`) are invisible to the pre-filter. The doc and
+  denial messages must stop implying the Bash filter is a guarantee; the real
+  guarantees are receipts + spawn-log + ctl-internal `require_write_allowed`. We keep
+  the filter as defense-in-depth and make it precise, not load-bearing.
+
+---
+
+## 1. Problem → root cause → change (index)
+
+| # | Problem | Root cause (file:line) | Change |
+|---|---------|------------------------|--------|
+| P0-a | Policy denies skill-prescribed `/tmp`, `/dev/null`, PYTHONPATH steps | `skills/start/SKILL.md:93,266,506,510,514`; `write_policy.py:296-298` | D1 (stdin payloads), D2 (scratch dir), D4 (prose rewrite) |
+| P0-b | Prompt-string `>` tokens flagged as writes | `pre_tool_use.py:72-90` regex over raw string | D5 (quote-aware tokenizer) |
+| P0-c | "Non-deterministic" denials | global role file mutation + per-file allowlists (`pre_tool_use.py:222-244`, `write_policy.py:327-330`) | D3 (per-actor roles), D5 (self-explaining denials) |
+| P0-d | `rm active-segment-role` prescribed but denied | `skills/start/SKILL.md:715-718`, `skills/execute/SKILL.md:232-236` vs `_WRAPPER_REQUIRED` (`write_policy.py:101`) + rm pattern (`pre_tool_use.py:87`) | D3 (`ctl clear-role`) |
+| P0-e | verify-evidence after finish hard-errors | `ctl.py:2664` via `ctl.py:4854`; ordering in `skills/execute/SKILL.md:298,323` | D7-1 |
+| P0-f | Hook denials masquerade as Claude permission problems; no override possible by design | `pre_tool_use.py:368,412` bare `write-policy: <reason>` | D5 (labeled denials), D4 (one allowlistable surface) |
+| P1-a | Orchestrator inherits last-stamped subagent role; races under parallel auditors | single `active-segment-role`; role read per tool call (`pre_tool_use.py:226-228`); race admitted at `skills/audit/SKILL.md:153` | D3 |
+| P1-b | Auditors can't verify execution ACs (correct refusal, missing proof) | no captured-command-output artifact; `spec-completion-auditor` tools `[Read, Write]` | D6 (verification-evidence runner) |
+| P2-a | `files_expected` can't be a directory | exact-string membership `ctl.py:2527` | D7-2 |
+| P2-b | investigator: read-only agent told to write `/tmp/bug_report.json`; dossier-only guarantee unenforced; renderer drift | `skills/investigate/SKILL.md:32` vs `agents/investigator.md:4`; `read_policy.py:57` exempts non-audit roles; `render_report.py:118,149-160` | D7-3 |
+| P2-c | Enum/validator papercuts (`ci` domain, `backend` vs `backend-executor`, Reference-Code backticks) | `lib_validate.py:329-330,571-573,498-504` | D7-4 |
+| — | H1 plugin-dir self-edit hole | `write_policy.py:292-293` | D6-hardening |
+
+---
+
+## 2. Design
+
+### D1 — ctl wrappers accept payloads on stdin (`--from -`)
+
+**Change.** `write-classification`, `write-execution-graph`, `write-repair-log` (and the
+new commands below) accept `--from -` to read the JSON payload from stdin
+(`_read_json_input`, `ctl.py:280-284`, gains a `-` branch). Skill prose switches to:
+
+```bash
+"${DYNOS_CTL}" write-classification .dynos/task-{id} --from - <<'JSON'
+{ ...payload returned by the planner... }
+JSON
+```
+
+Heredocs contain no redirection operator, so the (fixed, D5) pre-filter sees no write
+destination; the actual file write happens inside ctl under `role=ctl` with the
+capability key — exactly as today.
+
+**Invariant preserved.** Identical schema validation, normalization, atomic write, and
+event emission as the `--from <file>` path (`ctl.py` write-* commands are unchanged
+except input source). No new write primitive exists: ctl could already write these
+files. The agent never gains a raw filesystem write.
+
+**UX before/after.** Before: agent writes `/tmp/classification-{id}.json` → denied →
+retries → user fights prompts. After: one approved ctl call.
+
+**Test.** `tests/test_ctl.py::test_write_classification_stdin` (payload via stdin ==
+payload via file, byte-identical artifact + receipt); negative: malformed stdin JSON
+exits non-zero, writes nothing.
+
+### D2 — In-boundary scratch dir `.dynos/task-{id}/_scratch/`
+
+**Change.** `decide_write` gains an early rule: `rel_posix.startswith("_scratch/")` →
+allow create/modify/delete for every *recognized actor role* (planning, executors,
+orchestrator (D3), repair-coordinator, audit-*). `_scratch/` is never consulted by any
+receipt, gate, or validator — that is asserted by a test, making it forge-irrelevant by
+construction. All skill prose that needs a temp file (large payloads where heredoc is
+awkward, sidecar staging) uses `_scratch/`. `/tmp`, `/dev/null` and plugin-dir paths
+become forbidden tokens in skill prose (contract test, §3). `/dev/null` specifically is
+added to the policy as an always-allowed sink (it is not persistence; denying it only
+creates noise).
+
+**Invariant preserved.** Control-plane files keep their exact-path rules — scratch is a
+disjoint namespace inside the task boundary. Nothing reads scratch as proof, so writing
+it can't certify anything. Audit-* roles writing scratch cannot touch
+`audit-reports/` rules (still `audit-*`-only) nor receipts (still receipt-writer-only).
+
+**UX.** Sanctioned temp space; no more "path escapes task boundary" for staging files.
+
+**Test.** Policy unit tests per role × scratch op; grep-test that no gate/validator/
+receipt reads from `_scratch/`.
+
+### D3 — Per-actor role resolution (replaces the single global role file)
+
+This is the structural fix for P0-c and P1-a.
+
+**Mechanism.**
+1. **Pin the orchestrator.** The existing `session-start` hook records the main
+   session's `session_id` (already present in hook payloads; cf.
+   `agent_spawn_log.py:130`) to `.dynos/orchestrator-session.json` (hook-owned, like
+   `spawn-log.jsonl` — agent writes denied by policy). SessionStart fires only for the
+   main session (matcher `startup|clear|compact`), so a subagent can never re-pin it.
+2. **New role `orchestrator`.** `pre_tool_use` resolves any tool call whose
+   `session_id` matches the pin to role `orchestrator`, *never* the role file.
+   `decide_write` for `orchestrator`: allow `_scratch/**`, `execution-log.md`,
+   `escalation.md`, `audit-context.md`, `raw-input.md`, `discovery-notes.md`,
+   `design-decisions.md` (the Q&A appends are orchestrator work in start Steps 1–2);
+   deny `spec.md`/`plan.md`/`audit-reports/`/`evidence/`/all control-plane. Repo-source
+   writes for inline fast-track execution are allowed **only** when
+   `manifest.stage == EXECUTION` and `manifest.fast_track == true` (deterministic state
+   set exclusively by ctl gates — capability follows the state machine, not
+   self-declaration).
+3. **Grants instead of a mutable global.** `stamp-role` becomes `grant-role`
+   (back-compat alias kept): it appends a pending grant
+   `{role, granted_at, ttl, consumed: false}` to `role-grants.json` (wrapper-required,
+   same allowlist as today, `ctl.py:2202-2236`). When `pre_tool_use` sees a session_id
+   that is neither the orchestrator pin nor already bound, it binds that session to the
+   oldest unconsumed grant (hook-subprocess direct I/O, same precedent as the
+   `audit-grep-quota.json` writer) and marks it consumed. Subsequent calls from that
+   session resolve the bound role — mid-task re-stamps can no longer mutate a running
+   subagent's role, and parallel auditors each consume their own grant.
+4. **`ctl clear-role`** replaces the prescribed (and denied) `rm` — it expires
+   unconsumed grants. Clearing only ever *reduces* privilege.
+
+**Verification step (phase 0, before building).** Empirically confirm subagent hook
+payloads carry a distinct `session_id` (instrumented log on a scratch task). If they do
+not, key on `transcript_path` (also harness-provided) instead. If *neither*
+distinguishes actors, fall back to a reduced design: keep the role file for subagents
+but exclude the orchestrator by D3-1/2 — that alone fixes P0-c and the worst of P1-a.
+
+**Self-elevation analysis.**
+- Roles still come only from the ctl allowlist; sessions never name their own role.
+- The orchestrator cannot consume a grant (its session is pinned first, at startup).
+- A subagent cannot re-pin the orchestrator file (hook-owned + SessionStart-only).
+- Residual risk: two *concurrently spawned* subagents could swap grants (bind order is
+  arrival order). Spawn batches are same-class today (executor batch / auditor batch),
+  write-scope classes are identical within a batch, and `receipt_audit_done`'s
+  spawn-log cross-check still detects any report not backed by a real spawn. Documented
+  as a known bound; mitigation (grant carries expected `subagent_type`, bind prefers a
+  type match using the spawn-log `pre` entry) is included in the implementation.
+
+**UX.** The orchestrator stops getting "stuck on planning," stops tripping read-policy
+after stamping audit roles (`pre_tool_use.py:420-451` no longer applies to it), and its
+log appends stop failing depending on stamp history.
+
+**Tests.** Orchestrator session denied `audit-reports/` write even after granting
+`audit-spec-completion` (the self-elevation regression test); unknown session with no
+pending grant → deny; grant of non-allowlisted role refused; parallel-grant binding;
+TTL expiry; `clear-role` cannot mint anything.
+
+### D4 — One command surface + consolidated per-skill entrypoints
+
+**Change.**
+1. **Single funnel.** Extend the existing `bin/dynos` CLI with `dynos ctl ...`
+   (delegating to `hooks/ctl.py`, PYTHONPATH handled inside — it already does this for
+   other subcommands). Every skill-prescribed command becomes
+   `"${DYNOS_CTL}" <subcommand> ...` where `DYNOS_CTL="${CLAUDE_PLUGIN_ROOT}/bin/dynos ctl"`.
+   This removes `PYTHONPATH=` prefixes and the broken repo-relative
+   `python3 hooks/ctl.py` form (which only works when cwd is the plugin repo itself)
+   from prose, and gives the permissions-ON user **one** stable prefix to allow:
+   `Bash(${CLAUDE_PLUGIN_ROOT}/bin/dynos *)` — documented in README/INTERNALS, never
+   auto-written into the user's settings.
+2. **Absorb bookkeeping into existing run-* commands** rather than one mega
+   "run-skill" (which would hide the human gates):
+   - `run-start-init` (new): mkdir, `raw-input.md` from stdin, initial `manifest.json`,
+     `execution-log.md`, registry/daemon registration — replaces start Step 0's six
+     hand-run actions (manifest creation moves from agent-write to ctl-write, which is
+     *stricter* than today).
+   - `planner-receipt` / `audit-receipt` / `run-execution-segment-done` each gain
+     `--record-tokens` behavior so the separate `lib_tokens.py record` calls disappear
+     from prose (the SubagentStop hook already covers spawn tokens; deterministic-step
+     records move inside the ctl step that performed the deterministic work).
+   - `inject-prompt` / `audit-inject-prompt` keep their current contract; prose keeps
+     them as discrete steps because their stdout *is* the spawn prompt.
+   - `run-execution-finish` internally runs verify-evidence (D7-1) so Step 5 becomes
+     read-only confirmation.
+   Net effect per skill: the orchestrator's Bash usage collapses to ~6–10 `dynos ctl`
+   calls + Agent spawns + `AskUserQuestion` gates.
+
+**Invariant preserved.** Human gates (`approve-stage` at SPEC_REVIEW / PLAN_REVIEW /
+TDD_REVIEW) remain separate, explicit, hash-checked commands — consolidation never
+crosses a gate. Receipts, sidecar proof-of-injection, and spawn-log cross-checks are
+*more* reliably written (deterministic code instead of prose discipline). No bypass
+flag exists anywhere in this design.
+
+**UX before/after.** Before: ~30 hand-run commands per skill, each a permission prompt,
+several denied by the plugin itself. After: approve one command prefix once (or click
+through a handful of uniform `dynos ctl` prompts) + answer the spec/plan gates.
+
+**Tests.** Golden-path integration test running start→execute→audit on a fixture repo
+with the hook active and `DYNOS_ROLE` unset, asserting zero `write_policy_denied`
+events for prescribed steps (this is the Definition-of-Done test).
+
+### D5 — Deterministic, self-explaining enforcement
+
+**Change.**
+1. **Quote-aware extraction.** Replace `_BASH_WRITE_PATTERNS` raw-string regexes with
+   `shlex`-based tokenization (`punctuation_chars=True`): redirection operators and
+   `tee/mv/cp/rm/...` argv positions are detected on *tokens outside quotes*. Quoted
+   prompt text, heredoc bodies, and `python -c` strings can no longer produce
+   destinations. (H2 note: this filter remains defense-in-depth; under-detection via
+   interpreter-internal writes is unchanged and is covered by the receipts/spawn-log
+   layer — stated explicitly in `docs/write-boundary-spec.md`.)
+2. **Denial message contract.** Every deny prints:
+   `write-policy[dynos-work guardrail — not a Claude Code permission; changing
+   permission settings will not affect this]: role=<role> path=<path> — <reason>.
+   Sanctioned path: <ctl command | _scratch/ | n/a>. See docs/write-boundary-spec.md.`
+   `WriteDecision` already carries `wrapper_command`; extend `allowed_globs_for_role`
+   reuse so the hint names what the current role *may* do.
+3. **H1 hardening.** New deny rule (all agent-sourced roles, including executors):
+   paths under `CLAUDE_PLUGIN_ROOT`, the hooks.json host dir, and `~/.claude/plugins/`
+   are denied unless the *project root being worked on* is the plugin repo itself
+   (developer mode, detected by `.claude-plugin/` at project root — and even then,
+   `hooks.json` + `hooks/write_policy.py` + `hooks/pre_tool_use.py` + `hooks/ctl.py`
+   require… nothing new: in developer mode they are ordinary repo files reviewed by the
+   human like any diff; outside developer mode they are absolutely denied). This closes
+   the "agent edits its own guardrails" hole for every installed-plugin user.
+
+**Invariant preserved.** Strictly tightens enforcement: fewer false positives, no new
+allows except `/dev/null` (a sink) and `_scratch/` (D2). Self-explaining text changes
+no decision outcomes.
+
+**Tests.** Table-driven extractor tests (quoted `>`, heredocs, `python -c`, real
+redirects, `rm` flags); message-format snapshot test; H1 tests (executor write to
+plugin dir denied; same path allowed in developer-mode fixture).
+
+### D6 — Verification-evidence runner (closes P1-b, strengthens anti-trust-me-bro)
+
+**Change.**
+1. `execution-graph.json` segments gain optional `verify_commands:
+   [{id, command, criteria_ids}]`, validated at `write-execution-graph` time and locked
+   by the existing plan-approval hash — i.e., **the human approves the verification
+   commands at the plan gate**, the same trust anchor as the code itself.
+2. New `dynos ctl run-verification-evidence .dynos/task-{id} [--segment seg]`:
+   executes each declared command (cwd = project root, no LLM-supplied arguments at run
+   time — the command string comes only from the approved, wrapper-written graph),
+   captures `{command, exit_code, stdout_tail(8KB), stderr_tail(8KB), duration_ms}`
+   into `evidence/verification/{seg-id}.json` written under `role=ctl`, and writes a
+   receipt embedding the artifact's sha256.
+3. `run-execution-finish` requires verification evidence for every segment that
+   declares `verify_commands` (alongside D7-1's evidence checks).
+4. `spec-completion-auditor` prose: for ACs mapped (via `criteria_ids`) to a
+   verification record, the auditor cites the captured exit code/output as evidence —
+   it still **never** accepts an executor's narrative claim; it now has machine-captured
+   proof to read. ACs with no verification record and no static evidence remain
+   BLOCKING, exactly as the AC9 incident correctly behaved.
+
+**Invariant preserved / strengthened.** Auditors still certify only verifiable
+evidence; the evidence is produced by deterministic code, hash-chained by a receipt,
+and the commands themselves are human-approved plan content. An executor cannot doctor
+the artifact (`evidence/verification/` will be ctl-owned in `decide_write`, unlike the
+executor-owned `evidence/*.md`). Forging would require forging a receipt — already
+rejected by the chain validator.
+
+**UX.** "ruff check src exits 0"-style ACs stop producing false BLOCKING findings and
+stop requiring a human to re-run commands manually.
+
+**Tests.** Runner captures pass/fail faithfully (fixture commands); executor-role write
+to `evidence/verification/` denied; finish blocks on missing verification; auditor
+contract test that a verification-backed AC is citable; receipt-hash mismatch detected
+by `validate-task-receipt-chain`.
+
+### D7 — Targeted fixes
+
+1. **Execute ordering.** Swap Steps: verify-evidence runs at the end of Step 3 (before
+   `run-execution-finish`); `run-execution-finish` calls the same verification
+   internally so the gate is one deterministic unit; `run-execution-verify-evidence`
+   gains `--allow-stages EXECUTION,TEST_EXECUTION` semantics by giving
+   `_compute_execution_batch_payload` an `expected_stages` parameter (callers preserve
+   today's behavior; only verify-evidence widens). Prose Step 5 becomes "re-run for
+   confirmation; it is now legal post-transition."
+   *Invariant:* stage machine unchanged; the gate gets stronger (finish can no longer
+   succeed without evidence).
+2. **files_expected directories/globs.** In `_verify_git_diff_covers_files`
+   (`ctl.py:2462-2527`): entry ending `/` → prefix match against covered paths; entry
+   containing `*?[` → `fnmatch` against covered paths; plain entries unchanged. Mirror
+   the same matcher in verify-evidence's existence check and in the cross-segment
+   overlap validator (`lib_validate.py` graph rule 4: a directory entry overlaps a file
+   entry it prefixes — overlap detection becomes *stricter*, not looser).
+   *Invariant:* membership proof still derived from `git diff` + untracked listing;
+   a glob that matches nothing in the diff still fails the segment.
+3. **Investigate skill.** Phase 2 rewritten: the investigator (unchanged tools
+   `[Read, Grep]`) *returns* the bug-report JSON as its final message; the orchestrator
+   pipes it to a new deterministic step `triage.py finalize --from -` which (a)
+   validates against `bug_report.schema.json`, (b) runs the citation check against the
+   dossier's `evidence_index`, (c) persists report + rendered markdown to
+   `.dynos/investigations/{id}/`. Dossier-only guarantee becomes enforced:
+   `read_policy` gains an `investigator` branch (granted via D3) allowing Read of the
+   dossier path only and denying Grep — the prose guarantee at
+   `skills/investigate/SKILL.md:8` becomes code. `render_report.py` falls back from
+   `dossier.bug_type` to `bug_report.bug_type`; the classifier taxonomy gains
+   `ci-failure` and `config/process` patterns (P2, isolated change in
+   `bug_classifier.py`).
+   *Invariant:* citation validation is unchanged and now unskippable (it sits inside
+   the only persistence path).
+4. **Validator papercuts.** All enum errors adopt one helper:
+   `"<field> invalid: 'ci' — valid: [backend, db, docs, infra, ml, refactor, security,
+   testing, ui, migration]; did you mean 'infra'?"` (difflib close-matches), applied to
+   `lib_validate.py:329-330` (domains), `571-573` (executors, with explicit
+   `'backend' → 'backend-executor'` suffix hint), `761-762` (repair executors), and
+   `stamp-role`/`grant-role` refusals. Reference-Code check (`lib_validate.py:498-504`):
+   only backtick tokens containing `/` are treated as paths; a `### Files to be
+   created` (or `to-be-created`) *section* exempts every path listed in it, in addition
+   to the current per-line marker. Decide separately whether `ci` joins
+   `VALID_DOMAINS` (recommendation: **no** — map to `infra` via the did-you-mean hint;
+   adding a domain fans out into router/audit-plan domain tables).
+   *Invariant:* validators reject the same payload set or a strict superset of hints;
+   nothing formerly invalid becomes valid except non-path backtick tokens that were
+   false positives.
+5. **Prose/agent conformance.** Fix `skills/execute/SKILL.md:164` (stamp-role claim);
+   remove both "deletion is permitted" passages (start:715, execute:232) in favor of
+   `dynos ctl clear-role`; repair-coordinator's `/tmp` + self-run-ctl instruction
+   (`agents/repair-coordinator.md:44`, it has neither Write nor Bash) becomes
+   "return the payload; the orchestrator persists via
+   `dynos ctl write-repair-log --from -`" — matching how `run-repair-log-build`
+   already works; `security-auditor.md` description stops claiming "Read-only" while
+   prescribing a Bash-heredoc report write (the write is sanctioned; the label is
+   wrong).
+
+---
+
+## 3. The drift-proofing contract test
+
+New `tests/test_skill_prose_policy_contract.py`:
+
+1. Extract every fenced `bash`/`text` command block from every `skills/*/SKILL.md` and
+   `agents/*.md`.
+2. Run each through the *production* destination extractor (D5's tokenizer — same
+   code, imported, not a copy) and feed every detected destination to `decide_write`
+   under the role context the doc prescribes at that point (role annotations carried in
+   an adjacent fixture map per skill step; the test fails if a new write appears with
+   no annotation).
+3. Assert: zero denials for prescribed steps.
+4. Forbidden-token scan over the same blocks: `/tmp/`, `2>/dev/null` (and any
+   `/dev/null` outside ctl-internal code), `PYTHONPATH=`, `rm` targeting
+   `active-segment-role` or any `_CONTROL_PLANE_EXACT` name, and bare
+   `python3 hooks/` invocations (must use `${DYNOS_CTL}`).
+5. Agent-conformance check: any `agents/*.md` whose prose instructs a file write must
+   declare a tool capable of it (Write, Edit, or Bash), and the target must be allowed
+   for that agent's runtime role.
+
+This test is what keeps prose↔policy from drifting again; it would have caught every
+P0 in this document.
+
+## 4. Invariants — proof obligations (Definition of Done §2)
+
+Each shipped with a test (existing tests noted where they already cover it):
+
+| Invariant | Why it still holds | Test |
+|---|---|---|
+| No stage advance without proof | All transitions still flow through `transition_task` + receipts; D4 moves *more* steps into ctl; D6/D7-1 add evidence preconditions to finish | existing `test_ctl*`, new finish-requires-verification |
+| No forged receipts/reports | receipt-writer capability key + spawn-log cross-check untouched; `_scratch/` proven receipt-irrelevant; verification evidence is ctl-owned + hash-receipted | `test_write_policy_capability_key.py`, new D6 tests |
+| No self-elevation | grants from ctl allowlist only; orchestrator session pinned at SessionStart; role file no longer orchestrator-readable-as-self; H1 closes plugin-dir edits; `hooks.json`/policy files unwritable outside developer mode | new D3/D5 suites incl. the orchestrator-grants-audit-role regression |
+| Human gates at spec/plan | `approve-stage` untouched, never consolidated into a run-* command | existing `test_ctl_approve_stage.py` |
+| Auditors never certify unverified claims | spec-completion auditor still blocks unevidenced ACs; D6 only adds machine-captured proof for it to read | new auditor-contract test |
+| Out-of-scope writes rejected | role allowlists narrowed (orchestrator role is a subset of today's `execute-inline` fallback) | new role-matrix tests |
+
+## 5. Implementation phases
+
+- **Phase 0 (probe, ~0.5d):** instrument hook payloads on a scratch task; confirm
+  per-actor `session_id`/`transcript_path` distinctness → finalize D3 keying.
+- **Phase 1 (P0 unblock):** D5 tokenizer + denial messages, D1 stdin payloads, D2
+  scratch dir, D7-1 ordering fix, D7-5 prose fixes, contract test (§3). After this
+  phase a permissions-ON run already completes without plugin-self-denials.
+- **Phase 2 (structure):** D3 per-actor roles + `clear-role`; D4 `dynos ctl` funnel +
+  `run-start-init` + bookkeeping absorption; H1 hardening (D5-3).
+- **Phase 3 (proof):** D6 verification-evidence runner + auditor wiring.
+- **Phase 4 (P2 papercuts):** D7-2 globs, D7-3 investigate, D7-4 validator messages.
+
+Each phase lands with its tests; `tests/test_skill_prose_regressions.py` and
+`test_skill_stage_references.py` are extended rather than replaced.
+
+## 6. UX summary (before → after)
+
+- Before: orchestrator hand-runs ~30 commands per skill; ~a dozen are denied by the
+  plugin's own hook with messages indistinguishable from Claude permission failures;
+  user toggles permissions to no effect; pipeline dead-ends at execute Step 5 and at
+  AC-verification audit findings.
+- After: user allowlists (or click-approves) one `dynos ctl` prefix; the session pauses
+  only at discovery questions, spec approval, plan approval, TDD approval; every denial
+  that *does* appear names itself as a guardrail, names the role and path, and names
+  the sanctioned alternative — and never fires on an action the skills prescribe.

--- a/docs/write-boundary-spec.md
+++ b/docs/write-boundary-spec.md
@@ -644,3 +644,77 @@ This work is complete when:
 20. Add prompt regression scans.
 21. Add dashboard/reporting for denied writes.
 22. Repeat until no direct LLM control-plane writes remain.
+
+---
+
+## Addendum: Per-Actor Resolution & Permissions-ON Operation (v7.4.1)
+
+Implemented in v7.4.1 per `docs/permissions-on-design.md`. This addendum is normative
+for the additions; the sections above remain accurate for the original
+artifact classes.
+
+### Actor identity (D3)
+
+- The MAIN session is pinned at SessionStart: `.dynos/orchestrator-session.json`
+  (hook-owned; every agent write to it is denied). Tool calls matching the
+  pinned `session_id` resolve to the `orchestrator` role and never read role
+  files — stamping a subagent role cannot mutate the orchestrator's rights.
+- Subagent sessions consume single-use grants from
+  `.dynos/task-*/role-grants.json` (wrapper-required: `ctl grant-role` /
+  `ctl stamp-role`, allowlist-enforced). The first tool call of an unknown
+  session binds it (`role-bindings.json`, hook-owned); the binding is
+  immutable for the session's lifetime. `ctl clear-role` expires unconsumed
+  grants and is the only sanctioned cleanup (privilege-reducing).
+- Sessions without a pin fall back to the legacy `active-segment-role`
+  chain — no regression for pre-pin sessions.
+- Degraded mode: if the harness ever fails to give subagents distinct
+  session ids, their calls resolve as `orchestrator` and fail CLOSED with a
+  denial that names the condition ("degraded actor resolution").
+
+### Orchestrator role surface
+
+Allowed: `_scratch/**`, `execution-log.md`, `escalation.md`,
+`audit-context.md`, `raw-input.md`, `discovery-notes.md`,
+`design-decisions.md`; repo files ONLY while `manifest.stage == EXECUTION`
+with `fast_track == true` (inline execution — capability follows the ctl
+state machine). Everything else (spec/plan/audit-reports/evidence/
+control-plane) is denied with a self-explaining message.
+
+### New namespaces and sinks
+
+- `.dynos/task-*/_scratch/**` — sanctioned temp space for all recognized
+  actor roles. Proof-irrelevant by construction: no gate, receipt, or
+  validator reads it (CI-asserted by tests/test_scratch_namespace.py).
+- `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/tty` — always-allowed
+  sinks (not persistence).
+- `evidence/verification/**` — ctl-captured verification records (D6);
+  agent roles, including executors, are denied. Written only by
+  `ctl run-verification-evidence`, hash-bound by a receipt, consumed by
+  the spec-completion auditor as machine evidence for execution-based
+  acceptance criteria.
+
+### Self-modification guard (H1)
+
+Agent roles are denied writes under the installed plugin root,
+`~/.claude/plugins/`, `~/.claude/settings*.json`, and `~/.dynos/` — the
+"agent edits its own guardrails" primitive. Developer mode (the project IS
+the plugin source checkout) exempts the plugin-root check only.
+
+### Honest enforcement statement
+
+The Bash pre-filter (now shlex-based and quote-aware) is defense-in-depth,
+NOT the trust anchor: interpreter-internal writes (`python3 -c
+"open(p,'w')"`) are invisible to any command-text parser. The unforgeable
+guarantees are: capability-keyed `require_write_allowed` inside ctl,
+receipts + the task receipt chain, and the hook-owned `spawn-log.jsonl`
+cross-check at audit-receipt time.
+
+### Permissions-ON operation
+
+All skill-prescribed deterministic steps run through one funnel:
+`<plugin-root>/bin/dynos` (`dynos ctl ...`, `dynos hook ...`). JSON payloads
+travel over stdin (`--from -` + heredoc) — nothing is staged at /tmp or any
+raw path. A permissions-ON user can allow the single `bin/dynos` prefix and
+then interacts only with the human gates (discovery questions, SPEC_REVIEW,
+PLAN_REVIEW, TDD_REVIEW). `tests/test_skill_prose_policy_contract.py` keeps
+prose and policy from drifting apart again.

--- a/hooks.json
+++ b/hooks.json
@@ -56,7 +56,7 @@
     ],
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/hooks/actor_identity.py
+++ b/hooks/actor_identity.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Per-actor identity resolution for write-policy roles (D3).
+
+Replaces the single mutable ``active-segment-role`` file as the way the
+PreToolUse hook decides *who* is making a tool call:
+
+- The MAIN session is pinned at SessionStart: the hook payload's
+  ``session_id`` is recorded to ``.dynos/orchestrator-session.json``
+  (hook-owned — ``write_policy.decide_write`` denies every agent write to
+  it). Tool calls matching the pin resolve to the ``orchestrator`` role and
+  NEVER read role files, so stamping a role for a subagent can no longer
+  mutate the orchestrator's own write rights mid-flow (P0-c/P1-a in
+  docs/permissions-on-design.md).
+
+- SUBAGENT sessions (any other ``session_id``) consume single-use role
+  GRANTS from ``role-grants.json`` (task-scoped, wrapper-required — only
+  ``ctl.py grant-role``/``stamp-role`` may append). The first tool call from
+  an unknown session binds it to the oldest pending grant; the binding is
+  recorded in ``role-bindings.json`` (hook-owned) and is immutable for the
+  session's lifetime — a mid-task re-stamp cannot change a running
+  subagent's role, and parallel auditors each consume their own grant.
+
+Self-elevation analysis:
+- roles enter the ledger only through the ctl allowlist; a session never
+  names its own role,
+- the orchestrator cannot consume a grant (its session is pinned first),
+- no agent role can write the pin, the ledger, or the bindings file
+  (policy-denied; the hook subprocess writes them via direct file I/O, the
+  same precedent as spawn-log.jsonl and audit-grep-quota.json).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+PIN_FILENAME = "orchestrator-session.json"
+GRANTS_FILENAME = "role-grants.json"
+BINDINGS_FILENAME = "role-bindings.json"
+
+# A grant not consumed within this window is dead — it cannot be picked up
+# by a session that appears hours later (e.g. a stale ledger after a crash).
+GRANT_TTL_SECONDS = 7200
+
+
+def pin_path(project_root: Path) -> Path:
+    return project_root / ".dynos" / PIN_FILENAME
+
+
+def grants_path(task_dir: Path) -> Path:
+    return task_dir / GRANTS_FILENAME
+
+
+def bindings_path(task_dir: Path) -> Path:
+    return task_dir / BINDINGS_FILENAME
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator pin
+# ---------------------------------------------------------------------------
+
+def pin_orchestrator(project_root: Path, payload: dict) -> dict | None:
+    """Record the main session's identity. Called from the SessionStart hook.
+
+    SessionStart fires only for the main session, so a subagent can never
+    re-pin this file through the harness; agent tool-call writes to it are
+    denied by write_policy.
+    """
+    session_id = str(payload.get("session_id") or "").strip()
+    if not session_id:
+        return None
+    pin = {
+        "session_id": session_id,
+        "transcript_path": str(payload.get("transcript_path") or ""),
+        "source": str(payload.get("source") or ""),
+        "pinned_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    _atomic_write_json(pin_path(project_root), pin)
+    return pin
+
+
+def read_pin(project_root: Path) -> dict | None:
+    data = _load_json(pin_path(project_root))
+    if isinstance(data, dict) and data.get("session_id"):
+        return data
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Grant ledger (ctl-written via wrapper; hook consumes)
+# ---------------------------------------------------------------------------
+
+def _empty_ledger() -> dict:
+    return {"grants": []}
+
+
+def load_grants(task_dir: Path) -> dict:
+    data = _load_json(grants_path(task_dir))
+    if isinstance(data, dict) and isinstance(data.get("grants"), list):
+        return data
+    return _empty_ledger()
+
+
+def append_grant(task_dir: Path, role: str, *, write_json_fn=None) -> dict:
+    """Append a pending grant. Role validity is the CALLER's responsibility
+    (ctl validates against _STAMP_ROLE_ALLOWLIST before calling).
+
+    write_json_fn: injection point for ctl's policy-checked writer
+    (write_ctl_json); defaults to the module's direct atomic writer for the
+    hook-side expiry path.
+    """
+    ledger = load_grants(task_dir)
+    now = time.time()
+    grant = {
+        "role": role,
+        "granted_at": now,
+        "expires_at": now + GRANT_TTL_SECONDS,
+        "consumed_by": None,
+        "consumed_at": None,
+    }
+    ledger["grants"].append(grant)
+    writer = write_json_fn or (lambda p, d: _atomic_write_json(p, d))
+    writer(grants_path(task_dir), ledger)
+    return grant
+
+
+def expire_grants(task_dir: Path, *, write_json_fn=None) -> int:
+    """Mark every unconsumed grant expired. Clearing only reduces privilege."""
+    ledger = load_grants(task_dir)
+    now = time.time()
+    expired = 0
+    for grant in ledger["grants"]:
+        if grant.get("consumed_by") is None and grant.get("expires_at", 0) > now:
+            grant["expires_at"] = now
+            expired += 1
+    writer = write_json_fn or (lambda p, d: _atomic_write_json(p, d))
+    writer(grants_path(task_dir), ledger)
+    return expired
+
+
+def pending_grants(task_dir: Path) -> list[dict]:
+    now = time.time()
+    return [
+        g for g in load_grants(task_dir)["grants"]
+        if g.get("consumed_by") is None and g.get("expires_at", 0) >= now
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Session -> role bindings (hook-owned)
+# ---------------------------------------------------------------------------
+
+def lookup_binding(task_dir: Path, session_id: str) -> str | None:
+    data = _load_json(bindings_path(task_dir))
+    if not isinstance(data, dict):
+        return None
+    entry = (data.get("bindings") or {}).get(session_id)
+    if isinstance(entry, dict) and isinstance(entry.get("role"), str):
+        return entry["role"]
+    return None
+
+
+def consume_grant(task_dir: Path, session_id: str) -> str | None:
+    """Bind an unknown session to the oldest pending grant, atomically.
+
+    Returns the bound role, or None when no pending grant exists. The flock
+    serializes parallel subagents' first tool calls so two sessions cannot
+    consume the same grant.
+    """
+    if not session_id:
+        return None
+    lock_file = task_dir / ".role-grants.lock"
+    try:
+        task_dir.mkdir(parents=True, exist_ok=True)
+        with open(lock_file, "w", encoding="utf-8") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            try:
+                existing = lookup_binding(task_dir, session_id)
+                if existing:
+                    return existing
+                ledger = load_grants(task_dir)
+                now = time.time()
+                chosen: dict | None = None
+                for grant in sorted(
+                    ledger["grants"], key=lambda g: g.get("granted_at", 0)
+                ):
+                    if grant.get("consumed_by") is None and grant.get("expires_at", 0) >= now:
+                        chosen = grant
+                        break
+                if chosen is None:
+                    return None
+                chosen["consumed_by"] = session_id
+                chosen["consumed_at"] = now
+                _atomic_write_json(grants_path(task_dir), ledger)
+
+                bindings = _load_json(bindings_path(task_dir))
+                if not isinstance(bindings, dict) or not isinstance(
+                    bindings.get("bindings"), dict
+                ):
+                    bindings = {"bindings": {}}
+                bindings["bindings"][session_id] = {
+                    "role": chosen["role"],
+                    "bound_at": now,
+                }
+                _atomic_write_json(bindings_path(task_dir), bindings)
+                return str(chosen["role"])
+            finally:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI (used by the session-start bash hook)
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[1] == "pin":
+        root = Path(argv[argv.index("--root") + 1]) if "--root" in argv else Path.cwd()
+        try:
+            payload = json.loads(sys.stdin.read() or "{}")
+        except json.JSONDecodeError:
+            return 0  # malformed payload: skip pinning, legacy behavior applies
+        if not isinstance(payload, dict):
+            return 0
+        pin_orchestrator(root.resolve(), payload)
+        return 0
+    print("actor_identity: unknown command", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -46,6 +46,7 @@ from lib_receipts import (
     receipt_spawn_budget_resumed,
     receipt_spec_validated,
     receipt_executor_routing,
+    write_receipt,
 )
 from lib_validate import apply_fast_track, check_segment_ownership, require_nonblank, validate_task_artifacts
 from write_policy import WriteAttempt, _get_capability_key, require_write_allowed
@@ -278,7 +279,22 @@ def _write_ctl_json(task_dir: Path, path: Path, payload: dict) -> None:
 
 
 def _read_json_input(path: str) -> dict:
-    payload = load_json(Path(path).resolve())
+    """Load a JSON-object payload from a file path, or from stdin when '-'.
+
+    The stdin form (`--from -`) exists so skills can pipe an LLM-returned
+    payload straight into the ctl wrapper via a heredoc instead of staging it
+    at a raw filesystem path the write policy would have to sanction
+    (D1 in docs/permissions-on-design.md). Validation, normalization, and the
+    atomic policy-checked write downstream are identical for both forms.
+    """
+    if path == "-":
+        raw = sys.stdin.read()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"stdin payload is not valid JSON: {exc}") from exc
+    else:
+        payload = load_json(Path(path).resolve())
     if not isinstance(payload, dict):
         raise ValueError("input payload must be a JSON object")
     return payload
@@ -349,6 +365,35 @@ def _normalize_execution_graph_payload(task_dir: Path, payload: dict) -> dict:
             reason = raw.get("no_op_reason")
             if isinstance(reason, str) and reason.strip():
                 normalized["no_op_reason"] = reason
+        # verify_commands (D6): deterministic verification commands declared
+        # at planning time and locked by the plan-approval gate. Executed by
+        # `ctl run-verification-evidence`, never by prompt logic.
+        verify_commands: list[dict] = []
+        seen_vc_ids: set[str] = set()
+        for entry in raw.get("verify_commands", []) or []:
+            if not isinstance(entry, dict):
+                raise ValueError("verify_commands entries must be objects")
+            vc_id = str(entry.get("id", "")).strip()
+            command = str(entry.get("command", "")).strip()
+            if not vc_id or not command:
+                raise ValueError(
+                    "verify_commands entries require non-empty 'id' and 'command'"
+                )
+            if vc_id in seen_vc_ids:
+                raise ValueError(f"duplicate verify_commands id: {vc_id}")
+            seen_vc_ids.add(vc_id)
+            vc: dict = {"id": vc_id, "command": command}
+            vc_criteria: list[int] = []
+            for crit in entry.get("criteria_ids", []) or []:
+                try:
+                    vc_criteria.append(int(crit))
+                except (TypeError, ValueError):
+                    continue
+            if vc_criteria:
+                vc["criteria_ids"] = vc_criteria
+            verify_commands.append(vc)
+        if verify_commands:
+            normalized["verify_commands"] = verify_commands
         normalized_segments.append(normalized)
     return {"task_id": task_dir.name, "segments": normalized_segments}
 
@@ -2202,19 +2247,168 @@ def cmd_write_classification(args: argparse.Namespace) -> int:
 _STAMP_ROLE_ALLOWLIST: frozenset[str] = frozenset({
     "backend-executor", "ui-executor", "testing-executor", "integration-executor",
     "ml-executor", "db-executor", "refactor-executor", "docs-executor",
-    "planning", "execute-inline", "repair-coordinator",
+    "planning", "execute-inline", "repair-coordinator", "investigator",
     "audit-spec-completion", "audit-security", "audit-code-quality",
     "audit-performance", "audit-dead-code", "audit-db-schema", "audit-ui",
     "audit-claude-md",
 })
 
 
+def cmd_run_start_init(args: argparse.Namespace) -> int:
+    """Initialize a new task deterministically (D4).
+
+    Replaces start-skill Step 0's six hand-run actions: .dynos creation,
+    silent registration + daemon ensure, task-id generation, raw-input.md,
+    the initial manifest.json, and execution-log.md. The manifest moves
+    from agent-write to ctl-write — strictly tighter than before.
+
+    The task description arrives via --description, or stdin when
+    `--description -` (heredoc-friendly for long inputs).
+    """
+    import time as _time
+
+    root = Path(args.root or ".").resolve()
+    description = args.description or ""
+    if description == "-":
+        description = sys.stdin.read()
+    description = description.strip()
+    if not description:
+        print("run-start-init: a non-empty task description is required", file=sys.stderr)
+        return 1
+
+    dynos_dir = root / ".dynos"
+    dynos_dir.mkdir(parents=True, exist_ok=True)
+
+    # Best-effort registration + daemon (idempotent, silent — failure here
+    # must never block task creation).
+    hooks_dir = Path(__file__).resolve().parent
+    import subprocess as _subprocess
+    for helper_cmd in (
+        [sys.executable, str(hooks_dir / "registry.py"), "register", str(root)],
+        [sys.executable, str(hooks_dir / "daemon.py"), "ensure", "--root", str(root)],
+    ):
+        try:
+            _subprocess.run(helper_cmd, capture_output=True, timeout=30, check=False)
+        except Exception:
+            pass
+
+    today = _time.strftime("%Y%m%d", _time.gmtime())
+    seq = 1
+    for existing in sorted(dynos_dir.glob(f"task-{today}-*")):
+        suffix = existing.name.rsplit("-", 1)[-1]
+        if suffix.isdigit():
+            seq = max(seq, int(suffix) + 1)
+    task_id = f"task-{today}-{seq:03d}"
+    task_dir = dynos_dir / task_id
+    task_dir.mkdir()
+
+    input_type = args.input_type or "text"
+    manifest = {
+        "task_id": task_id,
+        "created_at": now_iso(),
+        "title": description[:80],
+        "raw_input": description,
+        "input_type": input_type,
+        "stage": "FOUNDRY_INITIALIZED",
+        "classification": None,
+        "retry_counts": {},
+        "blocked_reason": None,
+        "completed_at": None,
+    }
+    _write_ctl_json(task_dir, task_dir / "manifest.json", manifest)
+
+    for filename, content in (
+        ("raw-input.md", description + "\n"),
+        ("execution-log.md", f"{now_iso()} [INIT] {task_id} created\n"),
+    ):
+        target = task_dir / filename
+        require_write_allowed(
+            WriteAttempt(
+                role=_WRITE_ROLE,
+                task_dir=task_dir,
+                path=target,
+                operation="create",
+                source=_WRITE_ROLE,
+            ),
+            capability_key=_get_capability_key(_WRITE_ROLE),
+        )
+        target.write_text(content, encoding="utf-8")
+
+    print(json.dumps({
+        "status": "task_initialized",
+        "task_id": task_id,
+        "task_dir": str(task_dir),
+        "stage": "FOUNDRY_INITIALIZED",
+        "input_type": input_type,
+    }, indent=2))
+    return 0
+
+
+def cmd_tdd_receipt(args: argparse.Namespace) -> int:
+    """Write the TDD receipt deterministically (replaces the inline-python
+    snippet the start skill used to prescribe)."""
+    from lib_receipts import receipt_tdd_tests
+
+    task_dir = Path(args.task_dir).resolve()
+    evidence_path = task_dir / "evidence" / "tdd-tests.md"
+    if not evidence_path.is_file():
+        print(f"tdd-receipt: evidence file missing: {evidence_path}", file=sys.stderr)
+        return 1
+    test_files = [p for p in (args.test_file or []) if p.strip()]
+    if not test_files:
+        print("tdd-receipt: at least one --test-file is required", file=sys.stderr)
+        return 1
+    try:
+        receipt_tdd_tests(
+            task_dir=task_dir,
+            test_file_paths=test_files,
+            tests_evidence_sha256=hash_file(evidence_path),
+            tokens_used=int(args.tokens_used or 0),
+            model_used=args.model or "unknown",
+        )
+    except Exception as exc:
+        print(f"tdd-receipt: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"status": "tdd_receipt_written", "task_dir": str(task_dir)}, indent=2))
+    return 0
+
+
+def _validated_grant_role(command: str, raw_role: str | None) -> str | None:
+    """Shared allowlist validation for stamp-role / grant-role."""
+    role = (raw_role or "").strip()
+    if not role:
+        print(f"{command}: --role is required and must be non-empty", file=sys.stderr)
+        return None
+    if role not in _STAMP_ROLE_ALLOWLIST:
+        print(
+            f"{command}: refused — role {role!r} is not in the role "
+            f"allowlist; permitted values: {sorted(_STAMP_ROLE_ALLOWLIST)}",
+            file=sys.stderr,
+        )
+        return None
+    return role
+
+
+def _append_role_grant(task_dir: Path, role: str) -> dict:
+    """Append a pending grant to the per-actor ledger (D3) via the
+    policy-checked ctl writer."""
+    import actor_identity
+
+    def _ctl_writer(path: Path, data: object) -> None:
+        _write_ctl_json(task_dir, path, data)
+
+    return actor_identity.append_grant(task_dir, role, write_json_fn=_ctl_writer)
+
+
 def cmd_stamp_role(args: argparse.Namespace) -> int:
-    """Write the executor role to active-segment-role under role=ctl.
+    """Write the executor role to active-segment-role under role=ctl,
+    AND append a matching grant to the per-actor ledger (D3).
 
     Replaces the legacy `printf '%s' "{role}" > active-segment-role` pattern.
-    Validates the role string against the allowlist. Forgery defense for
-    audit-* claims is enforced downstream at receipt_audit_done, which
+    Validates the role string against the allowlist. The legacy role file is
+    kept for sessions without an orchestrator pin (pre-D3 fallback); pinned
+    sessions resolve subagent roles from the grant ledger. Forgery defense
+    for audit-* claims is enforced downstream at receipt_audit_done, which
     cross-checks against spawn-log.jsonl — see task-20260430-005.
     """
     task_dir = Path(args.task_dir).resolve()
@@ -2222,17 +2416,8 @@ def cmd_stamp_role(args: argparse.Namespace) -> int:
         print(f"stamp-role: task_dir does not exist: {task_dir}", file=sys.stderr)
         return 1
 
-    role = (args.role or "").strip()
-    if not role:
-        print("stamp-role: --role is required and must be non-empty", file=sys.stderr)
-        return 1
-
-    if role not in _STAMP_ROLE_ALLOWLIST:
-        print(
-            f"stamp-role: refused — role {role!r} is not in the role "
-            f"allowlist; permitted values: {sorted(_STAMP_ROLE_ALLOWLIST)}",
-            file=sys.stderr,
-        )
+    role = _validated_grant_role("stamp-role", args.role)
+    if role is None:
         return 1
 
     role_file = task_dir / "active-segment-role"
@@ -2242,7 +2427,91 @@ def cmd_stamp_role(args: argparse.Namespace) -> int:
         print(f"stamp-role: failed to write {role_file}: {exc}", file=sys.stderr)
         return 1
 
-    print(json.dumps({"status": "role_stamped", "path": str(role_file), "role": role}, indent=2))
+    try:
+        _append_role_grant(task_dir, role)
+    except Exception as exc:
+        print(f"stamp-role: failed to append role grant: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "status": "role_stamped",
+        "path": str(role_file),
+        "role": role,
+        "grant_appended": True,
+    }, indent=2))
+    return 0
+
+
+def cmd_grant_role(args: argparse.Namespace) -> int:
+    """Append a single-use role grant for the NEXT subagent spawn (D3).
+
+    The grant is consumed by the first tool call of the first unbound
+    session that appears; the binding is immutable for that session's
+    lifetime. Grants expire unconsumed after the TTL. Unlike stamp-role this
+    does not touch the legacy active-segment-role file.
+    """
+    task_dir = Path(args.task_dir).resolve()
+    if not task_dir.is_dir():
+        print(f"grant-role: task_dir does not exist: {task_dir}", file=sys.stderr)
+        return 1
+
+    role = _validated_grant_role("grant-role", args.role)
+    if role is None:
+        return 1
+
+    try:
+        grant = _append_role_grant(task_dir, role)
+    except Exception as exc:
+        print(f"grant-role: failed to append role grant: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "status": "role_granted",
+        "role": role,
+        "expires_at": grant.get("expires_at"),
+    }, indent=2))
+    return 0
+
+
+def cmd_clear_role(args: argparse.Namespace) -> int:
+    """Expire all unconsumed grants and remove the legacy role file.
+
+    This is the sanctioned replacement for the (policy-denied)
+    `rm active-segment-role` step the skills used to prescribe. Clearing
+    only ever REDUCES privilege: existing session bindings are untouched
+    (a running subagent keeps its role), no new role can be minted here.
+    """
+    task_dir = Path(args.task_dir).resolve()
+    if not task_dir.is_dir():
+        print(f"clear-role: task_dir does not exist: {task_dir}", file=sys.stderr)
+        return 1
+
+    import actor_identity
+
+    def _ctl_writer(path: Path, data: object) -> None:
+        _write_ctl_json(task_dir, path, data)
+
+    try:
+        expired = actor_identity.expire_grants(task_dir, write_json_fn=_ctl_writer)
+    except Exception as exc:
+        print(f"clear-role: failed to expire grants: {exc}", file=sys.stderr)
+        return 1
+
+    role_file = task_dir / "active-segment-role"
+    removed = False
+    if role_file.is_file():
+        try:
+            role_file.unlink()
+            removed = True
+        except OSError as exc:
+            print(f"clear-role: failed to remove {role_file}: {exc}", file=sys.stderr)
+            return 1
+
+    print(json.dumps({
+        "status": "role_cleared",
+        "grants_expired": expired,
+        "legacy_role_file_removed": removed,
+    }, indent=2))
     return 0
 
 
@@ -2524,7 +2793,26 @@ def _verify_git_diff_covers_files(
         if stripped:
             covered.add(stripped)
 
-    return [f for f in files_expected if f not in covered]
+    return [f for f in files_expected if not _entry_covered(f, covered)]
+
+
+def _entry_covered(entry: str, covered: set[str]) -> bool:
+    """Match a files_expected entry against covered diff paths (D7-2).
+
+    - trailing '/'  -> directory prefix: any covered path under it counts
+    - glob chars    -> path-aware glob against every covered path
+    - plain entry   -> exact membership (original behavior)
+
+    The proof source is unchanged (git diff + untracked listing); a
+    directory or glob entry that matches NOTHING in the diff still fails.
+    """
+    if entry in covered:
+        return True
+    if entry.endswith("/") or any(ch in entry for ch in "*?["):
+        from lib_validate import files_expected_entry_matches
+
+        return any(files_expected_entry_matches(entry, path) for path in covered)
+    return False
 
 
 def _segment_runtime_state(
@@ -2658,11 +2946,16 @@ def _segment_runtime_state(
     }
 
 
-def _compute_execution_batch_payload(task_dir: Path) -> dict:
+def _compute_execution_batch_payload(
+    task_dir: Path, expected_stages: frozenset[str] = frozenset({"EXECUTION"})
+) -> dict:
     manifest = _load_manifest(task_dir)
     stage = manifest.get("stage")
-    if stage != "EXECUTION":
-        raise ValueError(f"unexpected stage for execution batch planning: {stage}")
+    if stage not in expected_stages:
+        raise ValueError(
+            f"unexpected stage for execution batch planning: {stage} "
+            f"(expected one of: {', '.join(sorted(expected_stages))})"
+        )
 
     root = _root_for_task_dir(task_dir)
     graph_segments = _load_graph_segments(task_dir)
@@ -4792,6 +5085,102 @@ def cmd_run_rules_check(args: argparse.Namespace) -> int:
         return 1
 
 
+def _verify_execution_evidence(task_dir: Path, cached_ids: set[str]) -> tuple[list[str], list[str]]:
+    """Shared evidence verification: returns (errors, verified) line lists.
+
+    Checks every non-cached segment has a non-empty evidence file and that
+    every files_expected entry exists on disk. Used by both
+    run-execution-verify-evidence and run-execution-finish so the
+    EXECUTION -> TEST_EXECUTION gate cannot pass without evidence
+    (D7-1 in docs/permissions-on-design.md).
+    """
+    root = _root_for_task_dir(task_dir)
+    graph_path = task_dir / "execution-graph.json"
+    if not graph_path.exists():
+        return ["execution-graph.json not found"], []
+
+    graph = load_json(graph_path)
+    segments = graph.get("segments", []) if isinstance(graph, dict) else []
+    if not isinstance(segments, list):
+        segments = []
+
+    errors: list[str] = []
+    verified: list[str] = []
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        seg_id = str(seg.get("id", "") or "")
+        if not seg_id:
+            continue
+        if seg_id in cached_ids:
+            verified.append(f"{seg_id}: cached (evidence reused)")
+            continue
+
+        evidence_path = task_dir / "evidence" / f"{seg_id}.md"
+        if not evidence_path.exists():
+            errors.append(f"{seg_id}: evidence file missing at {evidence_path}")
+            continue
+        content = evidence_path.read_text(errors="ignore").strip()
+        if not content:
+            errors.append(f"{seg_id}: evidence file is empty at {evidence_path}")
+            continue
+
+        for expected_file in (seg.get("files_expected") or []):
+            if not isinstance(expected_file, str) or not expected_file.strip():
+                continue
+            entry = expected_file.strip()
+            # D7-2: directory entries ("dir/") must exist as directories;
+            # glob entries must match at least one path; plain entries must
+            # exist as before.
+            if entry.endswith("/"):
+                if not (root / entry).is_dir():
+                    errors.append(f"{seg_id}: files_expected directory missing on disk: {expected_file}")
+            elif any(ch in entry for ch in "*?["):
+                try:
+                    matched = next(iter(root.glob(entry)), None)
+                except (ValueError, NotImplementedError):
+                    matched = None
+                if matched is None:
+                    errors.append(f"{seg_id}: files_expected glob matched nothing on disk: {expected_file}")
+            elif not (root / entry).exists():
+                errors.append(f"{seg_id}: files_expected entry missing on disk: {expected_file}")
+
+        # D6: segments that declare verify_commands must have a passing
+        # machine-captured verification record before execution can finish.
+        declared = seg.get("verify_commands") or []
+        if declared:
+            record_path = task_dir / "evidence" / "verification" / f"{seg_id}.json"
+            if not record_path.exists():
+                errors.append(
+                    f"{seg_id}: verification evidence missing — run "
+                    f"`ctl.py run-verification-evidence` (expected {record_path})"
+                )
+            else:
+                record = load_json(record_path)
+                results = record.get("results", []) if isinstance(record, dict) else []
+                recorded = {
+                    str(r.get("id")): r for r in results if isinstance(r, dict)
+                }
+                for vc in declared:
+                    vc_id = str(vc.get("id"))
+                    entry = recorded.get(vc_id)
+                    if entry is None:
+                        errors.append(
+                            f"{seg_id}: verification record missing command {vc_id!r} — re-run run-verification-evidence"
+                        )
+                    elif str(entry.get("command")) != str(vc.get("command")):
+                        errors.append(
+                            f"{seg_id}: verification record for {vc_id!r} captured a different command than the approved graph — re-run run-verification-evidence"
+                        )
+                    elif entry.get("exit_code") != 0:
+                        errors.append(
+                            f"{seg_id}: verification command {vc_id!r} failed (exit {entry.get('exit_code')}) — fix and re-run run-verification-evidence"
+                        )
+
+        verified.append(f"{seg_id}: ok")
+    return errors, verified
+
+
 def cmd_run_execution_finish(args: argparse.Namespace) -> int:
     task_dir = Path(args.task_dir).resolve()
     root = _root_for_task_dir(task_dir)
@@ -4810,6 +5199,21 @@ def cmd_run_execution_finish(args: argparse.Namespace) -> int:
             }, indent=2))
             return 1
 
+        # Evidence gate: finish must not advance the stage when evidence is
+        # missing — the transition itself is the proof boundary, so the
+        # verification runs INSIDE the gate, not as a separate later step.
+        cached_ids = set(payload.get("cached_segments", []))
+        errors, verified = _verify_execution_evidence(task_dir, cached_ids)
+        if errors:
+            print(json.dumps({
+                "status": "blocked",
+                "task_dir": str(task_dir),
+                "error": f"{len(errors)} evidence verification failure(s)",
+                "failures": errors,
+                "verified": verified,
+            }, indent=2))
+            return 1
+
         _, manifest = transition_task(task_dir, "TEST_EXECUTION")
         print(json.dumps({
             "status": "test_execution_ready",
@@ -4817,6 +5221,7 @@ def cmd_run_execution_finish(args: argparse.Namespace) -> int:
             "stage": manifest.get("stage"),
             "completed_segments": payload["completed_segments"],
             "cached_segments": payload["cached_segments"],
+            "segments_verified": len(verified),
         }, indent=2))
         return 0
     except Exception as exc:
@@ -4825,7 +5230,7 @@ def cmd_run_execution_finish(args: argparse.Namespace) -> int:
 
 
 def cmd_run_execution_verify_evidence(args: argparse.Namespace) -> int:
-    """Deterministically verify evidence files and files_expected before Step 5 completion.
+    """Deterministically verify evidence files and files_expected.
 
     Checks:
     1. Each non-cached segment has a non-empty evidence file at evidence/{seg-id}.md.
@@ -4833,59 +5238,20 @@ def cmd_run_execution_verify_evidence(args: argparse.Namespace) -> int:
 
     Exits non-zero and prints a JSON error payload if any check fails.
     This replaces the model's narrative completion judgment in execute Step 5.
+
+    Legal at EXECUTION *and* TEST_EXECUTION: run-execution-finish performs
+    the same verification inside the stage gate, so the standalone command
+    is a re-runnable confirmation, not the gate itself. (It previously
+    hard-errored after finish advanced the stage — P0-e in
+    docs/permissions-on-design.md.)
     """
     task_dir = Path(args.task_dir).resolve()
-    root = _root_for_task_dir(task_dir)
     try:
-        graph_path = task_dir / "execution-graph.json"
-        if not graph_path.exists():
-            print(json.dumps({
-                "status": "blocked",
-                "task_dir": str(task_dir),
-                "error": "execution-graph.json not found",
-            }, indent=2))
-            return 1
-
-        graph = load_json(graph_path)
-        segments = graph.get("segments", []) if isinstance(graph, dict) else []
-        if not isinstance(segments, list):
-            segments = []
-
-        batch_payload = _compute_execution_batch_payload(task_dir)
+        batch_payload = _compute_execution_batch_payload(
+            task_dir, expected_stages=frozenset({"EXECUTION", "TEST_EXECUTION"})
+        )
         cached_ids = set(batch_payload.get("cached_segments", []))
-
-        errors: list[str] = []
-        verified: list[str] = []
-
-        for seg in segments:
-            if not isinstance(seg, dict):
-                continue
-            seg_id = str(seg.get("id", "") or "")
-            if not seg_id:
-                continue
-            if seg_id in cached_ids:
-                verified.append(f"{seg_id}: cached (evidence reused)")
-                continue
-
-            # Check evidence file.
-            evidence_path = task_dir / "evidence" / f"{seg_id}.md"
-            if not evidence_path.exists():
-                errors.append(f"{seg_id}: evidence file missing at {evidence_path}")
-                continue
-            content = evidence_path.read_text(errors="ignore").strip()
-            if not content:
-                errors.append(f"{seg_id}: evidence file is empty at {evidence_path}")
-                continue
-
-            # Check files_expected exist on disk.
-            for expected_file in (seg.get("files_expected") or []):
-                if not isinstance(expected_file, str) or not expected_file.strip():
-                    continue
-                fpath = root / expected_file.strip()
-                if not fpath.exists():
-                    errors.append(f"{seg_id}: files_expected entry missing on disk: {expected_file}")
-
-            verified.append(f"{seg_id}: ok")
+        errors, verified = _verify_execution_evidence(task_dir, cached_ids)
 
         if errors:
             print(json.dumps({
@@ -4907,6 +5273,134 @@ def cmd_run_execution_verify_evidence(args: argparse.Namespace) -> int:
     except Exception as exc:
         print(str(exc), file=sys.stderr)
         return 1
+
+
+def cmd_run_verification_evidence(args: argparse.Namespace) -> int:
+    """Execute plan-declared verify_commands and capture machine evidence (D6).
+
+    For every segment declaring `verify_commands` in execution-graph.json
+    (wrapper-written, human-approved at the plan gate), runs each command and
+    captures exit code + output tails into the ctl-owned artifact
+    `evidence/verification/{seg-id}.json`, then writes a receipt embedding
+    the artifact's sha256.
+
+    Anti-trust-me-bro property: the auditor reads THIS artifact instead of
+    accepting the executor's narrative claim that "ruff exits 0". Executors
+    cannot write or doctor it (write_policy denies evidence/verification/
+    for executor roles); the commands come only from the approved graph, so
+    an executor cannot substitute `exit 0` at audit time.
+    """
+    import subprocess as _subprocess
+    import time as _time
+
+    task_dir = Path(args.task_dir).resolve()
+    root = _root_for_task_dir(task_dir)
+    blocked = _refuse_if_rules_corrupt(root)
+    if blocked is not None:
+        return blocked
+
+    try:
+        graph = load_json(task_dir / "execution-graph.json")
+    except Exception as exc:
+        print(f"run-verification-evidence: cannot read execution-graph.json: {exc}", file=sys.stderr)
+        return 1
+    segments = graph.get("segments", []) if isinstance(graph, dict) else []
+
+    targets: list[dict] = []
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        seg_id = str(seg.get("id", "") or "")
+        if args.segment and seg_id != args.segment:
+            continue
+        if seg.get("verify_commands"):
+            targets.append(seg)
+    if args.segment and not targets:
+        print(
+            f"run-verification-evidence: segment {args.segment!r} not found "
+            "or declares no verify_commands",
+            file=sys.stderr,
+        )
+        return 1
+
+    timeout_s = int(args.timeout or 300)
+    tail_bytes = 8192
+    summary: list[dict] = []
+    any_failed = False
+
+    for seg in targets:
+        seg_id = str(seg.get("id"))
+        records: list[dict] = []
+        all_passed = True
+        for vc in seg.get("verify_commands", []):
+            command = str(vc.get("command", ""))
+            started = _time.monotonic()
+            try:
+                proc = _subprocess.run(
+                    ["bash", "-c", command],
+                    cwd=str(root),
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_s,
+                    check=False,
+                )
+                exit_code: int | None = proc.returncode
+                stdout_tail = proc.stdout[-tail_bytes:]
+                stderr_tail = proc.stderr[-tail_bytes:]
+                timed_out = False
+            except _subprocess.TimeoutExpired as exc:
+                exit_code = None
+                stdout_tail = (exc.stdout or "")[-tail_bytes:] if isinstance(exc.stdout, str) else ""
+                stderr_tail = (exc.stderr or "")[-tail_bytes:] if isinstance(exc.stderr, str) else ""
+                timed_out = True
+            duration_ms = int((_time.monotonic() - started) * 1000)
+            passed = exit_code == 0
+            if not passed:
+                all_passed = False
+            records.append({
+                "id": str(vc.get("id")),
+                "command": command,
+                "criteria_ids": list(vc.get("criteria_ids", []) or []),
+                "exit_code": exit_code,
+                "timed_out": timed_out,
+                "duration_ms": duration_ms,
+                "stdout_tail": stdout_tail,
+                "stderr_tail": stderr_tail,
+                "passed": passed,
+            })
+
+        artifact = {
+            "segment_id": seg_id,
+            "captured_at": now_iso(),
+            "all_passed": all_passed,
+            "results": records,
+        }
+        artifact_path = task_dir / "evidence" / "verification" / f"{seg_id}.json"
+        _write_ctl_json(task_dir, artifact_path, artifact)
+        artifact_sha = hash_file(artifact_path)
+        write_receipt(
+            task_dir,
+            f"verification-evidence-{seg_id}",
+            artifact_sha256=artifact_sha,
+            command_count=len(records),
+            all_passed=all_passed,
+        )
+        if not all_passed:
+            any_failed = True
+        summary.append({
+            "segment_id": seg_id,
+            "all_passed": all_passed,
+            "commands": len(records),
+            "artifact": str(artifact_path),
+            "artifact_sha256": artifact_sha,
+        })
+
+    print(json.dumps({
+        "status": "verification_failed" if any_failed else "verification_captured",
+        "task_dir": str(task_dir),
+        "segments": summary,
+    }, indent=2))
+    return 1 if any_failed else 0
 
 
 def cmd_run_repair_execution_ready(args: argparse.Namespace) -> int:
@@ -6220,6 +6714,33 @@ def register_planning_parsers(subparsers: argparse._SubParsersAction) -> None:
     """Register planning-stage subcommands: run-start-classification, run-spec-ready,
     run-planning-mode, run-planning, run-plan-audit, plan-validated-receipt,
     plan-audit-receipt, planner-receipt."""
+    run_start_init_parser = subparsers.add_parser(
+        "run-start-init",
+        help="Initialize a new task: .dynos, registration, task id, raw-input.md, manifest, execution log (D4)",
+    )
+    run_start_init_parser.add_argument("--root", default=".", help="Project root (default: cwd)")
+    run_start_init_parser.add_argument(
+        "--description", required=True,
+        help="Task description, or '-' to read it from stdin",
+    )
+    run_start_init_parser.add_argument(
+        "--input-type", choices=["text", "prd", "wireframe", "mixed"], default="text",
+    )
+    run_start_init_parser.set_defaults(func=cmd_run_start_init)
+
+    tdd_receipt_parser = subparsers.add_parser(
+        "tdd-receipt",
+        help="Write the TDD-tests receipt deterministically from on-disk evidence",
+    )
+    tdd_receipt_parser.add_argument("task_dir")
+    tdd_receipt_parser.add_argument(
+        "--test-file", action="append", default=[],
+        help="Test file path written this run (repeatable)",
+    )
+    tdd_receipt_parser.add_argument("--tokens-used", type=int, default=0)
+    tdd_receipt_parser.add_argument("--model", default="unknown")
+    tdd_receipt_parser.set_defaults(func=cmd_tdd_receipt)
+
     run_start_classification_parser = subparsers.add_parser(
         "run-start-classification",
         help="Validate classification, apply fast-track, and advance to SPEC_NORMALIZATION when ready",
@@ -6362,6 +6883,15 @@ def register_execution_parsers(subparsers: argparse._SubParsersAction) -> None:
     )
     run_execution_verify_evidence_parser.add_argument("task_dir")
     run_execution_verify_evidence_parser.set_defaults(func=cmd_run_execution_verify_evidence)
+
+    run_verification_parser = subparsers.add_parser(
+        "run-verification-evidence",
+        help="Execute plan-declared verify_commands and capture exit codes/output into ctl-owned evidence (D6)",
+    )
+    run_verification_parser.add_argument("task_dir")
+    run_verification_parser.add_argument("--segment", help="Limit to one segment id")
+    run_verification_parser.add_argument("--timeout", type=int, default=300, help="Per-command timeout in seconds")
+    run_verification_parser.set_defaults(func=cmd_run_verification_evidence)
 
     ownership_parser = subparsers.add_parser("check-ownership", help="Check that files belong to a segment")
     ownership_parser.add_argument("task_dir")
@@ -6530,7 +7060,7 @@ def register_repair_parsers(subparsers: argparse._SubParsersAction) -> None:
         help="Validate, normalize, and atomically write repair-log.json",
     )
     repair_write_parser.add_argument("task_dir")
-    repair_write_parser.add_argument("--from", dest="from_path", required=True)
+    repair_write_parser.add_argument("--from", dest="from_path", required=True, help="payload JSON file path, or '-' to read from stdin")
     repair_write_parser.set_defaults(func=cmd_write_repair_log)
 
 
@@ -6542,7 +7072,7 @@ def register_artifact_parsers(subparsers: argparse._SubParsersAction) -> None:
         help="Validate, normalize, and atomically write execution-graph.json",
     )
     graph_write_parser.add_argument("task_dir")
-    graph_write_parser.add_argument("--from", dest="from_path", required=True)
+    graph_write_parser.add_argument("--from", dest="from_path", required=True, help="payload JSON file path, or '-' to read from stdin")
     graph_write_parser.set_defaults(func=cmd_write_execution_graph)
 
     classification_write_parser = subparsers.add_parser(
@@ -6550,7 +7080,7 @@ def register_artifact_parsers(subparsers: argparse._SubParsersAction) -> None:
         help="Validate, normalize, and atomically write classification.json plus synced manifest state",
     )
     classification_write_parser.add_argument("task_dir")
-    classification_write_parser.add_argument("--from", dest="from_path", required=True)
+    classification_write_parser.add_argument("--from", dest="from_path", required=True, help="payload JSON file path, or '-' to read from stdin")
     classification_write_parser.set_defaults(func=cmd_write_classification)
 
     record_snapshot_parser = subparsers.add_parser(
@@ -6615,11 +7145,26 @@ def register_meta_parsers(subparsers: argparse._SubParsersAction) -> None:
     validate-chain, list-pending, approve, stats-dora, stats-usage, bus, calibration, config."""
     stamp_role_parser = subparsers.add_parser(
         "stamp-role",
-        help="Stamp the active-segment-role file under role=ctl (refuses audit-* roles)",
+        help="Stamp the legacy active-segment-role file AND append a role grant (allowlist enforced)",
     )
     stamp_role_parser.add_argument("task_dir")
-    stamp_role_parser.add_argument("--role", required=True, help="Executor role to stamp (allowlist enforced)")
+    stamp_role_parser.add_argument("--role", required=True, help="Role to stamp/grant (allowlist enforced)")
     stamp_role_parser.set_defaults(func=cmd_stamp_role)
+
+    grant_role_parser = subparsers.add_parser(
+        "grant-role",
+        help="Append a single-use role grant for the next subagent spawn (allowlist enforced)",
+    )
+    grant_role_parser.add_argument("task_dir")
+    grant_role_parser.add_argument("--role", required=True, help="Role to grant (allowlist enforced)")
+    grant_role_parser.set_defaults(func=cmd_grant_role)
+
+    clear_role_parser = subparsers.add_parser(
+        "clear-role",
+        help="Expire unconsumed role grants and remove the legacy role file (privilege-reducing)",
+    )
+    clear_role_parser.add_argument("task_dir")
+    clear_role_parser.set_defaults(func=cmd_clear_role)
 
     run_audit_reflect_parser = subparsers.add_parser(
         "run-audit-reflect",

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -28,6 +28,107 @@ from write_policy import find_write_violations
 # passed plan validation are grandfathered through unaffected.
 _OVERFLOW_GUARD_STAGES: set[str] = {"PLANNING", "PLAN_REVIEW", "EXECUTION_GRAPH_BUILD"}
 
+def _glob_entry_regex(entry: str) -> "re.Pattern[str]":
+    """Translate a files_expected glob to a regex with PATH semantics:
+    `*`/`?` do not cross `/`; `**` does. (fnmatch's `*` crosses slashes,
+    which would make `src/*.py` silently claim `src/sub/a.py`.)"""
+    out: list[str] = []
+    i = 0
+    n = len(entry)
+    while i < n:
+        ch = entry[i]
+        if ch == "*":
+            if entry[i : i + 3] == "**/":
+                out.append(r"(?:[^/]+/)*")
+                i += 3
+                continue
+            if entry[i : i + 2] == "**":
+                out.append(r".*")
+                i += 2
+                continue
+            out.append(r"[^/]*")
+        elif ch == "?":
+            out.append(r"[^/]")
+        elif ch == "[":
+            end = entry.find("]", i + 1)
+            if end == -1:
+                out.append(re.escape(ch))
+            else:
+                out.append(entry[i : end + 1])
+                i = end
+        else:
+            out.append(re.escape(ch))
+        i += 1
+    return re.compile("".join(out) + r"\Z")
+
+
+# Known shorthand -> canonical-value hints for enum errors. difflib catches
+# typos; this table catches *conceptual* aliases it cannot (e.g. "ci" is not
+# string-similar to "infra"). Per the 2026-06 decision, "ci" maps to "infra"
+# — it is intentionally NOT added to VALID_DOMAINS.
+_ENUM_ALIAS_HINTS: dict[str, str] = {
+    "ci": "infra",
+    "cicd": "infra",
+    "ci/cd": "infra",
+    "devops": "infra",
+    "ops": "infra",
+    "frontend": "ui",
+    "front-end": "ui",
+    "database": "db",
+    "documentation": "docs",
+}
+
+
+def invalid_enum_error(field: str, value: object, valid: Iterable[str]) -> str:
+    """Uniform enum-violation message: names the valid set and, when
+    possible, a did-you-mean hint (D7-4 — errors must be self-correcting,
+    a bare 'invalid: ci' sends the model guessing)."""
+    import difflib
+
+    valid_sorted = sorted(valid)
+    msg = f"{field} invalid: {value!r} — valid values: [{', '.join(valid_sorted)}]"
+    if isinstance(value, str) and value:
+        lowered = value.strip().lower()
+        hint = _ENUM_ALIAS_HINTS.get(lowered)
+        if hint is None and f"{lowered}-executor" in valid_sorted:
+            hint = f"{lowered}-executor"
+        if hint is None:
+            close = difflib.get_close_matches(lowered, valid_sorted, n=1, cutoff=0.6)
+            hint = close[0] if close else None
+        if hint and hint in valid_sorted:
+            msg += f"; did you mean {hint!r}?"
+    return msg
+
+
+def files_expected_entry_matches(entry: str, file_path: str) -> bool:
+    """True when a files_expected entry covers a concrete file path (D7-2).
+
+    - trailing '/'  -> directory prefix containment
+    - glob chars    -> path-aware glob (`*` within a segment, `**` across)
+    - plain entry   -> exact equality (original behavior)
+    """
+    if entry == file_path:
+        return True
+    if entry.endswith("/"):
+        return file_path.startswith(entry)
+    if any(ch in entry for ch in "*?["):
+        return _glob_entry_regex(entry).match(file_path) is not None
+    return False
+
+
+def files_expected_entries_overlap(a: str, b: str) -> bool:
+    """True when two files_expected entries could claim the same file.
+
+    Used by the cross-segment exclusivity rule: directory/glob entries
+    overlap any entry they contain or match, in either direction.
+    """
+    if a == b:
+        return True
+    return files_expected_entry_matches(a, b.rstrip("/")) or files_expected_entry_matches(
+        b, a.rstrip("/")
+    ) or files_expected_entry_matches(a, b) or files_expected_entry_matches(b, a)
+
+
 def require_nonblank(value: str, *, field_name: str) -> str:
     """Validate that *value* is a non-empty string and return its stripped form.
 
@@ -313,10 +414,10 @@ def validate_manifest(manifest: dict) -> list[str]:
             return errors
         ctype = classification.get("type")
         if ctype not in VALID_CLASSIFICATION_TYPES:
-            errors.append(f"classification.type invalid: {ctype!r}")
+            errors.append(invalid_enum_error("classification.type", ctype, VALID_CLASSIFICATION_TYPES))
         risk = classification.get("risk_level")
         if risk not in VALID_RISK_LEVELS:
-            errors.append(f"classification.risk_level invalid: {risk!r}")
+            errors.append(invalid_enum_error("classification.risk_level", risk, VALID_RISK_LEVELS))
         domains = classification.get("domains")
         if not isinstance(domains, list) or not domains:
             errors.append("classification.domains must be a non-empty array")
@@ -327,7 +428,7 @@ def validate_manifest(manifest: dict) -> list[str]:
                     errors.append("classification.domains entries must be non-empty strings")
                     continue
                 if domain not in VALID_DOMAINS:
-                    errors.append(f"classification domain invalid: {domain!r}")
+                    errors.append(invalid_enum_error("classification domain", domain, VALID_DOMAINS))
                 if domain in seen_domains:
                     errors.append(f"classification.domains contains duplicate entry: {domain!r}")
                 else:
@@ -488,6 +589,23 @@ def validate_task_artifacts(
         for heading in all_required:
             if heading not in plan_headings:
                 errors.append(f"plan missing heading: {heading}")
+        # Section-level exemption (D7-4): every backtick path listed under a
+        # "Files to be created" heading (any level) is exempt everywhere, in
+        # addition to the per-line "to-be-created" marker.
+        to_be_created: set[str] = set()
+        in_create_section = False
+        for line in plan_text.splitlines():
+            heading_match = re.match(r"#{2,4}\s+(.*)", line)
+            if heading_match:
+                title = heading_match.group(1).strip().lower()
+                in_create_section = (
+                    "files to be created" in title or "to-be-created" in title
+                )
+                continue
+            if in_create_section:
+                for match in re.finditer(r"`([^`]+)`", line):
+                    to_be_created.add(match.group(1).strip())
+
         in_ref_section = False
         for line in plan_text.splitlines():
             if line.startswith("## "):
@@ -497,11 +615,22 @@ def validate_task_artifacts(
                 continue
             for match in re.finditer(r"`([^`]+\.[a-zA-Z]{1,5})`", line):
                 ref_path = match.group(1)
+                # Only slash-containing tokens are treated as repo paths —
+                # bare tokens like `policy.json` are frequently concepts or
+                # basenames, and path-checking them produced false rejects.
+                if "/" not in ref_path:
+                    continue
                 if "to-be-created" in line.lower():
+                    continue
+                if ref_path in to_be_created:
                     continue
                 full = task_dir.parent.parent / ref_path
                 if not full.exists():
-                    errors.append(f"plan Reference Code path does not exist: {ref_path}")
+                    errors.append(
+                        f"plan Reference Code path does not exist: {ref_path} "
+                        "(mark new files as to-be-created on the same line, or "
+                        "list them under a 'Files to be created' heading)"
+                    )
 
         components_section = extract_markdown_section(plan_text, "Components / Modules")
         if components_section.strip():
@@ -570,7 +699,7 @@ def validate_task_artifacts(
                     errors.append(f"{segment_id}: description must be a non-empty string")
                 executor = segment.get("executor")
                 if executor not in VALID_EXECUTORS:
-                    errors.append(f"{segment_id}: invalid executor {executor!r}")
+                    errors.append(invalid_enum_error(f"{segment_id}: executor", executor, VALID_EXECUTORS))
                 files_expected = segment.get("files_expected")
                 if not isinstance(files_expected, list) or not files_expected:
                     errors.append(f"{segment_id}: files_expected must be a non-empty array")
@@ -586,11 +715,17 @@ def validate_task_artifacts(
                             errors.append(f"{segment_id}: duplicate file in files_expected: {file_path}")
                         else:
                             segment_seen_files.add(file_path)
-                        owner = seen_files.get(file_path)
-                        if owner and owner != segment_id:
-                            errors.append(f"file {file_path} appears in multiple segments: {owner}, {segment_id}")
-                        else:
-                            seen_files[file_path] = segment_id
+                        # Cross-segment exclusivity. Directory ("dir/") and
+                        # glob entries participate by containment, so a
+                        # directory segment cannot silently share files with
+                        # a per-file segment (D7-2 — stricter, not looser).
+                        for other_path, owner in seen_files.items():
+                            if owner != segment_id and files_expected_entries_overlap(file_path, other_path):
+                                errors.append(
+                                    f"file {file_path} appears in multiple segments: {owner}, {segment_id}"
+                                )
+                                break
+                        seen_files.setdefault(file_path, segment_id)
                     # AC-9 / AC-10: plan-time overflow guard. Fires only at
                     # plan-creation/review stages so that in-flight tasks at
                     # PRE_EXECUTION_SNAPSHOT or later are grandfathered.
@@ -759,7 +894,7 @@ def validate_repair_log(task_dir: Path) -> list[str]:
                 errors.append(f"{batch_id}: instruction must be a non-empty string")
             executor = task.get("assigned_executor")
             if executor not in VALID_EXECUTORS:
-                errors.append(f"{batch_id}: invalid assigned_executor {executor!r}")
+                errors.append(invalid_enum_error(f"{batch_id}: assigned_executor", executor, VALID_EXECUTORS))
             files = task.get("affected_files")
             if files is None:
                 files = task.get("files_to_modify")
@@ -1486,7 +1621,10 @@ def check_segment_ownership(task_dir: Path, segment_id: str, files: Iterable[str
                     rel_to_task = None
                 if rel_to_task is not None and rel_to_task.startswith("evidence/"):
                     continue
-                if file_path not in allowed:
+                if not any(
+                    files_expected_entry_matches(entry, str(file_path))
+                    for entry in allowed
+                ):
                     violations.append(str(file_path))
             return violations
     raise ValueError(f"Unknown segment id: {segment_id}")

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -27,7 +28,7 @@ from pathlib import Path
 _EXECUTOR_ROLE_ALLOWLIST: frozenset[str] = frozenset({
     "backend-executor", "ui-executor", "testing-executor", "integration-executor",
     "ml-executor", "db-executor", "refactor-executor", "docs-executor",
-    "planning", "execute-inline", "repair-coordinator",
+    "planning", "execute-inline", "repair-coordinator", "investigator",
     "audit-spec-completion", "audit-security", "audit-code-quality",
     "audit-performance", "audit-dead-code", "audit-db-schema", "audit-ui", "audit-claude-md",
 })
@@ -65,41 +66,186 @@ def _find_task_dir_from_ancestors(cwd: Path) -> Path | None:
 
 
 # ---------------------------------------------------------------------------
-# Bash pre-filter: commands that could write files
+# Bash pre-filter: quote-aware write-destination extraction
 # ---------------------------------------------------------------------------
-# These patterns detect shell commands that write to the filesystem.
-# Group index indicates which capture group holds the destination path.
-_BASH_WRITE_PATTERNS: list[tuple[re.Pattern[str], int]] = [
-    # redirection: > file or >> file  (looks for > after optional command text)
+# The original implementation ran regexes over the raw command string, which
+# matched `>` characters inside quoted prompt text and heredoc bodies and
+# produced false-positive "write destinations" (P0-b in
+# docs/permissions-on-design.md). Extraction is now token-based:
+#   1. heredoc bodies are stripped (their content is data, not shell),
+#   2. the command is tokenized with shlex (quoted strings stay single
+#      tokens and can never be operators),
+#   3. redirection operators and write-verb argv positions are resolved on
+#      the token stream.
+# This filter is defense-in-depth, not the trust anchor: interpreter-internal
+# writes (e.g. `python3 -c "open(p,'w')"`) are invisible to any Bash-level
+# parser. The unforgeable guarantees live in receipts + spawn-log + the
+# ctl-internal require_write_allowed path (see docs/write-boundary-spec.md).
+
+# Legacy regex patterns, retained ONLY as the fallback when shlex cannot
+# tokenize the command (unbalanced quotes). Fallback keeps the filter
+# fail-closed rather than silently allowing unparseable commands.
+_LEGACY_BASH_WRITE_PATTERNS: list[tuple[re.Pattern[str], int]] = [
     (re.compile(r">>?\s*([^\s;|&>]+)"), 1),
-    # tee: tee [-a] file
     (re.compile(r"\btee\s+(?:-a\s+)?([^\s;|&]+)"), 1),
-    # mv: mv src dst
     (re.compile(r"\bmv\s+\S+\s+([^\s;|&]+)"), 1),
-    # cp: cp [-rRp...] src dst
     (re.compile(r"\bcp\s+(?:-[a-zA-Z]+\s+)?(?:\S+\s+)+([^\s;|&]+)"), 1),
-    # rsync: rsync [opts...] src dst
     (re.compile(r"\brsync\s+(?:\S+\s+)+([^\s;|&]+)"), 1),
-    # install: install [-m MODE] [opts] src dst
     (re.compile(r"\binstall\s+(?:-[a-zA-Z]+\s+(?:\S+\s+)?)?(?:\S+\s+)+([^\s;|&]+)"), 1),
-    # rm: rm [opts] file — sec-1 fix: deletion of audit-grep-quota.json
-    # was the quota-bypass primitive. Each non-flag argument is checked.
     (re.compile(r"\brm\s+(?:-[a-zA-Z]+\s+)*([^\s;|&]+)"), 1),
-    # unlink: unlink file
     (re.compile(r"\bunlink\s+([^\s;|&]+)"), 1),
 ]
 
+# Heredoc opener: `<< WORD`, `<<-WORD`, `<<'WORD'`, `<<"WORD"`. The negative
+# lookbehind keeps herestrings (`<<<`) from being misparsed as heredocs.
+_HEREDOC_OPEN_RE = re.compile(r"(?<!<)<<-?\s*(['\"]?)(\w+)\1")
 
-def _extract_bash_destinations(command: str) -> list[str]:
-    """Return a list of write destination paths detected in a Bash command string."""
+# Punctuation-run tokens that redirect output to a file. `>&` (fd dup) is
+# handled separately — its operand is a file descriptor, not a path.
+_REDIRECT_TOKENS = frozenset({">", ">>", "&>", "&>>", ">|"})
+
+# Device sinks: writing to these persists nothing. The plugin's own skills
+# prescribe `2>/dev/null`; denying a sink only produces noise.
+_SINK_DESTINATIONS = frozenset({
+    "/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty",
+})
+
+_COMMAND_SEPARATOR_TOKENS = frozenset({";", "|", "||", "&&", "&", "(", ")"})
+
+# argv-based write verbs -> which following non-flag args are destinations.
+#   "last" -> final non-flag argument (mv/cp/rsync/install)
+#   "all"  -> every non-flag argument (tee/rm/unlink/shred/truncate)
+_WRITE_VERB_DEST: dict[str, str] = {
+    "tee": "all",
+    "mv": "last",
+    "cp": "last",
+    "rsync": "last",
+    "install": "last",
+    "rm": "all",
+    "unlink": "all",
+    "shred": "all",
+    "truncate": "all",
+}
+
+
+def _strip_heredocs(command: str) -> str:
+    """Remove heredoc bodies so their content is not tokenized as shell."""
+    out: list[str] = []
+    terminator: str | None = None
+    for line in command.split("\n"):
+        if terminator is not None:
+            if line.strip() == terminator:
+                terminator = None
+            continue
+        match = _HEREDOC_OPEN_RE.search(line)
+        out.append(line)
+        if match:
+            terminator = match.group(2)
+    return "\n".join(out)
+
+
+def _tokenize_bash(command: str) -> list[str] | None:
+    """shlex-tokenize a command; None when the command cannot be parsed."""
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _extract_bash_destinations_legacy(command: str) -> list[str]:
+    """Regex fallback used only when shlex tokenization fails."""
     destinations: list[str] = []
     seen: set[str] = set()
-    for pattern, group in _BASH_WRITE_PATTERNS:
+    for pattern, group in _LEGACY_BASH_WRITE_PATTERNS:
         for match in pattern.finditer(command):
             dest = match.group(group).strip().rstrip(";|&>")
             if dest and dest not in seen:
                 seen.add(dest)
                 destinations.append(dest)
+    return destinations
+
+
+def _is_candidate_dest(token: str) -> bool:
+    """Filter tokens that cannot be filesystem write destinations."""
+    if not token:
+        return False
+    if token in _SINK_DESTINATIONS:
+        return False
+    if token.isdigit():  # fd numbers from `>& 2` style constructs
+        return False
+    if token.startswith("-"):
+        return False
+    if token in _COMMAND_SEPARATOR_TOKENS or token in _REDIRECT_TOKENS:
+        return False
+    if token in {"<", "<<", "<<<", ">&", "<&"}:
+        return False
+    return True
+
+
+def _extract_bash_destinations(command: str) -> list[str]:
+    """Return write destination paths detected in a Bash command string.
+
+    Token-based: quoted strings are single tokens (never operators), heredoc
+    bodies are stripped before tokenization. Falls back to the legacy regex
+    scan when the command cannot be tokenized.
+    """
+    stripped = _strip_heredocs(command)
+    tokens = _tokenize_bash(stripped)
+    if tokens is None:
+        return _extract_bash_destinations_legacy(command)
+
+    destinations: list[str] = []
+    seen: set[str] = set()
+
+    def _add(dest: str) -> None:
+        if _is_candidate_dest(dest) and dest not in seen:
+            seen.add(dest)
+            destinations.append(dest)
+
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        # Redirection operator: next token is the destination. Punctuation
+        # runs may glue a trailing newline onto the operator; normalize.
+        op = tok.strip()
+        if op in _REDIRECT_TOKENS:
+            if i + 1 < n:
+                _add(tokens[i + 1])
+                i += 2
+                continue
+        # Write verb: collect its argv tail up to the next separator. The
+        # verb is recognized at any statement position (parity with the old
+        # \b-anchored regexes) — quoted text can no longer false-positive
+        # because it arrives as a single token, not as words.
+        verb = os.path.basename(op)
+        if verb in _WRITE_VERB_DEST:
+            mode = _WRITE_VERB_DEST[verb]
+            args: list[str] = []
+            j = i + 1
+            while j < n and tokens[j] not in _COMMAND_SEPARATOR_TOKENS:
+                t = tokens[j]
+                if t in _REDIRECT_TOKENS:
+                    break
+                if t != "--" and not t.startswith("-"):
+                    args.append(t)
+                j += 1
+            if mode == "all":
+                for a in args:
+                    _add(a)
+            elif args:
+                # "last" verbs need >= 2 operands to have a distinct
+                # destination (`mv src dst`); a single operand is a source.
+                if verb in {"mv", "cp", "rsync", "install"}:
+                    if len(args) >= 2:
+                        _add(args[-1])
+                else:
+                    _add(args[-1])
+            i = j
+            continue
+        i += 1
     return destinations
 
 
@@ -109,6 +255,28 @@ def _resolve_path(raw: str, cwd: Path) -> Path:
     if not p.is_absolute():
         p = cwd / p
     return p.resolve()
+
+
+def _format_denial(role: str, path: Path | str, decision) -> str:
+    """Self-explaining denial text (P0-f in docs/permissions-on-design.md).
+
+    Denials from this hook are routinely mistaken for Claude Code permission
+    failures, sending users into settings changes that cannot help. Every
+    denial therefore names (a) what it is, (b) the role and path it judged,
+    and (c) the sanctioned alternative when one exists.
+    """
+    sanctioned = ""
+    wrapper = getattr(decision, "wrapper_command", None)
+    if wrapper:
+        sanctioned = f" Sanctioned path: {wrapper}."
+    return (
+        f"write-policy: DENIED — {decision.reason} "
+        f"[dynos-work guardrail, not a Claude Code permission; changing "
+        f"permission settings will not affect this] "
+        f"role={role} path={path}.{sanctioned} "
+        f"Temp files belong in .dynos/task-*/_scratch/. "
+        f"See docs/write-boundary-spec.md."
+    )
 
 
 def main() -> int:
@@ -197,51 +365,112 @@ def main() -> int:
     else:
         task_dir = _find_task_dir_from_ancestors(cwd)
 
-    # 3-step role resolution chain:
-    # (a) env var -- highest priority
-    # (b) role file in task dir -- searched whenever task_dir is known
-    #     (DYNOS_TASK_DIR env OR ancestor-walked discovery)
-    # (c) default "execute-inline"
+    # Actor identity inputs (D3): the harness-provided session_id and the
+    # SessionStart-pinned orchestrator identity. Neither is agent-writable.
+    session_id = str(payload.get("session_id") or "").strip()
+    actor_identity = None
+    pin = None
+    if task_dir is not None:
+        try:
+            import actor_identity as _ai
+            actor_identity = _ai
+            pin = _ai.read_pin(task_dir.parent.parent)
+        except Exception:
+            actor_identity = None
+            pin = None
+
+    # Role resolution chain:
+    # (a) DYNOS_ROLE env var — highest priority (daemon/scheduler/tests)
+    # (b) orchestrator pin — session_id matches the SessionStart pin: the
+    #     MAIN session always resolves to 'orchestrator' and never reads
+    #     role files (stamping a subagent role can no longer mutate the
+    #     orchestrator's own rights mid-flow)
+    # (c) session binding / grant consumption — any OTHER session is a
+    #     subagent: reuse its existing binding, else consume the oldest
+    #     pending grant from the ctl-written ledger
+    # (d) legacy role file — sessions without a pin (pre-D3 sessions) and
+    #     subagents on tasks that still stamp active-segment-role
+    # (e) default "execute-inline"
     role_file_searched: bool = False
     role_file_path: Path | None = None
-    role_file_reason: str | None = None  # "absent" | "empty" when falling to (c)
+    role_file_reason: str | None = None  # "absent" | "empty" | "invalid"
 
     if role_from_env:
         # Step (a): env var wins
         role = role_from_env
         role_missing = False
     else:
-        # Step (b): check role file whenever task_dir was resolved (env OR
-        # ancestor walk). Subagents spawned via the harness Agent tool do not
-        # inherit DYNOS_TASK_DIR, so gating this on the env var alone made the
-        # role-file fallback unreachable in real workflows — every spec.md
-        # write from a planning subagent fell to execute-inline and was denied.
-        role = "execute-inline"
+        role: str | None = None
         role_missing = True
 
-        if task_dir is not None:
-            role_file_path = task_dir / "active-segment-role"
-            role_file_searched = True
-            try:
-                if role_file_path.is_file():
-                    file_contents = role_file_path.read_text(encoding="utf-8").strip()
-                    if file_contents and file_contents in _EXECUTOR_ROLE_ALLOWLIST:
-                        # Step (b) resolved: use file contents, suppress role_missing
-                        role = file_contents
-                        role_missing = False
-                    elif file_contents and file_contents not in _EXECUTOR_ROLE_ALLOWLIST:
-                        # File has contents but value is not an allowed executor role --
-                        # reject and fall to (c) to prevent privilege escalation via role file.
-                        role_file_reason = "invalid"
+        # Steps (b)/(c): only meaningful when both a task dir and a pin
+        # exist — without a pin we cannot distinguish actors and fall back
+        # to the legacy chain wholesale (today's behavior, no regression).
+        if task_dir is not None and actor_identity is not None and pin and session_id:
+            if session_id == pin.get("session_id"):
+                role = "orchestrator"
+                role_missing = False
+            else:
+                bound = actor_identity.lookup_binding(task_dir, session_id)
+                if bound is None:
+                    bound = actor_identity.consume_grant(task_dir, session_id)
+                    if bound is not None:
+                        try:
+                            if log_event is not None:
+                                log_event(
+                                    task_dir.parent.parent,
+                                    "role_grant_consumed",
+                                    task=task_dir.name,
+                                    role=bound,
+                                    session=session_id[:16],
+                                )
+                        except Exception:
+                            pass
+                if bound is not None and bound in _EXECUTOR_ROLE_ALLOWLIST:
+                    role = bound
+                    role_missing = False
+
+        # Step (d): legacy role file fallback.
+        if role is None:
+            role = "execute-inline"
+            if task_dir is not None:
+                role_file_path = task_dir / "active-segment-role"
+                role_file_searched = True
+                try:
+                    if role_file_path.is_file():
+                        file_contents = role_file_path.read_text(encoding="utf-8").strip()
+                        if file_contents and file_contents in _EXECUTOR_ROLE_ALLOWLIST:
+                            role = file_contents
+                            role_missing = False
+                        elif file_contents and file_contents not in _EXECUTOR_ROLE_ALLOWLIST:
+                            # Not an allowed executor role — reject and fall to
+                            # (e) to prevent privilege escalation via role file.
+                            role_file_reason = "invalid"
+                        else:
+                            role_file_reason = "empty"
                     else:
-                        # File exists but empty/whitespace -- fall to (c)
-                        role_file_reason = "empty"
-                else:
-                    # File absent -- fall to (c)
+                        role_file_reason = "absent"
+                except Exception:
                     role_file_reason = "absent"
-            except Exception:
-                # File read failure is non-fatal -- treat as absent
-                role_file_reason = "absent"
+
+    # Degraded-mode diagnostic (D3): if the ORCHESTRATOR role is denied while
+    # grants are pending, the denial may actually be a subagent whose tool
+    # calls arrived under the pinned session_id (harness did not distinguish
+    # actors). Fail closed, but say so — this is the one failure mode of
+    # session-keyed actor resolution and it must be diagnosable from the
+    # error text alone.
+    degraded_hint = ""
+    if role == "orchestrator" and actor_identity is not None and task_dir is not None:
+        try:
+            if actor_identity.pending_grants(task_dir):
+                degraded_hint = (
+                    " NOTE: unconsumed role grants are pending for this task. "
+                    "If this denial occurred inside a SUBAGENT, the harness "
+                    "did not present a distinct session_id for it (degraded "
+                    "actor resolution) — see docs/permissions-on-design.md §D3."
+                )
+        except Exception:
+            pass
 
     # Emit pre_tool_use_role_missing event if role was not set in the environment
     # AND role was not resolved from the role file (step b)
@@ -303,9 +532,17 @@ def main() -> int:
         # is the authoritative set of valid agent roles; anything else is a
         # mis-configured or injected role and should be denied unconditionally.
         if task_dir is not None:
-            if role not in _EXECUTOR_ROLE_ALLOWLIST and not role.endswith("-executor"):
+            if (
+                role != "orchestrator"
+                and role not in _EXECUTOR_ROLE_ALLOWLIST
+                and not role.endswith("-executor")
+            ):
                 print(
-                    f"write-policy: role '{role}' is not in the authorized role allowlist",
+                    f"write-policy: role '{role}' is not in the authorized role "
+                    f"allowlist [dynos-work guardrail, not a Claude Code "
+                    f"permission]. Stamp a valid role via "
+                    f"`ctl.py stamp-role <task_dir> --role <role>`; valid roles: "
+                    f"{', '.join(sorted(_EXECUTOR_ROLE_ALLOWLIST))}",
                     file=sys.stderr,
                 )
                 return 2
@@ -365,7 +602,7 @@ def main() -> int:
                 pass
 
             if not decision.allowed:
-                print(f"write-policy: {decision.reason}", file=sys.stderr)
+                print(_format_denial(role, dest_path, decision) + degraded_hint, file=sys.stderr)
                 return 2
 
         return 0
@@ -409,15 +646,74 @@ def main() -> int:
             _emit_policy_event(attempt, decision)
 
             if not decision.allowed:
-                print(f"write-policy: {decision.reason}", file=sys.stderr)
+                print(_format_denial(role, target_path, decision) + degraded_hint, file=sys.stderr)
                 return 2
 
         return 0
 
     # -----------------------------------------------------------------
     # Handle Read, Grep, Glob tools: enforce read policy for audit roles
+    # and the investigator's dossier-only guarantee
     # -----------------------------------------------------------------
     if tool_name in ("Read", "Grep", "Glob"):
+        # Investigator (D7-3): "the LLM never gathers evidence on its own"
+        # is enforced here, not just promised in prose. Reads are allowed
+        # only inside .dynos/investigations/ (the dossier and its siblings)
+        # or for files the dossier itself references; Grep/Glob are denied
+        # outright — searching IS evidence-gathering.
+        if role == "investigator":
+            if tool_name in ("Grep", "Glob"):
+                print(
+                    "read-policy: investigator is dossier-only — Grep/Glob "
+                    "are evidence-gathering and are denied [dynos-work "
+                    "guardrail]. Cite pre-minted evidence IDs from the "
+                    "dossier instead.",
+                    file=sys.stderr,
+                )
+                return 2
+            raw_path = ""
+            if isinstance(tool_input, dict):
+                raw_path = tool_input.get("file_path") or tool_input.get("path") or ""
+            target = _resolve_path(str(raw_path), cwd) if raw_path else cwd
+            # Locate the project .dynos root: task dir wins, else cwd walk.
+            dynos_root: Path | None = None
+            if task_dir is not None:
+                dynos_root = task_dir.parent
+            else:
+                for ancestor in [cwd, *cwd.parents]:
+                    if (ancestor / ".dynos").is_dir():
+                        dynos_root = ancestor / ".dynos"
+                        break
+            if dynos_root is not None:
+                investigations = (dynos_root / "investigations").resolve()
+                try:
+                    target.relative_to(investigations)
+                    return 0  # dossier and investigation artifacts: allowed
+                except ValueError:
+                    pass
+                # Files referenced by the most recent dossier are citable —
+                # allow confirming a citation snippet.
+                try:
+                    dossiers = sorted(investigations.glob("*/dossier.json"))
+                    if dossiers:
+                        dossier_text = dossiers[-1].read_text(encoding="utf-8", errors="ignore")
+                        project_root = dynos_root.parent.resolve()
+                        try:
+                            rel = target.resolve().relative_to(project_root).as_posix()
+                        except ValueError:
+                            rel = None
+                        if rel and rel in dossier_text:
+                            return 0
+                except OSError:
+                    pass
+            print(
+                f"read-policy: investigator is dossier-only — {target} is "
+                "neither under .dynos/investigations/ nor referenced by the "
+                "dossier [dynos-work guardrail].",
+                file=sys.stderr,
+            )
+            return 2
+
         # AC 16: non-audit roles bypass read-policy enforcement entirely.
         if not role.startswith("audit-"):
             return 0

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -5,6 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
+# Pin the orchestrator session identity (D3). SessionStart fires only for
+# the MAIN session, so this records which session_id is the orchestrator;
+# pre_tool_use resolves that session to the 'orchestrator' role and every
+# other session to a granted subagent role. The hook payload arrives on
+# stdin — capture it before anything else consumes it.
+HOOK_PAYLOAD="$(cat 2>/dev/null || true)"
+if [ -n "${HOOK_PAYLOAD}" ]; then
+  printf '%s' "${HOOK_PAYLOAD}" | python3 "${SCRIPT_DIR}/actor_identity.py" pin --root "${PROJECT_ROOT}" >/dev/null 2>&1 || true
+fi
 
 python3 "${SCRIPT_DIR}/registry.py" set-active "${PROJECT_ROOT}" >/dev/null 2>&1 || true
 python3 "${SCRIPT_DIR}/dashboard.py" generate --root "${PROJECT_ROOT}" >/dev/null 2>&1 || true

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -86,6 +87,8 @@ _CONTROL_PLANE_EXACT = frozenset({
     "events.jsonl",
     "spawn-log.jsonl",
     "audit-grep-quota.json",
+    "role-grants.json",
+    "role-bindings.json",
 })
 
 _WRAPPER_REQUIRED = {
@@ -96,9 +99,13 @@ _WRAPPER_REQUIRED = {
     # pre_tool_use call. If an agent could write it directly, it could elevate
     # itself to audit-* and unlock audit-reports/ writes, which is exactly the
     # primitive the 2026-04-30 audit-chain forgery incident exploited. The
-    # stamp-role wrapper enforces an executor-role allowlist (audit-* roles
-    # cannot be stamped — auditors must come from a real Agent-tool spawn).
+    # stamp-role wrapper enforces a role allowlist; the real forgery defense
+    # for audit-* claims is the spawn-log cross-check at receipt time.
     "active-segment-role": "python3 hooks/ctl.py stamp-role <task_dir> --role <role>",
+    # role-grants.json is the per-actor grant ledger (D3). Same elevation
+    # primitive as active-segment-role: only the ctl wrapper may append
+    # grants, and the wrapper enforces the role allowlist.
+    "role-grants.json": "python3 hooks/ctl.py grant-role <task_dir> --role <role>",
 }
 
 
@@ -134,6 +141,17 @@ def is_control_plane_path(path: Path, task_dir: Path | None) -> bool:
 
 
 def allowed_globs_for_role(role: str, task_dir: Path | None) -> list[str]:
+    if role == "orchestrator":
+        return [
+            ".dynos/task-*/_scratch/**",
+            ".dynos/task-*/execution-log.md",
+            ".dynos/task-*/escalation.md",
+            ".dynos/task-*/audit-context.md",
+            ".dynos/task-*/raw-input.md",
+            ".dynos/task-*/discovery-notes.md",
+            ".dynos/task-*/design-decisions.md",
+            "repo files only during inline fast-track EXECUTION",
+        ]
     if _matches_role(role, "planning"):
         return [
             ".dynos/task-*/discovery-notes.md",
@@ -180,14 +198,172 @@ def allowed_globs_for_role(role: str, task_dir: Path | None) -> list[str]:
     return []
 
 
+# Device sinks: writing here persists nothing, so no boundary applies.
+# Skill steps legitimately use `2>/dev/null`; denying a sink only produces
+# noise and teaches users that denials are arbitrary.
+_DEVICE_SINKS = frozenset({"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"})
+
+# Roles that may use the task-scoped scratch namespace. _scratch/ is
+# deliberately excluded from every receipt, gate, and validator read path
+# (asserted by tests/test_scratch_namespace.py), so a scratch write can never
+# certify or forge anything — it is temp space inside the task boundary.
+_SCRATCH_ROLES = frozenset({
+    "orchestrator", "planning", "execute-inline", "repair-coordinator",
+})
+
+
+def _scratch_allowed_for(role: str) -> bool:
+    return (
+        role in _SCRATCH_ROLES
+        or role.endswith("-executor")
+        or role.startswith("audit-")
+    )
+
+
+# --- H1 self-modification guard (docs/permissions-on-design.md §D5-3) -------
+# Executor roles may write repo work artifacts anywhere, which historically
+# included the *installed plugin directory itself* — hooks.json, this file,
+# ctl.py. That is the "agent disables its own guardrails" primitive. Agent
+# roles are therefore denied writes under the plugin root and under the
+# host-level config locations that control hook execution.
+#
+# Developer mode: when the project being worked on IS the plugin source repo
+# (its root equals the plugin root and carries .claude-plugin/), plugin files
+# are ordinary repo files reviewed by the human like any other diff — the
+# guard stands down for the plugin-root check only.
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+# Roles that are deterministic framework code, not LLM tool calls.
+_FRAMEWORK_ROLES = frozenset({
+    "ctl", "scheduler", "eventbus", "system", "receipt-writer", "daemon",
+})
+
+
+def _protected_host_paths() -> tuple[Path, ...]:
+    home = Path.home()
+    return (
+        home / ".claude" / "plugins",
+        home / ".claude" / "settings.json",
+        home / ".claude" / "settings.local.json",
+        home / ".dynos",
+    )
+
+
+def _is_under(path: Path, prefix: Path) -> bool:
+    try:
+        path.relative_to(prefix)
+        return True
+    except ValueError:
+        return False
+
+
+def _self_modification_denial(attempt: WriteAttempt, path: Path) -> WriteDecision | None:
+    """Return a deny decision when an agent role targets guardrail-owning paths."""
+    if attempt.role in _FRAMEWORK_ROLES:
+        return None
+    if _is_under(path, _PLUGIN_ROOT):
+        if attempt.task_dir is not None:
+            project_root = attempt.task_dir.resolve().parent.parent
+            dev_mode = (
+                project_root == _PLUGIN_ROOT
+                and (project_root / ".claude-plugin").is_dir()
+            )
+        else:
+            # No active task: developer mode iff the plugin root is a source
+            # checkout (marketplace cache installs ship without .git).
+            dev_mode = (
+                (_PLUGIN_ROOT / ".claude-plugin").is_dir()
+                and (_PLUGIN_ROOT / ".git").exists()
+            )
+        if not dev_mode:
+            return WriteDecision(
+                False,
+                "plugin installation directory is not writable by task "
+                "agents (guardrail self-modification defense)",
+                "deny",
+            )
+        return None
+    for protected in _protected_host_paths():
+        if path == protected or _is_under(path, protected):
+            return WriteDecision(
+                False,
+                f"{protected} controls harness/hook execution and is not "
+                "writable by task agents (guardrail self-modification defense)",
+                "deny",
+            )
+    return None
+
+
+# Task-root files the orchestrator authors directly: logs, escalation notes,
+# the audit-context sidecar, the raw task input, and the discovery/design Q&A
+# records it appends user answers to. spec.md / plan.md / audit-reports /
+# evidence stay out — those belong to the planner, auditors, and executors.
+_ORCHESTRATOR_TASK_FILES = frozenset({
+    "execution-log.md",
+    "escalation.md",
+    "audit-context.md",
+    "raw-input.md",
+    "discovery-notes.md",
+    "design-decisions.md",
+})
+
+
+def _orchestrator_inline_execution_active(task_dir: Path | None) -> bool:
+    """True when the orchestrator may write repo files: inline fast-track
+    execution (single segment, no subagent spawn). Capability follows the
+    deterministic state machine — stage and fast_track are set exclusively
+    by ctl gates, never by the model."""
+    if task_dir is None:
+        return False
+    try:
+        manifest = json.loads((task_dir / "manifest.json").read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    return (
+        manifest.get("stage") in {"EXECUTION", "TEST_EXECUTION"}
+        and manifest.get("fast_track") is True
+    )
+
+
 def decide_write(attempt: WriteAttempt) -> WriteDecision:
     path = attempt.path.resolve()
+    if str(path) in _DEVICE_SINKS:
+        return WriteDecision(True, "device sink — not a persistence target", "direct")
+    self_mod = _self_modification_denial(attempt, path)
+    if self_mod is not None:
+        return self_mod
+    # The orchestrator-session pin is hook-owned identity state (D3): only
+    # the SessionStart hook subprocess writes it. If any agent role could
+    # rewrite or delete it, a session could re-pin itself or force the
+    # orchestrator into the grant-consuming subagent branch.
+    if path.name == "orchestrator-session.json" and path.parent.name == ".dynos":
+        return WriteDecision(
+            False,
+            "orchestrator-session.json is hook-owned actor identity; only "
+            "the SessionStart hook subprocess may write it",
+            "deny",
+        )
     if path.name == ".rules_corrupt" and path.parent.name == ".dynos":
         if attempt.role == "daemon":
             return WriteDecision(True, ".dynos/.rules_corrupt allowed for daemon role", "direct")
         return WriteDecision(False, ".dynos/.rules_corrupt is daemon-owned kill-switch state; agent writes denied", "deny")
     rel = _task_relative(path, attempt.task_dir)
     rel_posix = rel.as_posix() if rel is not None else None
+
+    # Task-scoped scratch namespace (D2 in docs/permissions-on-design.md):
+    # sanctioned temp space for any recognized actor role. Nothing in the
+    # control plane reads _scratch/, so these writes are proof-irrelevant.
+    if rel_posix is not None and (
+        rel_posix == "_scratch" or rel_posix.startswith("_scratch/")
+    ):
+        if _scratch_allowed_for(attempt.role):
+            return WriteDecision(True, "task scratch namespace", "direct")
+        return WriteDecision(
+            False,
+            f"_scratch/ is reserved for recognized task actor roles; "
+            f"role={attempt.role!r} is not one",
+            "deny",
+        )
 
     if rel_posix is not None and rel_posix in _WRAPPER_REQUIRED:
         if attempt.role == "ctl":
@@ -248,6 +424,18 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
             "deny",
         )
 
+    if rel_posix == "role-bindings.json":
+        # Session->role bindings are hook-owned (the pre_tool_use subprocess
+        # writes them via direct file I/O when a subagent's first tool call
+        # consumes a grant). If an agent could write this file it could bind
+        # its own session to an arbitrary granted role out of order.
+        return WriteDecision(
+            False,
+            "role-bindings.json is hook-owned actor identity; only the "
+            "pre-tool-use hook subprocess may write it",
+            "deny",
+        )
+
     if rel_posix == "web-tool-log.jsonl":
         # web-tool-log.jsonl is hook-owned. The web-tool-log hook subprocess
         # appends to it directly via Python file I/O (bypassing this policy
@@ -277,9 +465,27 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
             return WriteDecision(True, "audit report is auditor-owned evidence", "direct")
         return WriteDecision(False, "audit reports are reserved for auditor roles", "deny")
 
+    if rel_posix is not None and rel_posix.startswith("evidence/verification/"):
+        # Machine-captured verification evidence (D6): written ONLY by
+        # `ctl run-verification-evidence`. If executors could write here
+        # they could doctor the captured exit codes — the exact narrative-
+        # claim laundering this artifact exists to prevent.
+        if attempt.role == "ctl":
+            return WriteDecision(True, "verification evidence is ctl-captured", "direct")
+        return WriteDecision(
+            False,
+            "evidence/verification/ is machine-captured by "
+            "`ctl.py run-verification-evidence`; agent roles may not write it",
+            "deny",
+        )
+
     if rel_posix is not None and rel_posix.startswith("evidence/"):
         if attempt.role == "execute-inline" or attempt.role.endswith("-executor"):
             return WriteDecision(True, "evidence markdown is executor-owned", "direct")
+        if attempt.role == "orchestrator" and _orchestrator_inline_execution_active(attempt.task_dir):
+            # Inline fast-track execution: the orchestrator IS the executor
+            # for the single segment, so it writes that segment's evidence.
+            return WriteDecision(True, "inline fast-track evidence write", "direct")
         return WriteDecision(False, "evidence artifacts are reserved for executor roles", "deny")
 
     if rel_posix is None:
@@ -291,6 +497,24 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
         # write repo artifacts.
         if attempt.role == "execute-inline" or attempt.role.endswith("-executor"):
             return WriteDecision(True, "repo work artifact allowed for executor role", "direct")
+        if attempt.role == "orchestrator":
+            # The orchestrator only writes repo files itself during inline
+            # fast-track execution (no subagent spawn); otherwise repo work
+            # belongs to executor subagents.
+            if _orchestrator_inline_execution_active(attempt.task_dir):
+                return WriteDecision(
+                    True,
+                    "repo work artifact allowed for orchestrator during "
+                    "inline fast-track execution",
+                    "direct",
+                )
+            return WriteDecision(
+                False,
+                "orchestrator may not write repo files outside inline "
+                "fast-track execution; spawn an executor (after "
+                "`ctl.py grant-role`) or use the task _scratch/ dir",
+                "deny",
+            )
         if attempt.role in {"scheduler", "eventbus", "system"}:
             return WriteDecision(True, "non-task system path allowed", "direct")
         if attempt.task_dir is not None:
@@ -324,6 +548,16 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
 
     if attempt.role == "execute-inline" or attempt.role.endswith("-executor"):
         return WriteDecision(True, "repo work artifact allowed for executor role", "direct")
+    if attempt.role == "orchestrator":
+        if rel_posix in _ORCHESTRATOR_TASK_FILES:
+            return WriteDecision(True, f"{rel_posix} is orchestrator-owned coordination output", "direct")
+        return WriteDecision(
+            False,
+            f"orchestrator role may not write {rel_posix}; planner/auditor/"
+            "executor artifacts are written by their subagents, control-plane "
+            "files by ctl wrappers",
+            "deny",
+        )
     if attempt.role == "planning":
         if rel_posix in {"discovery-notes.md", "design-decisions.md", "design-doc.md", "spec.md", "plan.md"}:
             return WriteDecision(True, f"{rel_posix} is planner-owned judgment output", "direct")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
-  "version": "7.4.0",
-  "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
+  "version": "7.4.1",
+  "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone \u2014 no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",
   "hooks": "./hooks.json"

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -7,7 +7,19 @@ description: "Run checkpoint audit, repair any findings, then reach DONE — all
 
 Runs the full audit-to-done pipeline: audit → repair loop → DONE.
 
-All repair-log persistence must go through `python3 hooks/ctl.py write-repair-log ... --from ...`.
+## Command Funnel (applies to every command in this skill)
+
+Every deterministic step below runs through the plugin CLI. Resolve it once at the start of the skill and substitute the ABSOLUTE path literally into each command you run (permission prefix-matching operates on literal command text):
+
+```bash
+DYNOS="${CLAUDE_PLUGIN_ROOT}/bin/dynos"   # resolve once; use the absolute path in every command
+```
+
+`"$DYNOS" ctl <subcommand>` wraps `hooks/ctl.py`; `"$DYNOS" hook <script> ...` wraps helper scripts (router, lib_tokens, build_prompt_context, ...) with PYTHONPATH handled internally. A permissions-ON user can allow the single `<plugin-root>/bin/dynos` prefix once instead of approving every call.
+
+JSON payloads (classification, execution-graph, repair-log) are piped to the ctl wrapper over stdin with `--from -` and a heredoc — NEVER staged at `/tmp` or any raw filesystem path (the write policy denies those, by design). Temp files, when genuinely needed, belong in `.dynos/task-{id}/_scratch/`.
+
+All repair-log persistence must go through `"$DYNOS" ctl write-repair-log ... --from ...`.
 Do not hand-write `.dynos/task-{id}/repair-log.json`.
 
 ## Ruthlessness Standard
@@ -27,7 +39,7 @@ Do not hand-write `.dynos/task-{id}/repair-log.json`.
 After finding the active task, validate that all required inputs from the execute skill are present:
 
 ```text
-python3 hooks/ctl.py validate-contract --skill audit --task-dir .dynos/task-{id}
+"$DYNOS" ctl validate-contract --skill audit --task-dir .dynos/task-{id}
 ```
 
 If validation fails with missing required inputs (evidence files, snapshot SHA), print the errors and stop.
@@ -43,7 +55,7 @@ Verify stage is `CHECKPOINT_AUDIT`. If not, print the current stage and what com
 Build the deterministic audit setup first:
 
 ```text
-python3 hooks/ctl.py run-audit-setup .dynos/task-{id}
+"$DYNOS" ctl run-audit-setup .dynos/task-{id}
 ```
 
 This command reads `manifest.json`, derives the audit plan, writes `.dynos/task-{id}/audit-plan.json`, and computes diff scope from `snapshot.head_sha` (or `HEAD` fallback when needed). Use its JSON output directly. Do not hand-derive diff scope, task type, domains, fast-track, skip policy, or model selection in prompt logic.
@@ -70,7 +82,7 @@ For each auditor in the plan:
 
 ```bash
 AUDIT_CONTEXT_PATH=".dynos/task-{id}/audit-context.md"
-python3 "${PLUGIN_HOOKS}/build_prompt_context.py" --diff {diff_base} --root . --sidecar "$AUDIT_CONTEXT_PATH"
+"$DYNOS" hook build_prompt_context --diff {diff_base} --root . --sidecar "$AUDIT_CONTEXT_PATH"
 ```
 
 <!-- pre-resolved-context-start -->
@@ -90,7 +102,7 @@ Read calls are cheap and parallel (per auditor, per session); prompt input token
 **Parallelism note (task-20260430-011):** This sidecar pre-computation is per-auditor work, NOT a serial constraint between auditors. Issue all `router.py audit-inject-prompt` Bash commands in **a single message with multiple Bash tool calls** — they have no inter-dependencies and complete independently. Then issue the Agent-tool spawns themselves the same way: a single message with multiple Agent tool calls, one per spawned auditor. Sequential pre-step bash calls followed by sequential Agent calls is the slow path the latency investigation flagged; the harness already supports parallel tool calls in a single message and the pre-step has no ordering constraints. Wall-clock cost drops from `sum(per-auditor sidecar + spawn)` to `max(sidecar) + max(spawn)`.
 
 ```bash
-echo "{base prompt for this auditor}" | PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/router.py" audit-inject-prompt \
+echo "{base prompt for this auditor}" | "$DYNOS" hook router audit-inject-prompt \
   --root . \
   --task-type {task_type} \
   --audit-plan .dynos/task-{id}/audit-plan.json \
@@ -107,7 +119,7 @@ The auditor's final text message IS the envelope JSON (a single bare JSON line).
 ```bash
 INJECTED_AGENT_SHA256=$(cat .dynos/task-{id}/receipts/_injected-auditor-prompts/{auditor_name}-{model_used}.sha256)
 FINAL_ENVELOPE=$(... <extract last line of Agent tool return>)
-python3 hooks/ctl.py audit-receipt .dynos/task-{id} {auditor_name} \
+"$DYNOS" ctl audit-receipt .dynos/task-{id} {auditor_name} \
   --model {model_used} \
   --report-path .dynos/task-{id}/audit-reports/{report_filename}.json \
   --tokens-used {tokens_used} \
@@ -119,7 +131,7 @@ python3 hooks/ctl.py audit-receipt .dynos/task-{id} {auditor_name} \
 
 For `route_mode == "generic"` the `--final-envelope` argument may be omitted.
 
-`python3 hooks/ctl.py audit-receipt ...` calls `receipt_audit_done(...)`, which re-asserts the same sidecar exists at that exact path and that its contents match `injected_agent_sha256`. A mismatch raises `ValueError`. For `route_mode == "generic"` (no learned agent) the sidecar assertion is skipped and `injected_agent_sha256` may be `None`; `route_mode` and `agent_path` are still required keyword arguments. The wrapper derives counts from `--report-path`; when no report exists it writes literal zero findings only. The new `receipt_audit_routing` writer also enforces these fields per-entry, so any auditor entry missing `injected_agent_sha256` (when non-generic) or `agent_path` will hard-fail at the routing-receipt write.
+`"$DYNOS" ctl audit-receipt ...` calls `receipt_audit_done(...)`, which re-asserts the same sidecar exists at that exact path and that its contents match `injected_agent_sha256`. A mismatch raises `ValueError`. For `route_mode == "generic"` (no learned agent) the sidecar assertion is skipped and `injected_agent_sha256` may be `None`; `route_mode` and `agent_path` are still required keyword arguments. The wrapper derives counts from `--report-path`; when no report exists it writes literal zero findings only. The new `receipt_audit_routing` writer also enforces these fields per-entry, so any auditor entry missing `injected_agent_sha256` (when non-generic) or `agent_path` will hard-fail at the routing-receipt write.
 
 The router handles fast-track reduction, skip policy, model policy, security floor enforcement, ensemble voting triggers, and learned agent routing in deterministic code. No prompt interpretation needed for these decisions. Do not re-derive skip thresholds, model assignments, or routing modes from markdown tables or retrospective files.
 
@@ -145,7 +157,7 @@ Append to log (transition_task already auto-logged the `[STAGE] → CHECKPOINT_A
 **Role stamping (MANDATORY — BEFORE each Agent spawn):** Before each auditor's Agent tool invocation, stamp the role file via the deterministic ctl wrapper. The auditor subagent's `pre_tool_use.py` reads `active-segment-role` to resolve role; without this stamp the subagent runs as `execute-inline` and its `audit-reports/` writes are denied by `write_policy`. Issue all stamp-role Bash calls in a single message with multiple Bash tool uses (no inter-dependencies):
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "audit-{name-without-suffix}"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "audit-{name-without-suffix}"
 ```
 
 The role string strips the `-auditor` suffix from the agent file name: `spec-completion-auditor` → `audit-spec-completion`, `security-auditor` → `audit-security`, `claude-md-auditor` → `audit-claude-md`. The wrapper validates against an allowlist (`hooks/ctl.py::_STAMP_ROLE_ALLOWLIST`) and fails with exit 1 if the resolved string is unknown — a fail-fast guard that catches typos before the spawn.
@@ -157,12 +169,12 @@ When auditors run in parallel, the role file is overwritten on each stamp; this 
 Before issuing each parallel auditor batch (this includes the first batch AND every subsequent re-audit batch — the check runs once per spawn cycle, before EACH batch, not only the first), run:
 
 ```bash
-python3 hooks/ctl.py check-spawn-budget .dynos/task-{id}
+"$DYNOS" ctl check-spawn-budget .dynos/task-{id}
 ```
 
 Parse the JSON output. The command emits a single-line JSON object with keys `status`, `count`, `threshold`, `exempt_count`, and `task_class`. If `status` is `'paused'` or `'already_paused'`:
 
-1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the auditor count, the threshold, the `task_class`, and instruct the operator to run `python3 hooks/ctl.py spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
+1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the auditor count, the threshold, the `task_class`, and instruct the operator to run `"$DYNOS" ctl spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
 2. Append a line beginning with `[BUDGET-PAUSE]` to `execution-log.md` that records the timestamp, count, and threshold.
 3. Exit non-zero.
 
@@ -178,7 +190,7 @@ Each auditor writes its own report to `.dynos/task-{id}/audit-reports/{auditor}-
 
 **For LLM subagent spawns** (auditors, repair executors):
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+"$DYNOS" hook lib_tokens record \
   --task-dir .dynos/task-{id} \
   --agent "{agent_name}" \
   --model "{model_name}" \
@@ -192,7 +204,7 @@ PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens
 
 **For deterministic steps** (router decisions, retrospective computation, repair-log validation):
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+"$DYNOS" hook lib_tokens record \
   --task-dir .dynos/task-{id} \
   --agent "{tool_name}" \
   --model "none" \
@@ -222,7 +234,7 @@ Run this after EVERY event. The hook writes to `.dynos/task-{id}/token-usage.jso
 Decide whether audit proceeds to repair or reflect through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-findings-gate .dynos/task-{id}
+"$DYNOS" ctl run-audit-findings-gate .dynos/task-{id}
 ```
 
 Use the JSON output as authoritative:
@@ -240,7 +252,7 @@ This step runs only when blocking findings exist.
 Build the repair queue through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-repair-cycle-plan .dynos/task-{id}
+"$DYNOS" ctl run-audit-repair-cycle-plan .dynos/task-{id}
 ```
 
 Use this JSON output as authoritative:
@@ -262,7 +274,7 @@ Append to log:
 Build the repair log through ctl — Q-learning assignments are computed inside this command from `repair-cycle-plan.json`; do NOT construct or pipe a separate findings payload:
 
 ```text
-python3 "${PLUGIN_HOOKS}/ctl.py" run-repair-log-build .dynos/task-{id}
+"$DYNOS" ctl run-repair-log-build .dynos/task-{id}
 ```
 
 This command reads `repair-cycle-plan.json`, calls Q-learning itself, derives `files_to_modify`, writes `.dynos/task-{id}/repair-log.json`, and validates the result. Do NOT ask an LLM to draft `repair-log.json`.
@@ -270,7 +282,7 @@ This command reads `repair-cycle-plan.json`, calls Q-learning itself, derives `f
 Wait for completion, then finalize repair execution readiness through the control plane:
 
 ```text
-python3 "${PLUGIN_HOOKS}/ctl.py" run-repair-execution-ready .dynos/task-{id}
+"$DYNOS" ctl run-repair-execution-ready .dynos/task-{id}
 ```
 
 This command validates `repair-log.json` and advances `REPAIR_PLANNING -> REPAIR_EXECUTION`. Use its JSON output directly.
@@ -278,7 +290,7 @@ This command validates `repair-log.json` and advances `REPAIR_PLANNING -> REPAIR
 Build the repair execution groups through ctl:
 
 ```text
-python3 "${PLUGIN_HOOKS}/ctl.py" run-repair-batch-plan .dynos/task-{id}
+"$DYNOS" ctl run-repair-batch-plan .dynos/task-{id}
 ```
 
 Use this JSON output as authoritative:
@@ -304,7 +316,7 @@ After all batches complete, append to log:
 **Phase 1 re-audit (domain-aware, incremental scope):** Build the re-audit plan through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-reaudit-plan .dynos/task-{id}
+"$DYNOS" ctl run-audit-reaudit-plan .dynos/task-{id}
 ```
 
 Use its JSON output as authoritative:
@@ -320,7 +332,7 @@ After re-audit, run `run-audit-findings-gate` again.
 Update Q-learning outcomes through ctl:
 
 ```text
-python3 "${PLUGIN_HOOKS}/ctl.py" run-repair-q-update .dynos/task-{id}
+"$DYNOS" ctl run-repair-q-update .dynos/task-{id}
 ```
 
 This command derives outcomes from `repair-log.json` plus the current blocking audit findings and updates the Q-tables deterministically. Do NOT build `outcomes` JSON by hand.
@@ -329,7 +341,7 @@ This command derives outcomes from `repair-log.json` plus the current blocking a
 - If `status == "repair_required"`: let the control plane decide whether another repair cycle is legal:
 
   ```text
-  python3 "${PLUGIN_HOOKS}/ctl.py" run-repair-retry .dynos/task-{id}
+  "$DYNOS" ctl run-repair-retry .dynos/task-{id}
   ```
 
   Interpret the JSON result:
@@ -341,7 +353,7 @@ This command derives outcomes from `repair-log.json` plus the current blocking a
 Write the deterministic audit summary:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-summary .dynos/task-{id}
+"$DYNOS" ctl run-audit-summary .dynos/task-{id}
 ```
 
 This command writes `audit-summary.json` from the on-disk audit reports. Do not aggregate counts by hand.
@@ -351,7 +363,7 @@ This command writes `audit-summary.json` from the on-disk audit reports. Do not 
 Generate the retrospective through the control plane:
 
 ```text
-python3 hooks/ctl.py run-audit-reflect .dynos/task-{id}
+"$DYNOS" ctl run-audit-reflect .dynos/task-{id}
 ```
 
 This command computes `task-retrospective.json` and writes the `retrospective` receipt deterministically. Use its JSON output directly.
@@ -368,7 +380,7 @@ Append to log:
 **Deterministic Postmortem (Step 5a):** Generate the deterministic postmortem report before the LLM analysis so the LLM has access to anomaly detection, recurring patterns, and similar task comparisons.
 
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/postmortem.py" generate --root . --task-id {task-id}
+"$DYNOS" hook postmortem generate --root . --task-id {task-id}
 ```
 
 `memory/postmortem.py:generate_postmortem` (called by `postmortem.py generate`) now writes its own receipt internally as part of the same call. You do NOT need to write a receipt from this skill:
@@ -386,14 +398,14 @@ This writes `postmortems/{task-id}.json` and `postmortems/{task-id}.md` to the p
 
 1. Build the analysis prompt:
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/postmortem_analysis.py" build-prompt .dynos/task-{id}
+"$DYNOS" hook postmortem_analysis build-prompt .dynos/task-{id}
 ```
 
 2. If the result has `"has_findings": true`, spawn an **opus** agent with the prompt from the `"prompt"` field. Instruct the agent to respond with ONLY the JSON object described in the prompt — no markdown, no explanation.
 
 3. Parse the agent's JSON response and apply it:
 ```bash
-echo '${AGENT_JSON_OUTPUT}' | PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/postmortem_analysis.py" apply .dynos/task-{id}
+echo '${AGENT_JSON_OUTPUT}' | "$DYNOS" hook postmortem_analysis apply .dynos/task-{id}
 ```
 
 This writes `postmortem-analysis.json` to the task dir and merges new prevention rules into `prevention-rules.json`. These rules are automatically included in `project_rules.md` by the policy engine on the next task.
@@ -419,7 +431,7 @@ If `has_findings` is false, skip this step and append:
 Finalize completion through ctl:
 
 ```text
-python3 "${PLUGIN_HOOKS}/ctl.py" run-audit-finish .dynos/task-{id}
+"$DYNOS" ctl run-audit-finish .dynos/task-{id}
 ```
 
 This command writes `completion.json` and advances `CHECKPOINT_AUDIT|FINAL_AUDIT -> DONE` deterministically. Do NOT call `transition_task(...)` directly from prompt logic.

--- a/skills/dry-run/SKILL.md
+++ b/skills/dry-run/SKILL.md
@@ -107,9 +107,9 @@ Result: PASS (or FAIL if any required field is missing/mismatched)
 If an active or completed task exists in `.dynos/`, run the runtime contract validator against it to verify real artifacts match the declared contracts:
 
 ```text
-python3 hooks/ctl.py validate-contract --skill start --task-dir .dynos/task-{id} --direction both --strict
-python3 hooks/ctl.py validate-contract --skill execute --task-dir .dynos/task-{id} --direction both --strict
-python3 hooks/ctl.py validate-contract --skill audit --task-dir .dynos/task-{id} --direction both --strict
+"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl validate-contract --skill start --task-dir .dynos/task-{id} --direction both --strict
+"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl validate-contract --skill execute --task-dir .dynos/task-{id} --direction both --strict
+"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl validate-contract --skill audit --task-dir .dynos/task-{id} --direction both --strict
 ```
 
 Report any mismatches between declared contracts and actual artifacts. This catches drift between what contracts promise and what skills actually produce.

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -7,6 +7,18 @@ description: "Execute the approved plan. Orchestrates execution graph segments t
 
 Manages the parallel execution of the implementation plan via the execution graph. Handles dependency ordering, executor spawning, and final integration.
 
+## Command Funnel (applies to every command in this skill)
+
+Every deterministic step below runs through the plugin CLI. Resolve it once at the start of the skill and substitute the ABSOLUTE path literally into each command you run (permission prefix-matching operates on literal command text):
+
+```bash
+DYNOS="${CLAUDE_PLUGIN_ROOT}/bin/dynos"   # resolve once; use the absolute path in every command
+```
+
+`"$DYNOS" ctl <subcommand>` wraps `hooks/ctl.py`; `"$DYNOS" hook <script> ...` wraps helper scripts (router, lib_tokens, build_prompt_context, ...) with PYTHONPATH handled internally. A permissions-ON user can allow the single `<plugin-root>/bin/dynos` prefix once instead of approving every call.
+
+JSON payloads (classification, execution-graph, repair-log) are piped to the ctl wrapper over stdin with `--from -` and a heredoc — NEVER staged at `/tmp` or any raw filesystem path (the write policy denies those, by design). Temp files, when genuinely needed, belong in `.dynos/task-{id}/_scratch/`.
+
 ## Ruthlessness Standard
 
 - No silent shortcuts.
@@ -23,7 +35,7 @@ Manages the parallel execution of the implementation plan via the execution grap
 Validate that all required inputs from the start skill are present:
 
 ```text
-python3 hooks/ctl.py validate-contract --skill execute --task-dir .dynos/task-{id}
+"$DYNOS" ctl validate-contract --skill execute --task-dir .dynos/task-{id}
 ```
 
 If validation fails with missing required inputs, print the errors and stop. Do not proceed with execution.
@@ -41,7 +53,7 @@ Before any modification starts:
    ```
 2. Record the snapshot SHA into manifest.snapshot via the audited ctl wrapper:
    ```
-   python3 hooks/ctl.py record-snapshot .dynos/task-{id}
+   "$DYNOS" ctl record-snapshot .dynos/task-{id}
    ```
    The command auto-detects HEAD SHA and branch from git. It accepts optional
    `--head-sha SHA` and `--branch NAME` to override. Stage gate refuses anything
@@ -58,7 +70,7 @@ Read the printed JSON for `head_sha` and `branch`. Append to log:
 Run deterministic execute setup first:
 
 ```text
-python3 hooks/ctl.py run-execute-setup .dynos/task-{id}
+"$DYNOS" ctl run-execute-setup .dynos/task-{id}
 ```
 
 This command runs execution preflight validation, advances `PRE_EXECUTION_SNAPSHOT -> EXECUTION`, builds the executor plan, and writes the `executor-routing` receipt. Use its JSON output directly.
@@ -78,7 +90,7 @@ If any segment has route_mode in {replace, alongside} with non-null agent_path, 
 
 **Inline execution procedure (only when the decision table row says `inline`):** Inline execution skips the executor subagent entirely and runs the segment in this thread. This avoids the ~30K token overhead of agent context setup, but it does NOT relax any other rule. Even in the inline branch, you MUST still run the router, write the executor-routing receipt, and apply the prompt-injection/prevention pipeline to your own work:
 
-1. Run the executor plan router: `python3 "${PLUGIN_HOOKS}/router.py" executor-plan --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json`
+1. Run the executor plan router: `"$DYNOS" hook router executor-plan --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json`
 2. Write the executor-routing receipt (required for stage transitions).
 3. Re-verify the decision table row. If the router's response contains any segment with `route_mode` in `{"replace", "alongside"}` with a non-null `agent_path`, STOP — the inline branch is FORBIDDEN for this task. Fall through to the spawn path below.
 4. Run `inject-prompt` with your base prompt to get the complete prompt with prevention rules. Apply those rules to your own work.
@@ -86,7 +98,7 @@ If any segment has route_mode in {replace, alongside} with non-null agent_path, 
 6. **Transition the manifest stage `PRE_EXECUTION_SNAPSHOT → EXECUTION`** (mandatory — without this the Step 4 transition to `TEST_EXECUTION` is illegal per `ALLOWED_STAGE_TRANSITIONS`). `transition_task` auto-appends the `[STAGE] → EXECUTION` log line; do not write it manually:
 
 ```text
-python3 hooks/ctl.py transition .dynos/task-{id} EXECUTION
+"$DYNOS" ctl transition .dynos/task-{id} EXECUTION
 ```
 
 Then read the segment, extract the criteria from `spec.md`, make the code changes yourself, write evidence, and proceed to Step 4. Log: `{timestamp} [INLINE] seg-1 — fast-track inline execution (no subagent spawn)`.
@@ -102,7 +114,7 @@ Skipping the router in inline mode silently ignores learned agents and breaks th
 Immediately compute the authoritative execution schedule:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-execution-batch-plan .dynos/task-{id}
+"$DYNOS" ctl run-execution-batch-plan .dynos/task-{id}
 ```
 
 This command is authoritative for:
@@ -126,7 +138,7 @@ Do NOT read project_rules.md tables manually. The router handles model policy, a
 **Learned Agent Injection (MANDATORY — NOT OPTIONAL):** For every segment, you MUST build the executor prompt using the deterministic prompt builder. This is not a suggestion. This is an enforcement gate. For each segment in the executor plan:
 
 ```bash
-echo "{your base prompt for this segment}" | PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 hooks/router.py inject-prompt --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json --segment-id {seg-id}
+echo "{your base prompt for this segment}" | "$DYNOS" hook router inject-prompt --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json --segment-id {seg-id}
 ```
 
 This command:
@@ -140,7 +152,7 @@ This command:
 **Routing cache (automatic — no extra steps):** `executor-plan` writes its result to `.dynos/task-{id}/router-cache/executor-plan.json` keyed by a fingerprint over every input that drives the plan (graph, policy, effectiveness scores, retrospectives, learned registry, benchmark history, prevention rules). Each `inject-prompt` call checks this cache first; on a fingerprint match it reuses the cached entry instead of re-deriving routing. This guarantees the model the executor was spawned under matches the model the prompt was injected for, even with epsilon-greedy exploration enabled. Cache lookups emit a `router_cache_lookup` event with `status: hit | fingerprint_drift | stale_segment`. Inspect freshness with:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/router.py" router-cache-status --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json
+"$DYNOS" hook router router-cache-status --root . --task-type {task_type} --graph .dynos/task-{id}/execution-graph.json
 ```
 
 If status is `stale`, re-run `executor-plan` before continuing inject-prompt calls — otherwise per-segment routing will silently fall back to live builds.
@@ -161,10 +173,10 @@ If the injected prompt is weak, strengthen the base prompt before spawning. Do n
 
 If `inject-prompt` fails or is unavailable, stop and fix the deterministic routing path. Do NOT manually read `agent_path` or hand-build the learned-agent prompt.
 
-**Role stamping (MANDATORY — BEFORE every Agent tool spawn):** Stamp the executor role via the deterministic ctl wrapper immediately before spawning each executor subagent. The wrapper enforces the executor-role allowlist (audit-* roles cannot be stamped — auditors run as subagents whose role is established at spawn time, not via orchestrator-stamped role files; this closes the self-elevation primitive behind the 2026-04-30 audit-chain forgery incident). Direct writes to `active-segment-role` are denied by `write_policy.py` and surface a wrapper hint to the model.
+**Role granting (MANDATORY — BEFORE every Agent tool spawn):** Grant the executor role via the deterministic ctl wrapper immediately before spawning each executor subagent. The wrapper enforces the role allowlist; the grant is single-use and is consumed by the spawned subagent's first tool call (the orchestrator's own session is pinned at SessionStart and can never consume a grant — that closes the role-leak behind the 2026-04-30 audit-chain forgery incident; the audit-* forgery defense itself is the spawn-log cross-check at receipt time). Direct writes to `active-segment-role`, `role-grants.json`, or `role-bindings.json` are denied by `write_policy.py` and surface a wrapper hint.
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "{executor-role}"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "{executor-role}"
 ```
 
 Where `{executor-role}` is the exact role string from the executor plan (e.g. `backend-executor`, `ui-executor`, `integration-executor`). The write MUST complete (exit 0) before the Agent tool invocation that spawns the subagent — this is a sequential constraint, not a timing one. Exit 1 means the wrapper refused; the stderr names the cause (audit-* refusal, role outside allowlist, missing task dir).
@@ -178,12 +190,12 @@ Where `{executor-role}` is the exact role string from the executor plan (e.g. `b
 Before issuing each parallel next_batch executor batch (this includes the first batch AND every subsequent next_batch — the check runs once per spawn cycle, before EACH batch, not only the first), run:
 
 ```bash
-python3 hooks/ctl.py check-spawn-budget .dynos/task-{id}
+"$DYNOS" ctl check-spawn-budget .dynos/task-{id}
 ```
 
 Parse the JSON output. The command emits a single-line JSON object with keys `status`, `count`, `threshold`, `exempt_count`, and `task_class`. If `status` is `'paused'` or `'already_paused'`:
 
-1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the executor count, the threshold, the `task_class`, and instruct the operator to run `python3 hooks/ctl.py spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
+1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the executor count, the threshold, the `task_class`, and instruct the operator to run `"$DYNOS" ctl spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
 2. Append a line beginning with `[BUDGET-PAUSE]` to `execution-log.md` that records the timestamp, count, and threshold.
 3. Exit non-zero.
 
@@ -202,7 +214,7 @@ The base prompt for each executor (before inject-prompt) must include:
 5. **Pre-loaded file contents (MANDATORY):** Run the context builder for each file in the segment's `files_expected` and append its output to the base prompt:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/build_prompt_context.py" --root . {files_expected_1} {files_expected_2} ...
+"$DYNOS" hook build_prompt_context --root . {files_expected_1} {files_expected_2} ...
 ```
 
 Append the printed output verbatim to the base prompt. This gives the executor the current file contents upfront so it does not need to call Read at the start, keeping the context window small. If a file does not exist yet (new file), the script emits a placeholder — include it anyway so the executor knows the file is new.
@@ -212,7 +224,7 @@ Do NOT pass the full `spec.md` or `plan.md` to executors.
 **Segment finalization (MANDATORY):** After each executor completes, finalize the segment through ctl instead of hand-writing receipt / ownership / manifest logic:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-execution-segment-done \
+"$DYNOS" ctl run-execution-segment-done \
   .dynos/task-{id} \
   "{seg-id}" \
   --injected-prompt-sha256 "{INJECTED_PROMPT_SHA256 captured from sidecar}" \
@@ -229,10 +241,10 @@ This command deterministically:
 - writes `receipt_executor_done(...)`
 - updates `manifest.json.execution_progress` from deterministic execution state
 
-**Role file cleanup (MANDATORY — AFTER `run-execution-segment-done` writes the receipt):** Delete `.dynos/task-{id}/active-segment-role` immediately after the segment receipt is written. This prevents the completed segment's role from leaking into any subsequent segment's execution context. (Deletion is permitted by write_policy as a benign cleanup; only the *write* path is wrapper-required.)
+**Role cleanup (MANDATORY — AFTER `run-execution-segment-done` writes the receipt):** Clear unconsumed role grants immediately after the segment receipt is written. This prevents a stale grant from leaking into any subsequent segment's spawn. Do NOT `rm` the role file by hand — `active-segment-role` is wrapper-required and the deletion is denied by write_policy; `clear-role` is the sanctioned (privilege-reducing) path:
 
 ```bash
-rm -f .dynos/task-{id}/active-segment-role
+"$DYNOS" ctl clear-role .dynos/task-{id}
 ```
 
 After each batch (or cached resolution) completes, record events and verify:
@@ -246,7 +258,7 @@ After each batch (or cached resolution) completes, record events and verify:
   and remain the orchestrator's responsibility.)
 - **Token capture (deterministic checks):** After file ownership and evidence verification:
   ```bash
-  PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+  "$DYNOS" hook lib_tokens record \
     --task-dir .dynos/task-{id} \
     --agent "ctl-check-ownership" \
     --model "none" \
@@ -260,7 +272,7 @@ After each batch (or cached resolution) completes, record events and verify:
   ```
 - Also record the **router decision** before each batch:
   ```bash
-  PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+  "$DYNOS" hook lib_tokens record \
     --task-dir .dynos/task-{id} \
     --agent "router-executor-plan" \
     --model "none" \
@@ -277,7 +289,7 @@ After each batch (or cached resolution) completes, record events and verify:
 
 **For inline fast-track execution** (no subagent spawn), record with `--type inline`:
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+"$DYNOS" hook lib_tokens record \
   --task-dir .dynos/task-{id} \
   --agent "inline-executor" \
   --model "none" \
@@ -295,10 +307,10 @@ PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens
 When `run-execution-batch-plan` reports no pending segments, advance through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-execution-finish .dynos/task-{id}
+"$DYNOS" ctl run-execution-finish .dynos/task-{id}
 ```
 
-This command refuses the transition if any segment is still pending. Do not manually decide that execution is complete.
+This command refuses the transition if any segment is still pending, AND it runs the full evidence verification (non-empty `evidence/{seg-id}.md` per segment, every `files_expected` entry on disk) inside the stage gate before advancing to `TEST_EXECUTION`. If it reports `"status": "blocked"` with `failures`, address each listed failure and re-run. Do not manually decide that execution is complete.
 
 ### Step 4 — Run tests
 
@@ -317,13 +329,13 @@ If tests fail:
 
 ### Step 5 — Verify completion
 
-After successfully completing execution and tests (and any repairs triggered by tests or audit), run the deterministic evidence verifier:
+After successfully completing execution and tests (and any repairs triggered by tests or audit), re-run the deterministic evidence verifier as confirmation:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-execution-verify-evidence .dynos/task-{id}
+"$DYNOS" ctl run-execution-verify-evidence .dynos/task-{id}
 ```
 
-This command checks every non-cached segment's evidence file exists and is non-empty, and that every `files_expected` entry exists on disk. It exits non-zero with a JSON error payload if any check fails. **Do NOT assert completion in prompt logic — consume this command's output as the authoritative pass/fail signal.**
+This command checks every non-cached segment's evidence file exists and is non-empty, and that every `files_expected` entry exists on disk. It is legal at both `EXECUTION` and `TEST_EXECUTION` (the same verification already ran inside the `run-execution-finish` stage gate in Step 3 — this re-run confirms nothing regressed during test execution). It exits non-zero with a JSON error payload if any check fails. **Do NOT assert completion in prompt logic — consume this command's output as the authoritative pass/fail signal.**
 
 If the command reports `"status": "blocked"`, address each listed failure before proceeding.
 
@@ -337,7 +349,7 @@ Append to log:
 After Step 5, run:
 
 ```text
-python3 hooks/ctl.py write-execute-handoff .dynos/task-{id}
+"$DYNOS" ctl write-execute-handoff .dynos/task-{id}
 ```
 
 This writes `.dynos/task-{id}/handoff-execute-audit.json` deterministically from the live manifest stage. Do NOT hand-write the handoff JSON in prompt logic.

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -5,7 +5,7 @@ description: "Deep bug investigation. Pass a short description of the problem �
 
 # dynos-work: investigate
 
-Runs a deterministic-first investigation pipeline: triage first, reasoning second, citation validation third. The LLM never gathers evidence on its own — it reasons over a pre-built dossier.
+Runs a deterministic-first investigation pipeline: triage first, reasoning second, citation validation third. The LLM never gathers evidence on its own — it reasons over a pre-built dossier, and that guarantee is enforced in code: the investigator role's Read access is restricted to the investigations directory and its Grep/Glob calls are denied by the pre-tool-use hook.
 
 ## Ruthlessness Standard
 
@@ -15,33 +15,42 @@ Runs a deterministic-first investigation pipeline: triage first, reasoning secon
 
 ## Phase 1 — Deterministic Evidence Gathering
 
-Run the triage orchestrator before invoking the LLM:
+Create an investigation directory inside the project's `.dynos/` (never `/tmp` — the write policy denies it), then run the triage orchestrator before invoking the LLM:
 
 ```bash
-python3 debug-module/triage.py --bug "<bug text>" --repo <repo_path> --out /tmp/dossier.json
+INVESTIGATION_DIR=".dynos/investigations/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$INVESTIGATION_DIR"
+python3 "${CLAUDE_PLUGIN_ROOT}/debug-module/triage.py" --bug "<bug text>" --repo . --out "$INVESTIGATION_DIR/dossier.json"
 ```
 
-This produces an evidence dossier at `/tmp/dossier.json` with pre-minted evidence IDs (`F-001` for files, `S-001` for symbols, etc.), git blame, linter findings, and Semgrep silent-accomplice findings. The LLM does not gather evidence — it reasons over what triage has already found.
+This produces an evidence dossier with pre-minted evidence IDs (`F-001` for files, `S-001` for symbols, etc.), git blame, linter findings, and Semgrep silent-accomplice findings. The LLM does not gather evidence — it reasons over what triage has already found.
 
 ## Phase 2 — Causal Reasoning
 
-Spawn the `@investigator` subagent with the dossier path. Pass the contents of `/tmp/dossier.json` as input and instruct the agent to:
+If a task dir exists, grant the investigator role before the spawn (enforces dossier-only reads in the hook): `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/ctl.py" grant-role .dynos/task-{id} --role investigator`. Standalone investigations (no task) skip this.
+
+Spawn the `@investigator` subagent. Pass the contents of `$INVESTIGATION_DIR/dossier.json` as input and instruct the agent to:
 
 - Trace root cause, immediate cause, and detection failure.
 - Cite only evidence IDs that exist in the dossier.
-- Write its structured JSON output to `/tmp/bug_report.json`.
+- **Return the structured bug-report JSON as its final message** — a single JSON object matching `debug-module/schemas/bug_report.schema.json`, no prose, no markdown fences. The investigator is read-only (`tools: [Read, Grep]`); it must NOT attempt to write any file.
 
 The agent must not invent file paths, symbols, or findings outside the dossier.
 
-## Phase 3 — Citation Validation and Markdown Render
+## Phase 3 — Validation, Persistence, and Render
 
-Validate citations and render the final report:
+Pipe the agent's returned JSON into the deterministic finalize step. It validates the report structure (every claim must carry non-empty `evidence_ids`), mechanically verifies every cited evidence ID exists in the dossier, renders the Markdown via `debug-module/lib/render_report.py` (`render_report.render`), and persists `bug_report.json` + the rendered `report.md` — rejection exits non-zero and nothing is persisted:
 
 ```bash
-python3 debug-module/lib/render_report.py --report /tmp/bug_report.json --dossier /tmp/dossier.json
+python3 "${CLAUDE_PLUGIN_ROOT}/debug-module/triage.py" finalize \
+  --report - \
+  --dossier "$INVESTIGATION_DIR/dossier.json" <<'REPORT_JSON'
+{ ...the investigator's returned JSON, verbatim... }
+REPORT_JSON
 ```
 
-`render_report.py` mechanically verifies every `evidence_ids[]` reference in `bug_report.json` exists in the dossier and renders the final Markdown. Any citation pointing to a non-existent ID surfaces as a visible WARNING in the output.
+- Exit 0: print the rendered `report.md` content to the user.
+- Exit 1 (rejected — structural violation or unknown citation): the stderr names each violation. Re-spawn the investigator ONCE with the violations appended to its prompt; if the second attempt is also rejected, report the failure honestly. Do NOT edit the report JSON yourself to make validation pass — fabricating or trimming citations defeats the entire evidence chain.
 
 ## Usage
 
@@ -54,4 +63,5 @@ Examples:
 /dynos-work:investigate TypeError: Cannot read properties of undefined reading 'id' at UserService.ts:47
 /dynos-work:investigate the checkout flow always skips the discount calculation when coupon code is applied
 /dynos-work:investigate test suite: AuthController > login > should return 401 on invalid password is failing
+/dynos-work:investigate the GitHub Actions workflow fails on main but tests pass locally
 ```

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -5,6 +5,19 @@ description: "Internal dynos-work skill. Re-run planning on an existing task. Us
 
 # dynos-work: Plan
 
+
+## Command Funnel (applies to every command in this skill)
+
+Every deterministic step below runs through the plugin CLI. Resolve it once at the start of the skill and substitute the ABSOLUTE path literally into each command you run (permission prefix-matching operates on literal command text):
+
+```bash
+DYNOS="${CLAUDE_PLUGIN_ROOT}/bin/dynos"   # resolve once; use the absolute path in every command
+```
+
+`"$DYNOS" ctl <subcommand>` wraps `hooks/ctl.py`; `"$DYNOS" hook <script> ...` wraps helper scripts (router, lib_tokens, build_prompt_context, ...) with PYTHONPATH handled internally. A permissions-ON user can allow the single `<plugin-root>/bin/dynos` prefix once instead of approving every call.
+
+JSON payloads (classification, execution-graph, repair-log) are piped to the ctl wrapper over stdin with `--from -` and a heredoc — NEVER staged at `/tmp` or any raw filesystem path (the write policy denies those, by design). Temp files, when genuinely needed, belong in `.dynos/task-{id}/_scratch/`.
+
 Re-runs the planning phase on an existing task. Use this when:
 - You need to regenerate the plan after manual spec changes
 - The task was initialized externally and skipped planning
@@ -33,7 +46,7 @@ Verify `spec.md` exists. If not, print "No spec found. Run /dynos-work:start to 
 Transition the stage by running:
 
 ```text
-python3 hooks/ctl.py transition .dynos/task-{id} PLANNING
+"$DYNOS" ctl transition .dynos/task-{id} PLANNING
 ```
 
 Append to execution log (transition_task already auto-logged the `[STAGE] → PLANNING` line; only emit the `[SPAWN]` line):
@@ -41,12 +54,12 @@ Append to execution log (transition_task already auto-logged the `[STAGE] → PL
 {timestamp} [SPAWN] planning — generate implementation plan
 ```
 
-Spawn the `planning` agent with instruction: "Generate the implementation plan and execution graph. Read `spec.md`, `design-decisions.md` (if it exists), and `design-doc.md` (if it exists — §11 lists the intended segment shape your execution graph must match). Human design choices are binding. Write `plan.md` directly to `.dynos/task-{id}/plan.md`. For the execution graph, write the JSON payload to `/tmp/execution-graph-{id}.json`, then persist the final `.dynos/task-{id}/execution-graph.json` ONLY via `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`. Include: technical approach, module/component breakdown, data flow, error handling, failure modes, rollback or migration risk where relevant, test strategy, and explicit file ownership per segment. Do not leave any acceptance criterion covered only by implication. Do not hand-write `.dynos/task-{id}/execution-graph.json`."
+Spawn the `planning` agent with instruction: "Generate the implementation plan and execution graph. Read `spec.md`, `design-decisions.md` (if it exists), and `design-doc.md` (if it exists — §11 lists the intended segment shape your execution graph must match). Human design choices are binding. Write `plan.md` directly to `.dynos/task-{id}/plan.md`. For the execution graph, persist the final `.dynos/task-{id}/execution-graph.json` ONLY via `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl write-execution-graph .dynos/task-{id} --from -`, piping the JSON payload over stdin with a heredoc (never stage it at /tmp or any raw path). Include: technical approach, module/component breakdown, data flow, error handling, failure modes, rollback or migration risk where relevant, test strategy, and explicit file ownership per segment. Do not leave any acceptance criterion covered only by implication. Do not hand-write `.dynos/task-{id}/execution-graph.json`."
 
 Wait for completion. Finalize planning through the deterministic control-plane entrypoint. Run:
 
 ```text
-python3 hooks/ctl.py run-planning .dynos/task-{id}
+"$DYNOS" ctl run-planning .dynos/task-{id}
 ```
 
 `run-planning` owns full deterministic artifact validation, writes the `plan-validated` receipt, and advances `PLANNING -> PLAN_REVIEW` when the artifacts are sound. If it exits non-zero, the JSON payload tells you exactly why replanning is required.
@@ -72,12 +85,12 @@ Approve this plan? (yes / no + what to change)
 - If **approved**: run the `approve-stage` ctl command below. It hashes the current `plan.md`, writes the `human-approval-PLAN_REVIEW` receipt with that hash, then transitions PLAN_REVIEW → PLAN_AUDIT in one atomic step. The hash is computed from the CURRENT `plan.md` content **at transition time** (the `transition_task` gate re-hashes the file and compares it to `receipt.artifact_sha256`), so an approval that races against a manual edit to `plan.md` after the receipt is written will be refused with the literal substrings `human-approval-PLAN_REVIEW` and `hash mismatch`. Do NOT add a manual `[HUMAN]` log line — the receipt is the audit trail. Then proceed to Step 4.
 
   ```text
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW
+  "$DYNOS" ctl approve-stage .dynos/task-{id} PLAN_REVIEW
   ```
 
   Exit code 0 means success; exit code 1 means the gate refused (stderr identifies the cause: missing artifact, hash drift, illegal transition). Do not bypass with `transition --force`.
 - If **changes requested**: append `{timestamp} [HUMAN] PLAN_REVIEW — changes requested: {summary}` to log. Spawn planning agent again with the feedback. Re-present the updated plan. Repeat until approved. Do NOT call `approve-stage` against a stale plan — the next time you call it, the live `plan.md` content (and therefore its hash) MUST match the version the user just approved, otherwise the transition will be refused.
-- If **rejected**: run `python3 hooks/ctl.py transition .dynos/task-{id} FAILED`, append `[FAILED] Plan rejected by user`. Stop. Do not edit `manifest.json` directly.
+- If **rejected**: run `"$DYNOS" ctl transition .dynos/task-{id} FAILED`, append `[FAILED] Plan rejected by user`. Stop. Do not edit `manifest.json` directly.
 
 ### Step 4 — Spec coverage audit (PLAN_AUDIT)
 
@@ -86,7 +99,7 @@ The `approve-stage` call in Step 3 has already advanced the manifest to `PLAN_AU
 Run the deterministic plan-audit controller first:
 
 ```text
-python3 hooks/ctl.py run-plan-audit .dynos/task-{id}
+"$DYNOS" ctl run-plan-audit .dynos/task-{id}
 ```
 
 Interpret the JSON result:
@@ -96,7 +109,7 @@ Interpret the JSON result:
 - `status == "llm_audit_required"`: high/critical-risk task. Spawn `spec-completion-auditor`, then finalize with:
 
   ```text
-  python3 hooks/ctl.py run-plan-audit .dynos/task-{id} --report-path .dynos/task-{id}/audit-reports/plan-audit-{timestamp}.json --tokens-used {TOTAL_TOKENS} --model {MODEL_USED}
+  "$DYNOS" ctl run-plan-audit .dynos/task-{id} --report-path .dynos/task-{id}/audit-reports/plan-audit-{timestamp}.json --tokens-used {TOTAL_TOKENS} --model {MODEL_USED}
   ```
 
 If the final `run-plan-audit` call returns `status == "replan_required"`, repair the plan and rerun it. If it returns `status == "passed"`, proceed.
@@ -106,7 +119,7 @@ If the final `run-plan-audit` call returns `status == "replan_required"`, repair
 Transition the stage by running:
 
 ```text
-python3 hooks/ctl.py transition .dynos/task-{id} PRE_EXECUTION_SNAPSHOT
+"$DYNOS" ctl transition .dynos/task-{id} PRE_EXECUTION_SNAPSHOT
 ```
 
 Append to log:

--- a/skills/residual/SKILL.md
+++ b/skills/residual/SKILL.md
@@ -224,7 +224,7 @@ that case fall through to the normal human-approval path (the gates
 were not enabled, but the residual still runs).
 
 ```bash
-python3 hooks/ctl.py set-auto-approve-gates \
+"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl set-auto-approve-gates \
   --task-dir .dynos/task-{new_id} \
   --from-residual-id {row["id"]}
 ```

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -15,7 +15,7 @@ Resume a dynos-work task that was interrupted.
 
 ## What you do
 
-1. List all tasks in `.dynos/` that are not DONE or FAILED (read each manifest.json). If available in this repo, use `python3 hooks/ctl.py active-task`.
+1. List all tasks in `.dynos/` that are not DONE or FAILED (read each manifest.json). If available in this repo, use `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl active-task`.
 2. If one active task: resume it automatically
 3. If multiple active tasks: show list and ask which to resume
 4. Read `manifest.json` to determine current stage

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -9,6 +9,18 @@ You are the entry point for dynos-work. You own all human-in-the-loop gates befo
 
 There is one pipeline for all tasks. There are no shortcuts. Historical memory may inform discovery and design review, but it is advisory only. Human approval and deterministic artifact checks decide readiness.
 
+## Command Funnel (applies to every command in this skill)
+
+Every deterministic step below runs through the plugin CLI. Resolve it once at the start of the skill and substitute the ABSOLUTE path literally into each command you run (permission prefix-matching operates on literal command text):
+
+```bash
+DYNOS="${CLAUDE_PLUGIN_ROOT}/bin/dynos"   # resolve once; use the absolute path in every command
+```
+
+`"$DYNOS" ctl <subcommand>` wraps `hooks/ctl.py`; `"$DYNOS" hook <script> ...` wraps helper scripts (router, lib_tokens, build_prompt_context, ...) with PYTHONPATH handled internally. A permissions-ON user can allow the single `<plugin-root>/bin/dynos` prefix once instead of approving every call.
+
+JSON payloads (classification, execution-graph, repair-log) are piped to the ctl wrapper over stdin with `--from -` and a heredoc — NEVER staged at `/tmp` or any raw filesystem path (the write policy denies those, by design). Temp files, when genuinely needed, belong in `.dynos/task-{id}/_scratch/`.
+
 ## Ruthlessness Standard
 
 - Do not let ambiguity leak downstream.
@@ -24,58 +36,58 @@ There is one pipeline for all tasks. There are no shortcuts. Historical memory m
 
 After EVERY Agent tool call in this skill (planner, spec-completion auditor, testing-executor), you MUST write a receipt that records token usage. Read `total_tokens` from the Agent tool result's usage summary and run:
 
-Before EVERY planner receipt write, you MUST first write a per-phase injected-prompt sidecar by piping the planner prompt body into `hooks/router.py planner-inject-prompt`. Capture the printed sha256 digest and pass it back through as the `injected_prompt_sha256=<digest>` kwarg on the receipt call. The receipt will raise `ValueError` if the sidecar is missing or its contents do not match — that is the proof-of-injection gate.
+Before EVERY planner receipt write, you MUST first write a per-phase injected-prompt sidecar by piping the planner prompt body into `"$DYNOS" hook router planner-inject-prompt`. Capture the printed sha256 digest and pass it back through as the `injected_prompt_sha256=<digest>` kwarg on the receipt call. The receipt will raise `ValueError` if the sidecar is missing or its contents do not match — that is the proof-of-injection gate.
 
 ```bash
 # Discovery planner — write sidecar, capture digest:
-DISCOVERY_DIGEST=$(printf '%s' "$DISCOVERY_PROMPT" | python3 "${PLUGIN_HOOKS}/router.py" planner-inject-prompt --task-id {id} --phase discovery)
+DISCOVERY_DIGEST=$(printf '%s' "$DISCOVERY_PROMPT" | "$DYNOS" hook router planner-inject-prompt --task-id {id} --phase discovery)
 
 # Architectural Design Doc planner (high/critical-risk only) — write sidecar, capture digest:
-ARCH_DESIGN_DIGEST=$(printf '%s' "$ARCH_DESIGN_PROMPT" | python3 "${PLUGIN_HOOKS}/router.py" planner-inject-prompt --task-id {id} --phase arch-design)
+ARCH_DESIGN_DIGEST=$(printf '%s' "$ARCH_DESIGN_PROMPT" | "$DYNOS" hook router planner-inject-prompt --task-id {id} --phase arch-design)
 
 # Spec planner — write sidecar, capture digest:
-SPEC_DIGEST=$(printf '%s' "$SPEC_PROMPT" | python3 "${PLUGIN_HOOKS}/router.py" planner-inject-prompt --task-id {id} --phase spec)
+SPEC_DIGEST=$(printf '%s' "$SPEC_PROMPT" | "$DYNOS" hook router planner-inject-prompt --task-id {id} --phase spec)
 
 # Plan planner — write sidecar, capture digest:
-PLAN_DIGEST=$(printf '%s' "$PLAN_PROMPT" | python3 "${PLUGIN_HOOKS}/router.py" planner-inject-prompt --task-id {id} --phase plan)
+PLAN_DIGEST=$(printf '%s' "$PLAN_PROMPT" | "$DYNOS" hook router planner-inject-prompt --task-id {id} --phase plan)
 ```
 
 Then, after each planner subagent returns, write the matching deterministic receipt:
 
 ```bash
 # After planner spawn (discovery/design/classification):
-python3 hooks/ctl.py planner-receipt .dynos/task-{id} discovery \
+"$DYNOS" ctl planner-receipt .dynos/task-{id} discovery \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED} \
   --agent-name planning \
   --injected-prompt-sha256 "${DISCOVERY_DIGEST}"
 
 # After planner spawn (architectural design doc — high/critical-risk only):
-python3 hooks/ctl.py planner-receipt .dynos/task-{id} arch-design \
+"$DYNOS" ctl planner-receipt .dynos/task-{id} arch-design \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED} \
   --agent-name planning \
   --injected-prompt-sha256 "${ARCH_DESIGN_DIGEST}"
 
 # After planner spawn (spec normalization):
-python3 hooks/ctl.py planner-receipt .dynos/task-{id} spec \
+"$DYNOS" ctl planner-receipt .dynos/task-{id} spec \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED} \
   --agent-name planning \
   --injected-prompt-sha256 "${SPEC_DIGEST}"
 
 # After planner spawn (plan generation OR combined Spec + Plan):
-python3 hooks/ctl.py planner-receipt .dynos/task-{id} plan \
+"$DYNOS" ctl planner-receipt .dynos/task-{id} plan \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED} \
   --agent-name planning \
   --injected-prompt-sha256 "${PLAN_DIGEST}"
 
 # After validate_task_artifacts passes — REQUIRED before execute skill can run.
-python3 hooks/ctl.py plan-validated-receipt .dynos/task-{id}
+"$DYNOS" ctl plan-validated-receipt .dynos/task-{id}
 
 # After spec-completion auditor on high/critical-risk tasks only:
-python3 hooks/ctl.py plan-audit-receipt .dynos/task-{id} \
+"$DYNOS" ctl plan-audit-receipt .dynos/task-{id} \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED}
 ```
@@ -90,38 +102,24 @@ Each receipt auto-records tokens to `token-usage.json`. If you skip this, the re
 
 ## Step 0 — Metadata & Initialization
 
-1. Ensure `.dynos/` exists: `mkdir -p .dynos`. Then auto-register this project with the global registry (silent, idempotent): run `python3 "${PLUGIN_HOOKS}/registry.py" register "$(pwd)" 2>/dev/null || true`. This creates `~/.dynos/projects/{slug}/` and adds the project to `~/.dynos/registry.json` if not already registered. No user action needed. Then ensure the local maintenance daemon is running (silent, idempotent): run `PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/daemon.py" start --root "$(pwd)" 2>/dev/null || true`. If already running, it is a no-op.
-2. Generate a task ID in the format `task-YYYYMMDD-NNN`.
-3. Create the task directory: `.dynos/task-{id}/`.
-3. Write `raw-input.md` with the full task description exactly as given.
-4. Initialize `manifest.json` with at least:
+1. Before initializing, inspect the user input for:
+   - A file path ending in `.prd.md`, `.pdf`, or `.txt` — treat it as a primary spec source (`--input-type prd`).
+   - A URL to a Figma link, screenshot, or wireframe — note it as a design artifact (`--input-type wireframe`).
+   - An attached screenshot or image — note it as a visual spec artifact (`--input-type mixed`).
+2. Initialize the task through the single deterministic entrypoint. It creates `.dynos/`, registers the project + ensures the daemon (silent, idempotent), generates the `task-YYYYMMDD-NNN` id, and writes `raw-input.md`, the initial `manifest.json`, and `execution-log.md` — all under ctl ownership. Pipe the FULL task description exactly as given via stdin:
 
-```json
-{
-  "task_id": "task-20260403-001",
-  "created_at": "ISO timestamp",
-  "title": "First 80 characters of task description",
-  "raw_input": "Full task description as provided by user",
-  "input_type": "text | prd | wireframe | mixed",
-  "stage": "FOUNDRY_INITIALIZED",
-  "classification": null,
-  "retry_counts": {},
-  "blocked_reason": null,
-  "completed_at": null
-}
+```bash
+"$DYNOS" ctl run-start-init --root . --input-type {text|prd|wireframe|mixed} --description - <<'TASK_INPUT'
+{full task description exactly as provided by the user}
+TASK_INPUT
 ```
 
-5. Initialize `.dynos/task-{id}/execution-log.md`.
-6. Before writing `raw-input.md`, inspect the user input for:
-   - A file path ending in `.prd.md`, `.pdf`, or `.txt` and treat it as a primary spec source.
-   - A URL to a Figma link, screenshot, or wireframe and note it as a design artifact.
-   - An attached screenshot or image and note it as a visual spec artifact.
-7. Deterministically verify that `manifest.json` parses as valid JSON and that `task_id`, `created_at`, `raw_input`, and `stage` are present before continuing. Run:
+3. Read the printed JSON for `task_id` and `task_dir`; use them in every later step. Verify with:
 
 ```text
-python3 hooks/ctl.py validate-task .dynos/task-{id}
+"$DYNOS" ctl validate-task .dynos/task-{id}
 ```
-8. Print: `dynos-work: Foundry Task Initialized: task-YYYYMMDD-NNN`
+4. Print: `dynos-work: Foundry Task Initialized: {task_id}`
 
 ---
 
@@ -131,7 +129,7 @@ After every subagent spawn AND every deterministic validation, record the event:
 
 **For LLM subagent spawns** (planner, testing-executor, spec-completion-auditor):
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+"$DYNOS" hook lib_tokens record \
   --task-dir .dynos/task-{id} \
   --agent "{agent_name}" \
   --model "{model_name}" \
@@ -145,7 +143,7 @@ PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens
 
 **For deterministic Python validations** (validate_task_artifacts, ctl validate-task, spec heading check, etc.):
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 "${PLUGIN_HOOKS}/lib_tokens.py" record \
+"$DYNOS" hook lib_tokens record \
   --task-dir .dynos/task-{id} \
   --agent "{validation_tool_name}" \
   --model "none" \
@@ -190,7 +188,7 @@ Every Agent tool spawn in this skill (planner, spec-completion-auditor, testing-
 Direct writes to `active-segment-role` are denied by `write_policy.py` — the file is wrapper-required. Always go through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "{role}"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "{role}"
 ```
 
 The wrapper enforces `_STAMP_ROLE_ALLOWLIST` (`hooks/ctl.py`), which gates the allowed values. Forgery defense for `audit-*` claims is enforced downstream by `receipt_audit_done`, which cross-checks against `spawn-log.jsonl` — stamping a role that no real Agent spawn matches produces an unforgeable audit-trail mismatch at receipt time.
@@ -223,15 +221,17 @@ There is no direct-classify shortcut here. Always use the planner for Discovery 
 **Learned Planning Skill Injection (skip when `learning_enabled=false`):** Before spawning the planner, check if a learned planning skill exists for this task type:
 
 ```bash
-PYTHONPATH="${PLUGIN_HOOKS}:${PYTHONPATH:-}" python3 -c "from pathlib import Path; from router import resolve_route; r = resolve_route(Path('.'), 'plan-skill', '{task_type}'); print(r['agent_path'] or '')" 
+"$DYNOS" hook router resolve plan-skill {task_type} --root .
 ```
+
+Read `agent_path` from the printed JSON.
 
 If a non-empty path is returned AND the file exists, read it, strip frontmatter, and append its contents to the planner's instruction below under a `## Learned Planning Rules` heading. This injects project-specific planning patterns (e.g., tighter acceptance criteria, better segment sizing) derived from past task retrospectives. Log: `{timestamp} [ROUTE] plan-skill route={mode} agent={agent_name}`.
 
 **Stamp role BEFORE the spawn (MANDATORY):**
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "planning"
 ```
 
 Without this stamp the planner subagent resolves to `execute-inline` and its writes to `discovery-notes.md` and `design-decisions.md` are denied by `write_policy`.
@@ -263,7 +263,13 @@ If hard or critical design options were returned, present each option to the use
 
 If no high-risk design options were returned, write `design-decisions.md` with the autonomous design choices and rationale.
 
-Write the returned classification object to `/tmp/classification-{id}.json`, then run `python3 hooks/ctl.py write-classification .dynos/task-{id} --from /tmp/classification-{id}.json`.
+Persist the returned classification object by piping it to the ctl wrapper over stdin (never stage it at a raw path):
+
+```bash
+"$DYNOS" ctl write-classification .dynos/task-{id} --from - <<'JSON'
+{the planner's returned classification object, verbatim}
+JSON
+```
 
 Deterministic validation before proceeding:
 1. The wrapper enforces `classification.type`.
@@ -275,7 +281,7 @@ Transition the stage by running:
 Finalize classification through the deterministic control-plane entrypoint:
 
 ```text
-python3 hooks/ctl.py run-start-classification .dynos/task-{id}
+"$DYNOS" ctl run-start-classification .dynos/task-{id}
 ```
 
 `run-start-classification` validates the classification payload, applies fast-track + `tdd_required`, and advances the manifest to `SPEC_NORMALIZATION` when the task is ready to continue. If it exits non-zero, the JSON payload names the exact classification defects.
@@ -302,7 +308,7 @@ If any condition is not met, proceed normally (no fast-track). Do not ask the us
 Before inventing a solution from scratch, run the deterministic gate:
 
 ```text
-python3 hooks/ctl.py run-external-solution-gate .dynos/task-{id}
+"$DYNOS" ctl run-external-solution-gate .dynos/task-{id}
 ```
 
 This command writes `.dynos/task-{id}/external-solution-gate.json` and prints the same decision payload to stdout. The gate owns the decision artifact. Do NOT hand-write or rewrite this JSON in prompt logic.
@@ -332,7 +338,7 @@ Rules:
 - If `search_recommended` is `true`, you MUST conduct external research before proceeding. Use `query_reason` and `decision_basis` to form the search query, then call:
 
   ```text
-  python3 hooks/ctl.py write-search-receipt .dynos/task-{id} \
+  "$DYNOS" ctl write-search-receipt .dynos/task-{id} \
     --query "<your search query>" \
     --urls-consulted "<url1>,<url2>" \
     --findings-summary "<one-sentence summary of what the research found>"
@@ -361,7 +367,7 @@ For high/critical tasks, spawn the planner with the **Architectural Design Doc**
 **Stamp role BEFORE the spawn (MANDATORY):** write the per-phase injected-prompt sidecar and capture the digest:
 
 ```bash
-ARCH_DESIGN_DIGEST=$(printf '%s' "$ARCH_DESIGN_PROMPT" | python3 "${PLUGIN_HOOKS}/router.py" planner-inject-prompt --task-id {id} --phase arch-design)
+ARCH_DESIGN_DIGEST=$(printf '%s' "$ARCH_DESIGN_PROMPT" | "$DYNOS" hook router planner-inject-prompt --task-id {id} --phase arch-design)
 ```
 
 Without this stamp the planner subagent resolves to `execute-inline` and its write to `design-doc.md` is denied by `write_policy`.
@@ -373,7 +379,7 @@ Spawn the planner subagent (`dynos-work:planning`) with instruction:
 After the spawn returns, write the receipt:
 
 ```bash
-python3 hooks/ctl.py planner-receipt .dynos/task-{id} arch-design \
+"$DYNOS" ctl planner-receipt .dynos/task-{id} arch-design \
   --tokens-used {TOTAL_TOKENS} \
   --model {MODEL_USED} \
   --agent-name planning \
@@ -402,7 +408,7 @@ Proceed to Step 3.
 **Normal path:** **Stamp role BEFORE the spawn (MANDATORY):**
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "planning"
 ```
 
 Without this stamp the planner falls to `execute-inline` and the `spec.md` write is denied by `write_policy.decide_write` (the spec.md guard at `hooks/write_policy.py:290-296` denies executor roles outright). This is the failure mode reported in the SPEC_NORMALIZATION block incident.
@@ -431,7 +437,7 @@ If any rule fails, send the Planner back to fix `spec.md` before presenting it.
 Finalize spec readiness through the deterministic control-plane entrypoint:
 
 ```text
-python3 hooks/ctl.py run-spec-ready .dynos/task-{id}
+"$DYNOS" ctl run-spec-ready .dynos/task-{id}
 ```
 
 `run-spec-ready` validates `spec.md`, writes the `spec-validated` receipt, and advances `SPEC_NORMALIZATION -> SPEC_REVIEW` when the artifact is sound. If it exits non-zero, the JSON payload tells you exactly why the spec must be regenerated.
@@ -447,7 +453,7 @@ python3 hooks/ctl.py run-spec-ready .dynos/task-{id}
 **Auto-approve path (precedes the human path):** If `manifest.json` has `"auto_approve_gates": true`, do NOT present `spec.md` to the user. Run the auto-approved variant of the approve-stage ctl command instead. This is the only sanctioned bypass — it still hashes the live `spec.md`, writes a `human-approval-SPEC_REVIEW` receipt with `approver_type="residual-auto"`, and advances SPEC_REVIEW → PLANNING through the same atomic gate that the human path uses. The receipt is forensically distinguishable from a human approval (the `approver_type` field), so the audit chain remains intact.
 
 ```text
-python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
+"$DYNOS" ctl approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
 ```
 
 - Exit code 0: receipt was written and the stage advanced. Skip the rest of this step.
@@ -459,15 +465,15 @@ In the auto path, the "if changes requested" and "if rejected" branches of the h
 
 - If approved: run the `approve-stage` ctl command below. It hashes the current `spec.md`, writes the `human-approval-SPEC_REVIEW` receipt with that hash, the scheduler then observes the receipt write and advances the task to PLANNING asynchronously. Do NOT write a manual `[HUMAN]` log line — `approve-stage` is the only path that satisfies the receipt-gate in `transition_task` (which compares the receipt's `artifact_sha256` against the live `spec.md` at transition time and refuses with `human-approval-SPEC_REVIEW` / `hash mismatch` substrings on drift).
 - If changes are requested: append the feedback, respawn the Planner in Spec Normalization mode, re-run deterministic spec validation, write a new `receipt_spec_validated`, and present the updated spec again. Do NOT call `approve-stage` until the user re-approves the regenerated spec.
-- If rejected outright: run `python3 hooks/ctl.py transition .dynos/task-{id} FAILED`, append `[FAILED] Spec rejected by user`, and stop. Do not edit `manifest.json` directly.
+- If rejected outright: run `"$DYNOS" ctl transition .dynos/task-{id} FAILED`, append `[FAILED] Spec rejected by user`, and stop. Do not edit `manifest.json` directly.
 
 When approved:
 
 ```text
-python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW
+"$DYNOS" ctl approve-stage .dynos/task-{id} SPEC_REVIEW
 ```
 
-Exit code 0 means the receipt was written and the scheduler queued the advance to PLANNING (verify via manifest.stage after the in-process event dispatch completes). Exit code 1 means the gate refused — the stderr text identifies the cause (missing artifact, hash drift, illegal transition). Do not retry without addressing the reported cause; in particular, do not call `python3 hooks/ctl.py transition ... --force` to bypass — that would advance the stage without a receipt and break the audit chain.
+Exit code 0 means the receipt was written and the scheduler queued the advance to PLANNING (verify via manifest.stage after the in-process event dispatch completes). Exit code 1 means the gate refused — the stderr text identifies the cause (missing artifact, hash drift, illegal transition). Do not retry without addressing the reported cause; in particular, do not call `"$DYNOS" ctl transition ... --force` to bypass — that would advance the stage without a receipt and break the audit chain.
 
 ---
 
@@ -482,7 +488,7 @@ Exit code 0 means the receipt was written and the scheduler queued the advance t
 Choose planning mode through ctl:
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" run-planning-mode .dynos/task-{id}
+"$DYNOS" ctl run-planning-mode .dynos/task-{id}
 ```
 
 Use the JSON output as authoritative:
@@ -495,7 +501,7 @@ Do NOT re-derive fast-track, risk-based escalation, or acceptance-criteria thres
 **Stamp role BEFORE every planner spawn in this step (MANDATORY — applies to all three flows below):**
 
 ```bash
-python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "planning"
+"$DYNOS" ctl stamp-role .dynos/task-{id} --role "planning"
 ```
 
 For hierarchical flow, stamp once before the Master Planner spawn AND again before each Worker Planner spawn (each spawn reads the file fresh at its first tool call — successive stamps with the same role are idempotent and overwrite cleanly). Without these stamps the planner falls to `execute-inline` and `plan.md` / `execution-graph.json` writes are denied by `write_policy`.
@@ -503,20 +509,20 @@ For hierarchical flow, stamp once before the Master Planner spawn AND again befo
 Hierarchical flow:
 1. Spawn Master Planner using the default planning model for this repo.
 2. Spawn Worker Planners in parallel for non-overlapping subsystems.
-3. Merge outputs into final `plan.md` and an execution-graph payload, then persist the final graph ONLY via `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`.
+3. Merge outputs into final `plan.md` and an execution-graph payload, then persist the final graph ONLY via `"$DYNOS" ctl write-execution-graph .dynos/task-{id} --from -` (pipe the payload over stdin with a heredoc — never stage it at /tmp or any raw path).
 
 Fast-track combined flow (when `fast_track: true`):
 1. **Stage precondition:** the manifest is still at `SPEC_NORMALIZATION` (Step 3 deferred the walk). Do NOT advance yet.
-2. Spawn Planner (Opus) ONCE with phase `Spec + Plan` to produce `spec.md`, `plan.md`, and an execution-graph payload in `/tmp/execution-graph-{id}.json`, then persist the final graph ONLY via `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`. This replaces both Step 3 (Spec Normalization) and Step 5's normal planner spawn.
+2. Spawn Planner (Opus) ONCE with phase `Spec + Plan` to produce `spec.md`, `plan.md`, and an execution-graph payload returned in its final message; then persist the final graph ONLY via `"$DYNOS" ctl write-execution-graph .dynos/task-{id} --from -` (pipe the payload over stdin with a heredoc — never stage it at /tmp or any raw path). This replaces both Step 3 (Spec Normalization) and Step 5's normal planner spawn.
 3. After the spawn returns AND `validate_task_artifacts` passes (see below), walk the stage forward through `SPEC_NORMALIZATION → SPEC_REVIEW → PLANNING` (each transition is legal per `ALLOWED_STAGE_TRANSITIONS` in `hooks/lib_core.py`). Only advance once the artifacts that justify each stage exist on disk. Log each transition. Then continue with the post-validation flow below (which advances to `PLAN_REVIEW`).
 
 Standard flow:
-1. Spawn Planner (Opus) with instruction to generate `plan.md` and an execution-graph payload, then persist the final graph ONLY via `python3 hooks/ctl.py write-execution-graph .dynos/task-{id} --from /tmp/execution-graph-{id}.json`.
+1. Spawn Planner (Opus) with instruction to generate `plan.md` and an execution-graph payload, then persist the final graph ONLY via `"$DYNOS" ctl write-execution-graph .dynos/task-{id} --from -` (pipe the payload over stdin with a heredoc — never stage it at /tmp or any raw path).
 
 After generation, run deterministic artifact validation before any human review. If available in this repo, run:
 
 ```text
-python3 hooks/validate_task_artifacts.py .dynos/task-{id} --no-gap
+"$DYNOS" hook validate_task_artifacts .dynos/task-{id} --no-gap
 ```
 
 The command is the source of truth for artifact validation. Use the rules below to explain and repair failures:
@@ -543,7 +549,7 @@ If any validation fails, respawn planning and fix the artifacts before continuin
 **Receipt: plan-validated (MANDATORY).** Once `validate_task_artifacts` passes, write the plan-validated receipt. Without this receipt the eventual transition to `EXECUTION` (in the execute skill) will be blocked by the state machine:
 
 ```bash
-python3 hooks/ctl.py plan-validated-receipt .dynos/task-{id}
+"$DYNOS" ctl plan-validated-receipt .dynos/task-{id}
 ```
 
 Append to the execution log (transition_task auto-appends the `[STAGE] → PLAN_REVIEW` line — only the `[DONE]` line is the skill's responsibility):
@@ -555,7 +561,7 @@ Append to the execution log (transition_task auto-appends the `[STAGE] → PLAN_
 Transition the stage by running:
 
 ```text
-python3 hooks/ctl.py transition .dynos/task-{id} PLAN_REVIEW
+"$DYNOS" ctl transition .dynos/task-{id} PLAN_REVIEW
 ```
 
 ---
@@ -569,14 +575,14 @@ This gate always runs. For fast-track tasks it acts as the combined Spec + Plan 
 - Normal path (Step 4 already wrote the SPEC_REVIEW receipt — auto or human):
 
   ```text
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
+  "$DYNOS" ctl approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
   ```
 
 - Fast-track combined gate (Step 4 was skipped; the manifest is at SPEC_REVIEW after Step 5's stage walk and needs both receipts in order):
 
   ```text
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
+  "$DYNOS" ctl approve-stage .dynos/task-{id} SPEC_REVIEW --auto-approved
+  "$DYNOS" ctl approve-stage .dynos/task-{id} PLAN_REVIEW --auto-approved
   ```
 
   The state machine requires the SPEC_REVIEW receipt before the PLAN_REVIEW receipt — this ordering is unchanged by the auto-approval feature. Both calls must return exit 0; if either returns exit 1, log the stderr message and fall through to the human-approval path for that specific gate.
@@ -590,17 +596,17 @@ In the auto path, "if changes requested" and "if rejected outright" branches bel
 
 Present the artifact(s) to the user and ask for approval.
 
-- If approved (normal path): run `python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW`. This hashes the current `plan.md`, writes the `human-approval-PLAN_REVIEW` receipt with that hash, and atomically advances PLAN_REVIEW → PLAN_AUDIT. Exit code 0 means success; exit code 1 means the gate refused (stderr identifies the cause). Do not bypass with `transition --force`.
+- If approved (normal path): run `"$DYNOS" ctl approve-stage .dynos/task-{id} PLAN_REVIEW`. This hashes the current `plan.md`, writes the `human-approval-PLAN_REVIEW` receipt with that hash, and atomically advances PLAN_REVIEW → PLAN_AUDIT. Exit code 0 means success; exit code 1 means the gate refused (stderr identifies the cause). Do not bypass with `transition --force`.
 - If approved (fast-track combined gate): the manifest is currently at SPEC_REVIEW (Step 5 walked it through `SPEC_NORMALIZATION → SPEC_REVIEW → PLANNING → PLAN_REVIEW`). Run `approve-stage` twice in order — first for the spec, then for the plan:
 
   ```text
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} SPEC_REVIEW
-  python3 hooks/ctl.py approve-stage .dynos/task-{id} PLAN_REVIEW
+  "$DYNOS" ctl approve-stage .dynos/task-{id} SPEC_REVIEW
+  "$DYNOS" ctl approve-stage .dynos/task-{id} PLAN_REVIEW
   ```
 
   Each call hashes the live artifact, writes the matching receipt, and advances one stage. Both must succeed; if either returns exit 1, address the reported cause before retrying.
 - If changes are requested: append the feedback, respawn planning (combined Spec + Plan phase for fast-track, otherwise standard planning), re-run deterministic artifact validation, and present the updated artifact(s) again. Do NOT call `approve-stage` until the user re-approves the regenerated artifact(s) — the gate compares the receipt hash to the live file at transition time, so an approval against an out-of-date hash will be refused with `hash mismatch`.
-- If rejected outright: run `python3 hooks/ctl.py transition .dynos/task-{id} FAILED`, append `[FAILED] Plan rejected by user`, and stop. Do not edit `manifest.json` directly.
+- If rejected outright: run `"$DYNOS" ctl transition .dynos/task-{id} FAILED`, append `[FAILED] Plan rejected by user`, and stop. Do not edit `manifest.json` directly.
 
 ---
 
@@ -614,7 +620,7 @@ The deterministic gap analysis ALWAYS runs. The LLM auditor only runs for high/c
 
 1. **Deterministic gap analysis (mandatory, always runs):**
    ```bash
-   python3 hooks/plan_gap_analysis.py --root . --task-dir .dynos/task-{id}
+   "$DYNOS" hook plan_gap_analysis --root . --task-dir .dynos/task-{id}
    ```
    This verifies that claims in `## API Contracts` and `## Data Model` sections correspond to real code. If the plan claims an endpoint or table exists that the codebase doesn't have, the planner must either fix the table or explicitly mark the entry as to-be-created. Gap analysis failures block — repair before continuing.
 
@@ -623,7 +629,7 @@ The deterministic gap analysis ALWAYS runs. The LLM auditor only runs for high/c
    **Stamp role BEFORE the spawn (MANDATORY — only when the conditional fires):**
 
    ```bash
-   python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "audit-spec-completion"
+   "$DYNOS" ctl stamp-role .dynos/task-{id} --role "audit-spec-completion"
    ```
 
    Without this stamp the auditor falls to `execute-inline` and its `audit-reports/spec-completion.json` write is denied by `write_policy.decide_write` (which restricts `audit-reports/` to `audit-*` roles). Forgery defense: `receipt_audit_done` cross-checks the orchestrator-claimed spawn against `spawn-log.jsonl`, so stamping without a real Agent spawn produces an unforgeable mismatch at receipt time.
@@ -646,7 +652,7 @@ When `tdd_required` is `true`:
 1. **Stamp role BEFORE the spawn (MANDATORY):**
 
    ```bash
-   python3 "${PLUGIN_HOOKS}/ctl.py" stamp-role .dynos/task-{id} --role "testing-executor"
+   "$DYNOS" ctl stamp-role .dynos/task-{id} --role "testing-executor"
    ```
 
    Without this stamp the testing-executor falls to `execute-inline`. Repo-file writes still work because `write_policy` permits both `execute-inline` and `*-executor` for repo artifacts, but the role file is what every other dynos-work skill in this codebase stamps before an executor spawn — keeping the convention here ensures the spawn-log entry's claimed role matches the runtime role and that downstream receipts identify the spawn correctly.
@@ -667,26 +673,19 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
    - No production source files may be modified in this step.
 3. Present the test file paths and summary to the user.
 4. If changes are requested, rerun the testing executor and the same deterministic validation.
-5. When validation passes (and before asking for human approval), write the TDD receipt:
+5. When validation passes (and before asking for human approval), write the TDD receipt through ctl (the evidence hash is computed from the on-disk file — do not supply hashes yourself):
 
-   ```python
-   from pathlib import Path
-   from lib_receipts import receipt_tdd_tests, hash_file
-
-   evidence_path = Path(".dynos/task-{id}/evidence/tdd-tests.md")
-   receipt_tdd_tests(
-       task_dir=Path(".dynos/task-{id}"),
-       test_file_paths=[...],                       # list of test file paths from this run
-       tests_evidence_sha256=hash_file(evidence_path),
-       tokens_used=TOTAL_TOKENS,                    # from testing-executor spawn usage
-       model_used="opus",                           # or whichever model was used
-   )
+   ```bash
+   "$DYNOS" ctl tdd-receipt .dynos/task-{id} \
+     --test-file {path/to/test_one.py} --test-file {path/to/test_two.py} \
+     --tokens-used {TOTAL_TOKENS} \
+     --model {MODEL_USED}
    ```
 
 6. **Auto-approve path (precedes the human path):** If `manifest.json` has `"auto_approve_gates": true` AND `tdd_required: true` (which is the only condition under which Step 8 fires at all), do NOT present the test suite to the user. After the testing-executor spawn and the deterministic validation in step 2 above have both passed, run the auto-approved variant of approve-stage:
 
    ```text
-   python3 hooks/ctl.py approve-stage .dynos/task-{id} TDD_REVIEW --auto-approved
+   "$DYNOS" ctl approve-stage .dynos/task-{id} TDD_REVIEW --auto-approved
    ```
 
    - Exit code 0: receipt written, stage advanced TDD_REVIEW → PRE_EXECUTION_SNAPSHOT. Proceed to step 7 (commit tests).
@@ -697,7 +696,7 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
 7. When the user approves the test suite (or after step 6's auto-approval has run), transition out of TDD_REVIEW via the `approve-stage` ctl command. This hashes `evidence/tdd-tests.md`, writes the `human-approval-TDD_REVIEW` receipt with that hash, and advances TDD_REVIEW → PRE_EXECUTION_SNAPSHOT in one atomic step. Do NOT append a manual `[HUMAN]` log line — the receipt + approve-stage path is the only one the state machine accepts (the gate refuses with `human-approval-TDD_REVIEW` / `hash mismatch` substrings on drift):
 
    ```text
-   python3 hooks/ctl.py approve-stage .dynos/task-{id} TDD_REVIEW
+   "$DYNOS" ctl approve-stage .dynos/task-{id} TDD_REVIEW
    ```
 
    Exit code 0 means the receipt was written and the stage advanced. Exit code 1 means the gate refused — the stderr text identifies the cause. Do not bypass with `transition --force`. (If step 6's auto-approval already advanced the stage, this human-path call is unreachable.)
@@ -712,16 +711,16 @@ Write only test files and evidence to .dynos/task-{id}/evidence/tdd-tests.md.
 
 ## Step 9 — Done
 
-**Role file cleanup (MANDATORY — BEFORE the handoff transition):** Delete `.dynos/task-{id}/active-segment-role` so `/dynos-work:execute` starts each segment with a clean slate. Deletion is permitted by `write_policy` (only the *write* path is wrapper-required); leaving the file in place is benign because every executor stamp overwrites it, but cleaning up keeps the spawn-log → role file relationship one-to-one for the next phase.
+**Role cleanup (MANDATORY — BEFORE the handoff transition):** Clear unconsumed role grants and the legacy role file so `/dynos-work:execute` starts each segment with a clean slate. Do NOT `rm` the role file by hand — `active-segment-role` is wrapper-required and write_policy denies the deletion; `clear-role` is the sanctioned (privilege-reducing) path:
 
 ```bash
-rm -f .dynos/task-{id}/active-segment-role
+"$DYNOS" ctl clear-role .dynos/task-{id}
 ```
 
 Transition the stage by running:
 
 ```text
-python3 hooks/ctl.py transition .dynos/task-{id} PRE_EXECUTION_SNAPSHOT
+"$DYNOS" ctl transition .dynos/task-{id} PRE_EXECUTION_SNAPSHOT
 ```
 
 Append to the execution log:

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -15,7 +15,7 @@ Show the current state of the active dynos-work task.
 
 ## What you do
 
-1. Find the most recent active task in `.dynos/` (manifest.json with stage not DONE/FAILED). If available in this repo, use `python3 hooks/ctl.py active-task`.
+1. Find the most recent active task in `.dynos/` (manifest.json with stage not DONE/FAILED). If available in this repo, use `"${CLAUDE_PLUGIN_ROOT}/bin/dynos" ctl active-task`.
 2. If no active task, report "No active dynos-work task found. Start one with /dynos-work:start"
 3. Read: manifest.json, spec.md, execution-graph.json, latest audit-reports, repair-log.json, test-results.json, execution-log.md
 4. Print a human-readable status report

--- a/tests/test_actor_identity.py
+++ b/tests/test_actor_identity.py
@@ -1,0 +1,368 @@
+"""Tests for per-actor role resolution (D3 in docs/permissions-on-design.md).
+
+The orchestrator session is pinned at SessionStart and ALWAYS resolves to the
+'orchestrator' role; subagent sessions consume single-use grants. The suite's
+most important member is the self-elevation regression: granting an audit
+role must NOT let the orchestrator write audit-reports/.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import actor_identity  # noqa: E402
+import pre_tool_use  # noqa: E402
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+ORCH_SESSION = "session-orchestrator-0001"
+SUB_SESSION_A = "session-subagent-aaaa"
+SUB_SESSION_B = "session-subagent-bbbb"
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Project root with a task dir and a pinned orchestrator session."""
+    root = tmp_path / "proj"
+    task_dir = root / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260611-001",
+        "stage": "PLANNING",
+        "fast_track": False,
+    }))
+    actor_identity.pin_orchestrator(root, {"session_id": ORCH_SESSION})
+    monkeypatch.delenv("DYNOS_ROLE", raising=False)
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    return root
+
+
+def _task_dir(root: Path) -> Path:
+    return root / ".dynos" / "task-20260611-001"
+
+
+def _run_hook(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    session_id: str,
+    tool_name: str,
+    tool_input: dict,
+    cwd: Path,
+) -> tuple[int, str]:
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+        "cwd": str(cwd),
+        "session_id": session_id,
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        code = pre_tool_use.main()
+    return code, stderr.getvalue()
+
+
+def _grant(task_dir: Path, role: str) -> None:
+    result = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "ctl.py"), "grant-role", str(task_dir), "--role", role],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# The self-elevation regression test
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_cannot_write_audit_reports_even_with_audit_grant(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Granting (or stamping) an audit role must never elevate the
+    orchestrator's own session — the historical 'stuck role' behavior was
+    exactly this leak, and it is the forgery-adjacent primitive."""
+    task_dir = _task_dir(project)
+    _grant(task_dir, "audit-security")
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={
+            "file_path": str(task_dir / "audit-reports" / "security-1.json"),
+            "content": "{}",
+        },
+        cwd=project,
+    )
+    assert code == 2
+    assert "role=orchestrator" in err
+    # Degraded-mode diagnostic: a pending grant exists, so the denial says
+    # how to recognize a mis-attributed subagent call.
+    assert "degraded actor resolution" in err
+
+
+def test_orchestrator_ignores_stamped_role_file(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The P1-a fix: stamping a subagent role no longer mutates the
+    orchestrator's own rights."""
+    task_dir = _task_dir(project)
+    (task_dir / "active-segment-role").write_text("planning")
+    # planning may write spec.md — the orchestrator must NOT inherit that.
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 2
+    assert "role=orchestrator" in err
+
+
+def test_orchestrator_writes_its_own_coordination_files(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = _task_dir(project)
+    for filename in ("execution-log.md", "escalation.md", "discovery-notes.md"):
+        code, err = _run_hook(
+            monkeypatch,
+            session_id=ORCH_SESSION,
+            tool_name="Write",
+            tool_input={"file_path": str(task_dir / filename), "content": "x"},
+            cwd=project,
+        )
+        assert code == 0, f"{filename}: {err}"
+
+
+def test_orchestrator_repo_write_denied_outside_inline_execution(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={"file_path": str(project / "src" / "app.py"), "content": "x"},
+        cwd=project,
+    )
+    assert code == 2
+    assert "inline fast-track" in err
+
+
+def test_orchestrator_repo_write_allowed_during_inline_fast_track(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = _task_dir(project)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260611-001",
+        "stage": "EXECUTION",
+        "fast_track": True,
+    }))
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={"file_path": str(project / "src" / "app.py"), "content": "x"},
+        cwd=project,
+    )
+    assert code == 0, err
+
+
+# ---------------------------------------------------------------------------
+# Subagent grant consumption and binding
+# ---------------------------------------------------------------------------
+
+def test_subagent_consumes_grant_and_writes_its_artifact(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = _task_dir(project)
+    _grant(task_dir, "planning")
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=SUB_SESSION_A,
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 0, err
+    # Binding persisted and grant consumed.
+    assert actor_identity.lookup_binding(task_dir, SUB_SESSION_A) == "planning"
+    assert actor_identity.pending_grants(task_dir) == []
+
+
+def test_binding_is_immutable_for_session_lifetime(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A later grant (for the next spawn) must not re-role a bound session."""
+    task_dir = _task_dir(project)
+    _grant(task_dir, "planning")
+    code, _ = _run_hook(
+        monkeypatch,
+        session_id=SUB_SESSION_A,
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 0
+    _grant(task_dir, "audit-security")
+    # Session A is still planning: audit-reports write denied.
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=SUB_SESSION_A,
+        tool_name="Write",
+        tool_input={
+            "file_path": str(task_dir / "audit-reports" / "x.json"),
+            "content": "{}",
+        },
+        cwd=project,
+    )
+    assert code == 2
+    assert "role=planning" in err
+    # The audit grant is still pending for the real auditor session.
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=SUB_SESSION_B,
+        tool_name="Write",
+        tool_input={
+            "file_path": str(task_dir / "audit-reports" / "x.json"),
+            "content": "{}",
+        },
+        cwd=project,
+    )
+    assert code == 0, err
+
+
+def test_parallel_sessions_consume_distinct_grants(project: Path) -> None:
+    task_dir = _task_dir(project)
+    _grant(task_dir, "audit-security")
+    _grant(task_dir, "audit-code-quality")
+    role_a = actor_identity.consume_grant(task_dir, SUB_SESSION_A)
+    role_b = actor_identity.consume_grant(task_dir, SUB_SESSION_B)
+    assert {role_a, role_b} == {"audit-security", "audit-code-quality"}
+    # Re-consume returns the existing binding, not a new grant.
+    assert actor_identity.consume_grant(task_dir, SUB_SESSION_A) == role_a
+
+
+def test_unknown_session_without_grant_falls_back_to_default(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = _task_dir(project)
+    # No grant, no role file: execute-inline default applies (repo writes OK,
+    # planning artifacts denied).
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=SUB_SESSION_A,
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 2
+    assert "role=execute-inline" in err
+
+
+def test_no_pin_preserves_legacy_role_file_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "legacy"
+    task_dir = root / ".dynos" / "task-20260611-009"
+    task_dir.mkdir(parents=True)
+    (task_dir / "active-segment-role").write_text("planning")
+    monkeypatch.delenv("DYNOS_ROLE", raising=False)
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    code, err = _run_hook(
+        monkeypatch,
+        session_id="any-session",
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=root,
+    )
+    assert code == 0, err
+
+
+# ---------------------------------------------------------------------------
+# Ledger / pin protection (no self-elevation writes)
+# ---------------------------------------------------------------------------
+
+def test_ctl_refuses_non_allowlisted_grant(project: Path) -> None:
+    task_dir = _task_dir(project)
+    result = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "ctl.py"), "grant-role", str(task_dir),
+         "--role", "orchestrator"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "not in the role" in result.stderr
+
+
+def test_clear_role_expires_grants_and_removes_role_file(project: Path) -> None:
+    task_dir = _task_dir(project)
+    _grant(task_dir, "planning")
+    (task_dir / "active-segment-role").write_text("planning")
+    result = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "ctl.py"), "clear-role", str(task_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert actor_identity.pending_grants(task_dir) == []
+    assert not (task_dir / "active-segment-role").exists()
+    # Existing bindings untouched: clear-role only reduces privilege.
+
+
+@pytest.mark.parametrize(
+    ("filename", "roles"),
+    [
+        ("role-grants.json", ["orchestrator", "planning", "backend-executor", "audit-security"]),
+        ("role-bindings.json", ["orchestrator", "planning", "backend-executor", "audit-security", "ctl"]),
+    ],
+)
+def test_ledger_files_not_agent_writable(project: Path, filename: str, roles: list[str]) -> None:
+    task_dir = _task_dir(project)
+    for role in roles:
+        decision = decide_write(
+            WriteAttempt(
+                role=role,
+                task_dir=task_dir,
+                path=task_dir / filename,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is False, f"{role} wrote {filename}"
+
+
+def test_orchestrator_pin_not_agent_writable(project: Path) -> None:
+    pin = project / ".dynos" / "orchestrator-session.json"
+    for role in ("orchestrator", "planning", "backend-executor", "execute-inline"):
+        decision = decide_write(
+            WriteAttempt(
+                role=role,
+                task_dir=_task_dir(project),
+                path=pin,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is False, f"{role} rewrote the pin"
+        assert "hook-owned" in decision.reason
+
+
+def test_expired_grant_not_consumable(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    task_dir = _task_dir(project)
+    _grant(task_dir, "planning")
+    ledger = actor_identity.load_grants(task_dir)
+    ledger["grants"][0]["expires_at"] = 1.0  # long past
+    actor_identity._atomic_write_json(actor_identity.grants_path(task_dir), ledger)
+    assert actor_identity.consume_grant(task_dir, SUB_SESSION_A) is None

--- a/tests/test_bash_destination_extraction.py
+++ b/tests/test_bash_destination_extraction.py
@@ -1,0 +1,213 @@
+"""Tests for the quote-aware Bash write-destination extractor (D5).
+
+The old regex scan matched `>` characters inside quoted prompt text and
+heredoc bodies, producing false-positive write destinations that the policy
+then denied (P0-b in docs/permissions-on-design.md). These tests pin the
+token-based behavior: quoted strings and heredoc bodies are data, real
+redirects and write verbs are still caught.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import pre_tool_use  # noqa: E402
+from pre_tool_use import _extract_bash_destinations  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# False positives the old regex produced: must extract NOTHING.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `>` inside a quoted prompt string (inject-prompt pipe pattern).
+        'echo "Data flow: request -> handler > response" | python3 router.py inject-prompt',
+        # Markdown blockquote inside a quoted argument.
+        'git commit -m "fix: handle a > b comparisons"',
+        # python -c source containing a redirect-looking string.
+        "python3 -c \"print('exit > 0 means failure')\"",
+        # Heredoc body containing redirects and rm-looking text.
+        "python3 hooks/ctl.py write-classification .dynos/task-x --from - <<'JSON'\n"
+        '{"type": "feature", "notes": "rm old > new comparisons"}\n'
+        "JSON",
+        # Quoted token that merely *names* a write verb.
+        'echo "run rm -rf later"',
+        # fd duplication is not a path write.
+        "command 2>&1",
+        # mv with a single operand has no distinct destination.
+        "mv onlyarg",
+    ],
+)
+def test_no_false_positive_destinations(command: str) -> None:
+    assert _extract_bash_destinations(command) == []
+
+
+# ---------------------------------------------------------------------------
+# Sinks: extracted-then-filtered (never reach the policy).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python3 registry.py register . 2>/dev/null || true",
+        "noisy-tool > /dev/null",
+        "tool >> /dev/null 2>&1",
+    ],
+)
+def test_device_sinks_are_not_destinations(command: str) -> None:
+    assert _extract_bash_destinations(command) == []
+
+
+# ---------------------------------------------------------------------------
+# Real writes: still detected.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("echo hi > out.txt", ["out.txt"]),
+        ("echo hi >> log.md", ["log.md"]),
+        ("echo x>compact.txt", ["compact.txt"]),
+        ("cat a | tee -a notes.md", ["notes.md"]),
+        ("mv src.py dst.py", ["dst.py"]),
+        ("cp -r srcdir destdir", ["destdir"]),
+        ("rm -rf .dynos/task-1/active-segment-role", [".dynos/task-1/active-segment-role"]),
+        ("unlink some/file.json", ["some/file.json"]),
+        ("truncate -s 0 data.log", ["data.log"]),
+        # Multiple statements: each side of the separator is scanned.
+        ("echo a > first.txt; echo b > second.txt", ["first.txt", "second.txt"]),
+        ("ls && rm stale.lock", ["stale.lock"]),
+        # Redirect after a quoted argument still counts.
+        ('echo "a > b" > real-target.txt', ["real-target.txt"]),
+    ],
+)
+def test_real_write_destinations_detected(command: str, expected: list[str]) -> None:
+    assert _extract_bash_destinations(command) == expected
+
+
+def test_unparseable_command_falls_back_to_legacy_regex() -> None:
+    # Unbalanced quote: shlex fails; the legacy regex still sees the redirect.
+    command = "echo 'unterminated > target.txt"
+    assert "target.txt" in _extract_bash_destinations(command)
+
+
+def test_heredoc_terminator_resumes_scanning() -> None:
+    command = (
+        "cat <<'EOF'\n"
+        "body > not-a-write.txt\n"
+        "EOF\n"
+        "echo done > after.txt"
+    )
+    assert _extract_bash_destinations(command) == ["after.txt"]
+
+
+def test_herestring_is_not_treated_as_heredoc() -> None:
+    # `<<<` must not swallow the rest of the command as a heredoc body.
+    command = "grep pattern <<<'a > b'\necho hi > real.txt"
+    assert _extract_bash_destinations(command) == ["real.txt"]
+
+
+# ---------------------------------------------------------------------------
+# Denial message contract (D5-2): self-identifies as a plugin guardrail.
+# ---------------------------------------------------------------------------
+
+def _run_hook(monkeypatch: pytest.MonkeyPatch, payload: dict) -> tuple[int, str]:
+    import contextlib
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        code = pre_tool_use.main()
+    return code, stderr.getvalue()
+
+
+def test_denial_message_names_guardrail_role_path_and_docs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = tmp_path / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setenv("DYNOS_ROLE", "planning")
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    payload = {
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(tmp_path / "outside.txt"), "content": "x"},
+        "cwd": str(tmp_path),
+    }
+    code, err = _run_hook(monkeypatch, payload)
+    assert code == 2
+    assert "write-policy:" in err
+    assert "dynos-work guardrail" in err
+    assert "not a Claude Code permission" in err
+    assert "role=planning" in err
+    assert "outside.txt" in err
+    assert "docs/write-boundary-spec.md" in err
+
+
+def test_wrapper_required_denial_names_sanctioned_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = tmp_path / ".dynos" / "task-20260611-002"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setenv("DYNOS_ROLE", "planning")
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    payload = {
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": str(task_dir / "classification.json"),
+            "content": "{}",
+        },
+        "cwd": str(tmp_path),
+    }
+    code, err = _run_hook(monkeypatch, payload)
+    assert code == 2
+    assert "Sanctioned path:" in err
+    assert "write-classification" in err
+
+
+def test_prompt_string_redirect_no_longer_denied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The P0-b regression: quoted `>` in a piped prompt must pass."""
+    task_dir = tmp_path / ".dynos" / "task-20260611-003"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setenv("DYNOS_ROLE", "planning")
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (
+                'echo "Implement a > b ordering and pipe -> sink" '
+                "| python3 router.py inject-prompt --segment seg-1"
+            )
+        },
+        "cwd": str(tmp_path),
+    }
+    code, err = _run_hook(monkeypatch, payload)
+    assert code == 0, f"expected allow, got stderr={err!r}"
+
+
+def test_dev_null_redirect_allowed_for_planning_role(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The start-skill Step 0 pattern: `2>/dev/null || true` must pass."""
+    task_dir = tmp_path / ".dynos" / "task-20260611-004"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setenv("DYNOS_ROLE", "planning")
+    monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "python3 registry.py register . 2>/dev/null || true"},
+        "cwd": str(tmp_path),
+    }
+    code, err = _run_hook(monkeypatch, payload)
+    assert code == 0, f"expected allow, got stderr={err!r}"

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -843,6 +843,13 @@ def test_run_execution_finish_transitions_when_no_pending_segments(tmp_path) -> 
 
     evidence_dir = task_dir / "evidence"
     evidence_dir.mkdir(parents=True, exist_ok=True)
+    # run-execution-finish now verifies evidence + files_expected inside the
+    # stage gate (D7-1) — a finished execution has these files on disk.
+    root = task_dir.parent.parent
+    for expected in ("src/a.py", "tests/test_a.py"):
+        target = root / expected
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# produced by execution\n")
     for seg_id in ("seg-1", "seg-2"):
         evidence_path = evidence_dir / f"{seg_id}.md"
         evidence_path.write_text(f"{seg_id} evidence\n")
@@ -872,6 +879,85 @@ def test_run_execution_finish_transitions_when_no_pending_segments(tmp_path) -> 
 
     manifest = json.loads(manifest_path.read_text())
     assert manifest["stage"] == "TEST_EXECUTION"
+
+    # D7-1 regression: the standalone verifier must remain legal AFTER the
+    # stage advanced to TEST_EXECUTION (it used to hard-error here).
+    verify = _run_ctl("run-execution-verify-evidence", str(task_dir))
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+    verify_payload = json.loads(verify.stdout)
+    assert verify_payload["status"] == "verified"
+
+
+def test_run_execution_finish_blocks_when_evidence_missing(tmp_path) -> None:
+    """The finish gate cannot advance the stage without evidence on disk."""
+    from lib_receipts import (
+        receipt_executor_done,
+        receipt_executor_routing,
+        receipt_plan_validated,
+        receipt_rules_check_passed,
+    )
+
+    task_dir = _setup_task_dir(tmp_path)
+    manifest_path = task_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["stage"] = "EXECUTION"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    os.environ["DYNOS_ALLOW_TEST_OVERRIDE"] = "1"
+    try:
+        receipt_plan_validated(task_dir, validation_passed_override=True)
+    finally:
+        os.environ.pop("DYNOS_ALLOW_TEST_OVERRIDE", None)
+
+    receipt_executor_routing(task_dir, [
+        {
+            "segment_id": "seg-1",
+            "executor": "backend-executor",
+            "model": "sonnet",
+            "route_mode": "generic",
+            "agent_path": None,
+        },
+        {
+            "segment_id": "seg-2",
+            "executor": "testing-executor",
+            "model": "sonnet",
+            "route_mode": "generic",
+            "agent_path": None,
+        },
+    ])
+
+    evidence_dir = task_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for seg_id in ("seg-1", "seg-2"):
+        evidence_path = evidence_dir / f"{seg_id}.md"
+        evidence_path.write_text(f"{seg_id} evidence\n")
+        sidecar_dir = task_dir / "receipts" / "_injected-prompts"
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        digest = ("f" if seg_id == "seg-1" else "a") * 64
+        (sidecar_dir / f"{seg_id}.sha256").write_text(digest)
+        receipt_executor_done(
+            task_dir,
+            segment_id=seg_id,
+            executor_type="backend-executor" if seg_id == "seg-1" else "testing-executor",
+            model_used="sonnet",
+            injected_prompt_sha256=digest,
+            agent_name=None,
+            evidence_path=str(evidence_path),
+            tokens_used=5,
+            diff_verified_files=[],
+            no_op_justified=False,
+        )
+    receipt_rules_check_passed(task_dir, "all")
+    # Delete seg-2's evidence after the receipts: the gate must catch it.
+    (evidence_dir / "seg-2.md").unlink()
+
+    result = _run_ctl("run-execution-finish", str(task_dir))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert any("seg-2" in failure for failure in payload["failures"])
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["stage"] == "EXECUTION"
 
 
 def test_run_execution_finish_blocks_when_pending_segments_remain(tmp_path) -> None:

--- a/tests/test_ctl_stdin_payload.py
+++ b/tests/test_ctl_stdin_payload.py
@@ -1,0 +1,105 @@
+"""Tests for `--from -` stdin payloads on ctl write wrappers (D1).
+
+The stdin form lets skills pipe an LLM-returned payload straight into the
+wrapper via a heredoc instead of staging it at a raw filesystem path the
+write policy would have to sanction. Validation, normalization, and the
+atomic policy-checked write must be byte-identical to the file form.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from test_ctl import _setup_task_dir  # noqa: E402
+
+
+def _run_ctl_stdin(*args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(ROOT / "hooks" / "ctl.py"), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        input=stdin,
+        env=os.environ.copy(),
+        check=False,
+    )
+
+
+_CLASSIFICATION = {
+    "type": "bugfix",
+    "domains": ["backend", "security"],
+    "risk_level": "low",
+    "notes": "tighten auth path",
+}
+
+
+def test_write_classification_stdin_matches_file_form(tmp_path: Path) -> None:
+    task_a = _setup_task_dir(tmp_path / "a")
+    task_b = _setup_task_dir(tmp_path / "b")
+
+    payload_path = tmp_path / "classification.json"
+    payload_path.write_text(json.dumps(_CLASSIFICATION))
+    via_file = _run_ctl_stdin("write-classification", str(task_a), "--from", str(payload_path))
+    assert via_file.returncode == 0, via_file.stdout + via_file.stderr
+
+    via_stdin = _run_ctl_stdin(
+        "write-classification", str(task_b), "--from", "-",
+        stdin=json.dumps(_CLASSIFICATION),
+    )
+    assert via_stdin.returncode == 0, via_stdin.stdout + via_stdin.stderr
+
+    file_artifact = (task_a / "classification.json").read_text()
+    stdin_artifact = (task_b / "classification.json").read_text()
+    assert file_artifact == stdin_artifact
+
+
+def test_write_classification_stdin_invalid_json_writes_nothing(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path)
+    result = _run_ctl_stdin(
+        "write-classification", str(task_dir), "--from", "-",
+        stdin="{not json",
+    )
+    assert result.returncode != 0
+    assert "not valid JSON" in (result.stderr + result.stdout)
+    assert not (task_dir / "classification.json").exists()
+
+
+def test_write_classification_stdin_still_validates_schema(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path)
+    bad = dict(_CLASSIFICATION, domains=["backend", "unknown-domain"])
+    result = _run_ctl_stdin(
+        "write-classification", str(task_dir), "--from", "-",
+        stdin=json.dumps(bad),
+    )
+    assert result.returncode == 1
+    assert "classification domain invalid" in result.stderr
+    assert not (task_dir / "classification.json").exists()
+
+
+def test_write_execution_graph_stdin(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path)
+    graph = {
+        "segments": [
+            {
+                "id": "seg-1",
+                "executor": "backend-executor",
+                "files_expected": ["src/app.py"],
+                "criteria_ids": [1],
+                "depends_on": [],
+            }
+        ]
+    }
+    result = _run_ctl_stdin(
+        "write-execution-graph", str(task_dir), "--from", "-",
+        stdin=json.dumps(graph),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    persisted = json.loads((task_dir / "execution-graph.json").read_text())
+    assert persisted["segments"][0]["id"] == "seg-1"

--- a/tests/test_files_expected_globs.py
+++ b/tests/test_files_expected_globs.py
@@ -1,0 +1,114 @@
+"""Tests for directory/glob entries in files_expected (D7-2).
+
+Repo-wide segments can declare `src/pkg/` or `src/**/*.py` instead of
+enumerating every file. The proof source is unchanged: entries are matched
+against the git diff + untracked listing, and an entry that matches nothing
+still fails the segment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from ctl import _entry_covered  # noqa: E402
+from lib_validate import (  # noqa: E402
+    files_expected_entries_overlap,
+    files_expected_entry_matches,
+)
+
+COVERED = {
+    "src/andromede/core.py",
+    "src/andromede/util/helpers.py",
+    "tests/test_core.py",
+    "README.md",
+}
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        # plain entries: exact membership, original behavior
+        ("src/andromede/core.py", True),
+        ("src/missing.py", False),
+        # directory entries
+        ("src/andromede/", True),
+        ("src/other/", False),
+        # glob entries
+        ("src/andromede/*.py", True),
+        ("src/*/util/*.py", True),
+        ("docs/*.md", False),
+        ("tests/test_*.py", True),
+    ],
+)
+def test_entry_covered(entry: str, expected: bool) -> None:
+    assert _entry_covered(entry, COVERED) is expected
+
+
+@pytest.mark.parametrize(
+    ("entry", "file_path", "expected"),
+    [
+        ("src/a.py", "src/a.py", True),
+        ("src/a.py", "src/b.py", False),
+        ("src/pkg/", "src/pkg/mod.py", True),
+        ("src/pkg/", "src/pkgother/mod.py", False),
+        ("src/*.py", "src/a.py", True),
+        ("src/*.py", "src/sub/a.py", False),
+    ],
+)
+def test_entry_matches_file(entry: str, file_path: str, expected: bool) -> None:
+    assert files_expected_entry_matches(entry, file_path) is expected
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        # exact duplicates
+        ("src/a.py", "src/a.py", True),
+        # directory contains file -> overlap (stricter than before)
+        ("src/pkg/", "src/pkg/mod.py", True),
+        ("src/pkg/mod.py", "src/pkg/", True),
+        # nested directories overlap
+        ("src/pkg/", "src/pkg/sub/", True),
+        # glob covers file -> overlap
+        ("src/*.py", "src/a.py", True),
+        # disjoint
+        ("src/a.py", "src/b.py", False),
+        ("src/pkg/", "docs/", False),
+    ],
+)
+def test_entries_overlap(a: str, b: str, expected: bool) -> None:
+    assert files_expected_entries_overlap(a, b) is expected
+
+
+def test_segment_ownership_accepts_directory_scoped_files(tmp_path: Path) -> None:
+    import json
+
+    from lib_validate import check_segment_ownership
+
+    root = tmp_path
+    task_dir = root / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    (task_dir / "execution-graph.json").write_text(json.dumps({
+        "segments": [
+            {
+                "id": "seg-1",
+                "executor": "backend-executor",
+                "files_expected": ["src/andromede/"],
+                "criteria_ids": [1],
+                "depends_on": [],
+            }
+        ]
+    }))
+    violations = check_segment_ownership(
+        task_dir, "seg-1", ["src/andromede/core.py", "src/andromede/util/x.py"]
+    )
+    assert violations == []
+    # A file outside the directory is still a violation.
+    violations = check_segment_ownership(task_dir, "seg-1", ["src/elsewhere.py"])
+    assert violations == ["src/elsewhere.py"]

--- a/tests/test_investigate_finalize.py
+++ b/tests/test_investigate_finalize.py
@@ -1,0 +1,198 @@
+"""Tests for the investigate-skill conformance fixes (D7-3).
+
+The read-only investigator RETURNS its bug-report JSON; `triage.py finalize`
+owns validation (structure + citations) and persistence; the dossier-only
+guarantee is enforced by the pre-tool-use hook, not just promised in prose.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+sys.path.insert(0, str(ROOT / "debug-module"))
+
+import pre_tool_use  # noqa: E402
+
+TRIAGE = str(ROOT / "debug-module" / "triage.py")
+
+
+def _dossier(tmp_path: Path) -> Path:
+    inv_dir = tmp_path / ".dynos" / "investigations" / "20260611-120000"
+    inv_dir.mkdir(parents=True)
+    dossier_path = inv_dir / "dossier.json"
+    dossier_path.write_text(json.dumps({
+        "investigation_id": "INV-test-001",
+        "bug_type": "ci-failure",
+        "bug_text": "workflow fails on main",
+        "repo_path": str(tmp_path),
+        "evidence_index": {
+            "F-001": {"file": "src/app.py", "line": 10},
+            "S-001": {"symbol": "main", "file": "src/app.py"},
+        },
+    }))
+    return dossier_path
+
+
+_VALID_REPORT = {
+    "investigation_id": "INV-test-001",
+    "causal_chain": [
+        {"step": 1, "description": "config drift", "evidence_ids": ["F-001"]},
+    ],
+    "root_cause": {"description": "missing env var", "evidence_ids": ["F-001", "S-001"]},
+    "recommended_fix": {
+        "description": "set the var",
+        "locations": [{"file": "src/app.py", "line": 10}],
+        "evidence_ids": ["S-001"],
+    },
+}
+
+
+def _finalize(dossier: Path, report_json: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", TRIAGE, "finalize", "--report", "-", "--dossier", str(dossier)],
+        input=report_json,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_finalize_persists_valid_report_and_renders(tmp_path: Path) -> None:
+    dossier = _dossier(tmp_path)
+    result = _finalize(dossier, json.dumps(_VALID_REPORT))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "report_finalized"
+
+    report_path = Path(payload["report_path"])
+    assert json.loads(report_path.read_text())["investigation_id"] == "INV-test-001"
+    markdown = Path(payload["markdown_path"]).read_text()
+    # Renderer drift fix: bug_type comes through, causal chain renders.
+    assert "**Bug type:** ci-failure" in markdown
+    assert "No causal chain provided" not in markdown
+    assert "config drift" in markdown
+
+
+def test_finalize_tolerates_markdown_fences(tmp_path: Path) -> None:
+    dossier = _dossier(tmp_path)
+    fenced = "```json\n" + json.dumps(_VALID_REPORT) + "\n```"
+    result = _finalize(dossier, fenced)
+    assert result.returncode == 0, result.stderr
+
+
+def test_finalize_rejects_unknown_citation(tmp_path: Path) -> None:
+    dossier = _dossier(tmp_path)
+    bad = json.loads(json.dumps(_VALID_REPORT))
+    bad["root_cause"]["evidence_ids"] = ["F-999"]
+    result = _finalize(dossier, json.dumps(bad))
+    assert result.returncode == 1
+    assert "F-999" in result.stderr
+    # Nothing persisted on rejection.
+    assert not (dossier.parent / "bug_report.json").exists()
+
+
+def test_finalize_rejects_empty_evidence_ids(tmp_path: Path) -> None:
+    dossier = _dossier(tmp_path)
+    bad = json.loads(json.dumps(_VALID_REPORT))
+    bad["causal_chain"][0]["evidence_ids"] = []
+    result = _finalize(dossier, json.dumps(bad))
+    assert result.returncode == 1
+    assert "evidence_ids" in result.stderr
+
+
+def test_finalize_rejects_non_json(tmp_path: Path) -> None:
+    dossier = _dossier(tmp_path)
+    result = _finalize(dossier, "I found the bug, trust me")
+    assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Dossier-only enforcement (hook-level)
+# ---------------------------------------------------------------------------
+
+def _run_hook(
+    monkeypatch: pytest.MonkeyPatch, payload: dict
+) -> tuple[int, str]:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        code = pre_tool_use.main()
+    return code, stderr.getvalue()
+
+
+@pytest.fixture()
+def investigator_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _dossier(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('x')\n")
+    (tmp_path / "src" / "secret.py").write_text("KEY = 'x'\n")
+    monkeypatch.setenv("DYNOS_ROLE", "investigator")
+    monkeypatch.delenv("DYNOS_TASK_DIR", raising=False)
+    return tmp_path
+
+
+def test_investigator_grep_denied(investigator_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    code, err = _run_hook(monkeypatch, {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "password", "path": str(investigator_env)},
+        "cwd": str(investigator_env),
+    })
+    assert code == 2
+    assert "dossier-only" in err
+
+
+def test_investigator_reads_dossier(investigator_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dossier = investigator_env / ".dynos" / "investigations" / "20260611-120000" / "dossier.json"
+    code, err = _run_hook(monkeypatch, {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(dossier)},
+        "cwd": str(investigator_env),
+    })
+    assert code == 0, err
+
+
+def test_investigator_reads_dossier_referenced_file(
+    investigator_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    code, err = _run_hook(monkeypatch, {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(investigator_env / "src" / "app.py")},
+        "cwd": str(investigator_env),
+    })
+    assert code == 0, err
+
+
+def test_investigator_cannot_read_unreferenced_file(
+    investigator_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    code, err = _run_hook(monkeypatch, {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(investigator_env / "src" / "secret.py")},
+        "cwd": str(investigator_env),
+    })
+    assert code == 2
+    assert "dossier-only" in err
+
+
+# ---------------------------------------------------------------------------
+# Classifier taxonomy (process-shaped bugs)
+# ---------------------------------------------------------------------------
+
+def test_classifier_recognizes_ci_and_config_failures() -> None:
+    sys.path.insert(0, str(ROOT / "debug-module" / "lib"))
+    import bug_classifier
+
+    assert bug_classifier.classify("the GitHub Actions workflow fails on main")["bug_type"] == "ci-failure"
+    assert bug_classifier.classify("CI job failing after merge")["bug_type"] == "ci-failure"
+    assert bug_classifier.classify("missing environment variable DATABASE_URL in prod")["bug_type"] == "config-error"
+    # Existing classifications keep working.
+    assert bug_classifier.classify("TypeError: Cannot read properties of undefined")["bug_type"] == "runtime-error"

--- a/tests/test_refactor_decomposition.py
+++ b/tests/test_refactor_decomposition.py
@@ -580,6 +580,9 @@ class TestBinDynosUnchanged:
         "plan",
         "patterns",
         "ctl",
+        # D4 (permissions-on): generic helper-script funnel so skill prose
+        # never needs PYTHONPATH=... python3 incantations.
+        "hook",
         "postmortem",
         "registry",
         "calibration",

--- a/tests/test_scratch_namespace.py
+++ b/tests/test_scratch_namespace.py
@@ -1,0 +1,114 @@
+"""Tests for the task-scoped _scratch/ namespace (D2).
+
+_scratch/ is sanctioned temp space inside the task boundary, replacing the
+/tmp staging the skills used to prescribe (which the policy denied — P0-a in
+docs/permissions-on-design.md). Its safety property is proof-irrelevance:
+nothing in the control plane reads from _scratch/, so a scratch write can
+never certify a stage, forge evidence, or alter a receipt.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+
+def _task_dir(tmp_path: Path) -> Path:
+    task_dir = tmp_path / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    return task_dir
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        "orchestrator",
+        "planning",
+        "execute-inline",
+        "backend-executor",
+        "testing-executor",
+        "repair-coordinator",
+        "audit-security",
+        "audit-spec-completion",
+    ],
+)
+def test_recognized_actor_roles_may_write_scratch(tmp_path: Path, role: str) -> None:
+    task_dir = _task_dir(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role=role,
+            task_dir=task_dir,
+            path=task_dir / "_scratch" / "payload.json",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert decision.allowed is True, f"{role} denied scratch: {decision.reason}"
+
+
+def test_unrecognized_role_denied_scratch(tmp_path: Path) -> None:
+    task_dir = _task_dir(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="totally-made-up",
+            task_dir=task_dir,
+            path=task_dir / "_scratch" / "x.json",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False
+
+
+def test_scratch_cannot_shadow_control_plane(tmp_path: Path) -> None:
+    """A control-plane filename inside _scratch/ is just a scratch file —
+    and the real control-plane path stays protected."""
+    task_dir = _task_dir(tmp_path)
+    in_scratch = decide_write(
+        WriteAttempt(
+            role="planning",
+            task_dir=task_dir,
+            path=task_dir / "_scratch" / "manifest.json",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert in_scratch.allowed is True
+    real = decide_write(
+        WriteAttempt(
+            role="planning",
+            task_dir=task_dir,
+            path=task_dir / "manifest.json",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert real.allowed is False
+
+
+def test_no_control_plane_code_reads_scratch() -> None:
+    """Proof-irrelevance: no hook/receipt/validator resolves _scratch paths.
+
+    The only sanctioned mentions are in write_policy (the namespace rule
+    itself) and pre_tool_use (denial-message hint text).
+    """
+    allowed_files = {"write_policy.py", "pre_tool_use.py"}
+    offenders: list[str] = []
+    for py in (ROOT / "hooks").rglob("*.py"):
+        if py.name in allowed_files:
+            continue
+        text = py.read_text(encoding="utf-8", errors="ignore")
+        if re.search(r"_scratch", text):
+            offenders.append(str(py.relative_to(ROOT)))
+    assert offenders == [], (
+        f"_scratch/ must stay proof-irrelevant; control-plane code references "
+        f"it in: {offenders}"
+    )

--- a/tests/test_self_modification_guard.py
+++ b/tests/test_self_modification_guard.py
@@ -1,0 +1,198 @@
+"""Tests for the H1 self-modification guard (docs/permissions-on-design.md §D5-3).
+
+Agent roles must never be able to write the installed plugin directory
+(hooks.json, write_policy.py, ctl.py) or the host-level config locations that
+control hook execution — that is the "agent disables its own guardrails"
+primitive. The plugin source repo itself (developer mode) is exempt for the
+plugin-root check only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import write_policy  # noqa: E402
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+
+@pytest.fixture()
+def fake_plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An 'installed plugin' root: no .git, separate from the project."""
+    plugin_root = tmp_path / "installed" / "dynos-work"
+    (plugin_root / "hooks").mkdir(parents=True)
+    (plugin_root / ".claude-plugin").mkdir()
+    monkeypatch.setattr(write_policy, "_PLUGIN_ROOT", plugin_root.resolve())
+    return plugin_root
+
+
+def _project_task_dir(tmp_path: Path) -> Path:
+    task_dir = tmp_path / "project" / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    return task_dir
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["backend-executor", "execute-inline", "planning", "audit-security", "orchestrator"],
+)
+def test_agent_roles_cannot_write_installed_plugin_dir(
+    fake_plugin_root: Path, tmp_path: Path, role: str
+) -> None:
+    task_dir = _project_task_dir(tmp_path)
+    for target in (
+        fake_plugin_root / "hooks" / "write_policy.py",
+        fake_plugin_root / "hooks.json",
+        fake_plugin_root / "hooks" / "ctl.py",
+    ):
+        decision = decide_write(
+            WriteAttempt(
+                role=role,
+                task_dir=task_dir,
+                path=target,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is False, f"{role} wrote {target}"
+        assert "self-modification" in decision.reason
+
+
+def test_executor_repo_writes_still_allowed_outside_plugin_dir(
+    fake_plugin_root: Path, tmp_path: Path
+) -> None:
+    task_dir = _project_task_dir(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_dir,
+            path=tmp_path / "project" / "src" / "main.py",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is True
+
+
+def test_developer_mode_allows_plugin_repo_self_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the project IS the plugin source repo, plugin files are repo files."""
+    plugin_root = tmp_path / "dynos-work-src"
+    (plugin_root / "hooks").mkdir(parents=True)
+    (plugin_root / ".claude-plugin").mkdir()
+    (plugin_root / ".git").mkdir()
+    monkeypatch.setattr(write_policy, "_PLUGIN_ROOT", plugin_root.resolve())
+    task_dir = plugin_root / ".dynos" / "task-20260611-002"
+    task_dir.mkdir(parents=True)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_dir,
+            path=plugin_root / "hooks" / "lib_validate.py",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is True
+
+
+def test_no_task_dev_mode_requires_source_checkout(
+    fake_plugin_root: Path,
+) -> None:
+    """Installed (cache) plugin root without .git: denied even with no task."""
+    decision = decide_write(
+        WriteAttempt(
+            role="execute-inline",
+            task_dir=None,
+            path=fake_plugin_root / "hooks" / "ctl.py",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False
+    assert "self-modification" in decision.reason
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        Path(".claude") / "plugins" / "cache" / "dynos-work" / "hooks.json",
+        Path(".claude") / "settings.json",
+        Path(".claude") / "settings.local.json",
+        Path(".dynos") / "registry.json",
+    ],
+)
+def test_host_config_paths_denied_for_agent_roles(
+    fake_plugin_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: Path,
+) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    task_dir = _project_task_dir(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_dir,
+            path=fake_home / suffix,
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False
+    assert "self-modification" in decision.reason
+
+
+def test_project_memory_under_dot_claude_still_allowed(
+    fake_plugin_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only hook-controlling paths are protected, not all of ~/.claude."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    task_dir = _project_task_dir(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="docs-executor",
+            task_dir=task_dir,
+            path=fake_home / ".claude" / "projects" / "slug" / "memory" / "project_rules.md",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert decision.allowed is True
+
+
+def test_framework_roles_exempt(fake_plugin_root: Path, tmp_path: Path) -> None:
+    """The guard never fires for framework roles — they fall through to the
+    pre-existing boundary rules (which still deny ctl out-of-task writes)."""
+    task_dir = _project_task_dir(tmp_path)
+    ctl_decision = decide_write(
+        WriteAttempt(
+            role="ctl",
+            task_dir=task_dir,
+            path=fake_plugin_root / "hooks" / "anything.json",
+            operation="modify",
+            source="ctl",
+        )
+    )
+    assert "self-modification" not in ctl_decision.reason
+
+    system_decision = decide_write(
+        WriteAttempt(
+            role="system",
+            task_dir=task_dir,
+            path=fake_plugin_root / "logs" / "events.jsonl",
+            operation="modify",
+            source="system",
+        )
+    )
+    assert system_decision.allowed is True

--- a/tests/test_skill_prose_policy_contract.py
+++ b/tests/test_skill_prose_policy_contract.py
@@ -1,0 +1,204 @@
+"""Prose ↔ policy drift contract (§3 of docs/permissions-on-design.md).
+
+Every command the pipeline skills prescribe must be allowed by the write
+policy for the actor that runs it. This test extracts fenced command blocks
+from the skill/agent markdown, runs them through the PRODUCTION Bash
+destination extractor, and evaluates every detected write through the
+PRODUCTION decide_write — so any future prose change that prescribes a
+policy-denied action fails CI instead of failing a live run.
+
+It would have caught every P0 in the permissions-on incident: /tmp staging,
+`2>/dev/null` denials, `rm active-segment-role`, and the orchestrator
+audit-report write.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from pre_tool_use import _extract_bash_destinations  # noqa: E402
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+# The skills whose prose drives the start → execute → audit pipeline. The
+# orchestrator (main session) runs every command block in these files.
+PIPELINE_SKILLS = [
+    "skills/start/SKILL.md",
+    "skills/execute/SKILL.md",
+    "skills/audit/SKILL.md",
+    "skills/plan/SKILL.md",
+    "skills/investigate/SKILL.md",
+]
+
+AGENT_FILES = sorted((ROOT / "agents").glob("*.md"))
+
+_FENCE_RE = re.compile(r"```(?:bash|text|sh)\n(.*?)```", re.DOTALL)
+
+# Template placeholders → concrete values so paths resolve.
+_SUBSTITUTIONS = [
+    ("{id}", "20260611-001"),
+    ("{task-id}", "task-20260611-001"),
+    ("{task_id}", "task-20260611-001"),
+    ("{seg-id}", "seg-1"),
+    ("{segment-id}", "seg-1"),
+    ("$INVESTIGATION_DIR", ".dynos/investigations/20260611-000000"),
+    ('"$AUDIT_CONTEXT_PATH"', ".dynos/task-20260611-001/audit-context.md"),
+    ("${CLAUDE_PLUGIN_ROOT}", "/fake-plugin-root"),
+    ("${PLUGIN_HOOKS}", "/fake-plugin-root/hooks"),
+    ('"$DYNOS"', "/fake-plugin-root/bin/dynos"),
+    ("$(pwd)", "."),
+    ("$(date +%Y%m%d-%H%M%S)", "20260611-000000"),
+]
+
+
+def _command_blocks(markdown: str) -> list[str]:
+    return [m.group(1) for m in _FENCE_RE.finditer(markdown)]
+
+
+def _substituted(block: str) -> str:
+    for old, new in _SUBSTITUTIONS:
+        block = block.replace(old, new)
+    return block
+
+
+def _looks_like_commands(block: str) -> bool:
+    """Skip fenced blocks that are output samples / log lines, not commands."""
+    first = next((ln.strip() for ln in block.splitlines() if ln.strip()), "")
+    if not first:
+        return False
+    if first.startswith(("{", "#", ">", "-", "|", "[", "Foundry", "dynos-work:")):
+        return False
+    return True
+
+
+@pytest.fixture()
+def task_env(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path
+    task_dir = root / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    return root, task_dir
+
+
+@pytest.mark.parametrize("skill", PIPELINE_SKILLS)
+def test_every_prescribed_write_is_policy_allowed_for_orchestrator(
+    skill: str, task_env: tuple[Path, Path]
+) -> None:
+    root, task_dir = task_env
+    markdown = (ROOT / skill).read_text(encoding="utf-8")
+    violations: list[str] = []
+    for block in _command_blocks(markdown):
+        if not _looks_like_commands(block):
+            continue
+        command = _substituted(block)
+        for dest in _extract_bash_destinations(command):
+            path = Path(dest)
+            if not path.is_absolute():
+                path = root / dest
+            decision = decide_write(
+                WriteAttempt(
+                    role="orchestrator",
+                    task_dir=task_dir,
+                    path=path,
+                    operation="modify",
+                    source="agent",
+                )
+            )
+            if not decision.allowed:
+                violations.append(
+                    f"{skill}: block prescribes write to {dest!r} which the "
+                    f"policy DENIES for the orchestrator: {decision.reason}\n"
+                    f"--- block ---\n{block.strip()[:400]}"
+                )
+    assert violations == [], "\n\n".join(violations)
+
+
+@pytest.mark.parametrize("skill", PIPELINE_SKILLS)
+def test_no_forbidden_tokens_in_pipeline_skill_commands(skill: str) -> None:
+    markdown = (ROOT / skill).read_text(encoding="utf-8")
+    violations: list[str] = []
+    for block in _command_blocks(markdown):
+        if "/tmp/" in block:
+            violations.append(f"{skill}: command block stages a /tmp path:\n{block.strip()[:200]}")
+        if "PYTHONPATH=" in block:
+            violations.append(
+                f"{skill}: command block sets PYTHONPATH — use the dynos "
+                f"funnel instead:\n{block.strip()[:200]}"
+            )
+        if re.search(r"\brm\b[^\n]*active-segment-role", block):
+            violations.append(
+                f"{skill}: command block deletes active-segment-role — use "
+                f"`ctl clear-role`:\n{block.strip()[:200]}"
+            )
+        if re.search(r"python3 hooks/", block):
+            violations.append(
+                f"{skill}: repo-relative hook invocation breaks installed "
+                f"plugins — use the dynos funnel:\n{block.strip()[:200]}"
+            )
+    assert violations == [], "\n\n".join(violations)
+
+
+def test_no_tmp_staging_anywhere_in_skills_or_agents() -> None:
+    """/tmp staging is forbidden across ALL skills and agents — the policy
+    denies it for every non-executor actor, so prescribing it is drift."""
+    offenders: list[str] = []
+    for md in [*(ROOT / "skills").rglob("SKILL.md"), *AGENT_FILES]:
+        text = md.read_text(encoding="utf-8")
+        for block in _command_blocks(text):
+            if "/tmp/" in block:
+                offenders.append(str(md.relative_to(ROOT)))
+                break
+        else:
+            # also catch inline-code prescriptions like `--from /tmp/x.json`
+            if re.search(r"`[^`\n]*/tmp/[^`\n]*`", text):
+                offenders.append(str(md.relative_to(ROOT)))
+    assert offenders == [], f"/tmp staging prescribed in: {sorted(set(offenders))}"
+
+
+def test_agents_without_write_capability_are_not_told_to_write_files() -> None:
+    """An agent whose frontmatter lacks Write/Edit/Bash cannot materialize a
+    file; its prose must route output through its final message instead."""
+    violations: list[str] = []
+    for md in AGENT_FILES:
+        text = md.read_text(encoding="utf-8")
+        m = re.search(r"^tools:\s*\[([^\]]*)\]", text, re.MULTILINE)
+        if not m:
+            continue
+        tools = {t.strip() for t in m.group(1).split(",")}
+        if tools & {"Write", "Edit", "Bash", "MultiEdit"}:
+            continue
+        # Read-only agent: forbid imperative file-write instructions.
+        for pattern in (
+            r"[Ww]rite\s+(?:its|your|the)\s+[^.\n]{0,60}\s+to\s+`/",
+            r"[Ww]rite\s+[^.\n]{0,40}\s+to\s+`/tmp",
+            r"persists?\s+[^.\n]{0,40}\s+via\s+`python3\s",
+        ):
+            if re.search(pattern, text):
+                violations.append(f"{md.name}: read-only agent instructed to write/run: {pattern}")
+    assert violations == [], "\n".join(violations)
+
+
+def test_skill_prescribed_ctl_subcommands_exist() -> None:
+    """Every `dynos ctl <subcommand>` the pipeline skills reference must be a
+    registered ctl parser — catches prose referencing renamed commands."""
+    import subprocess
+
+    help_out = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "ctl.py"), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    known = set(re.findall(r"[a-z][a-z0-9-]+", help_out))
+    missing: list[str] = []
+    for skill in PIPELINE_SKILLS:
+        text = (ROOT / skill).read_text(encoding="utf-8")
+        for cmd in re.findall(r'"\$DYNOS" ctl ([a-z][a-z0-9-]+)', text):
+            if cmd not in known:
+                missing.append(f"{skill}: ctl subcommand {cmd!r} not registered")
+    assert missing == [], "\n".join(sorted(set(missing)))

--- a/tests/test_validator_error_messages.py
+++ b/tests/test_validator_error_messages.py
@@ -1,0 +1,134 @@
+"""Tests for self-correcting validator errors (D7-4).
+
+Enum violations must name the valid set and offer a did-you-mean hint;
+Reference-Code path checking must not reject non-path backtick tokens or
+files declared under a 'Files to be created' heading. Per the 2026-06
+decision, domain "ci" stays OUT of VALID_DOMAINS and hints to "infra".
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from lib_core import VALID_DOMAINS  # noqa: E402
+from lib_validate import (  # noqa: E402
+    invalid_enum_error,
+    validate_manifest,
+    validate_task_artifacts,
+)
+
+
+def test_ci_is_not_a_valid_domain() -> None:
+    assert "ci" not in VALID_DOMAINS
+
+
+def test_ci_domain_error_hints_infra() -> None:
+    msg = invalid_enum_error("classification domain", "ci", VALID_DOMAINS)
+    assert "valid values:" in msg
+    assert "infra" in msg
+    assert "did you mean 'infra'?" in msg
+
+
+def test_executor_error_hints_suffix() -> None:
+    msg = invalid_enum_error("seg-1: executor", "backend", {"backend-executor", "ui-executor"})
+    assert "did you mean 'backend-executor'?" in msg
+
+
+def test_typo_hint_via_difflib() -> None:
+    msg = invalid_enum_error("classification domain", "bakend", VALID_DOMAINS)
+    assert "did you mean 'backend'?" in msg
+
+
+def test_no_hint_for_unrelated_value() -> None:
+    msg = invalid_enum_error("classification domain", "zzzz", VALID_DOMAINS)
+    assert "valid values:" in msg
+    assert "did you mean" not in msg
+
+
+def test_manifest_domain_error_includes_valid_set() -> None:
+    errors = validate_manifest({
+        "task_id": "task-20260611-001",
+        "stage": "PLANNING",
+        "classification": {
+            "type": "feature",
+            "risk_level": "low",
+            "domains": ["ci"],
+        },
+    })
+    domain_errors = [e for e in errors if "classification domain" in e]
+    assert domain_errors, errors
+    assert "infra" in domain_errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Reference Code path checking
+# ---------------------------------------------------------------------------
+
+def _write_task(tmp_path: Path, plan_reference_section: str) -> Path:
+    task_dir = tmp_path / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    (task_dir / "manifest.json").write_text(json.dumps({
+        "task_id": "task-20260611-001",
+        "created_at": "2026-06-11T00:00:00Z",
+        "raw_input": "x",
+        "stage": "PLANNING",
+        "classification": {
+            "type": "feature",
+            "domains": ["docs"],
+            "risk_level": "low",
+        },
+    }))
+    (task_dir / "spec.md").write_text(
+        "## Task Summary\nA.\n\n## User Context\nB.\n\n"
+        "## Acceptance Criteria\n1. One criterion\n\n"
+        "## Implicit Requirements Surfaced\nC.\n\n## Out of Scope\nD.\n\n"
+        "## Assumptions\nsafe assumption: none\n\n## Risk Notes\nE.\n"
+    )
+    (task_dir / "plan.md").write_text(
+        "## Technical Approach\nA.\n\n"
+        f"## Reference Code\n{plan_reference_section}\n\n"
+        "## Components / Modules\n`docs/notes.md`\n\n"
+        "## Data Flow\nD.\n\n## Error Handling Strategy\nE.\n\n"
+        "## Test Strategy\nF.\n\n## Dependency Graph\nG.\n\n## Open Questions\nH.\n"
+    )
+    (tmp_path / "docs").mkdir(exist_ok=True)
+    (tmp_path / "docs" / "notes.md").write_text("x")
+    return task_dir
+
+
+def _ref_errors(task_dir: Path) -> list[str]:
+    errors = validate_task_artifacts(task_dir, run_gap=False)
+    return [e for e in errors if "Reference Code path" in e]
+
+
+def test_bare_filename_tokens_are_not_path_checked(tmp_path: Path) -> None:
+    task_dir = _write_task(tmp_path, "See `policy.json` and `settings.yaml` concepts.")
+    assert _ref_errors(task_dir) == []
+
+
+def test_missing_slash_path_still_rejected(tmp_path: Path) -> None:
+    task_dir = _write_task(tmp_path, "See `src/missing/file.py`.")
+    errors = _ref_errors(task_dir)
+    assert errors
+    assert "Files to be created" in errors[0]  # remediation guidance present
+
+
+def test_files_to_be_created_section_exempts_paths(tmp_path: Path) -> None:
+    task_dir = _write_task(
+        tmp_path,
+        "See `src/new/module.py`.\n\n"
+        "### Files to be created\n\n- `src/new/module.py`\n",
+    )
+    assert _ref_errors(task_dir) == []
+
+
+def test_existing_path_passes(tmp_path: Path) -> None:
+    task_dir = _write_task(tmp_path, "See `docs/notes.md`.")
+    assert _ref_errors(task_dir) == []

--- a/tests/test_verification_evidence.py
+++ b/tests/test_verification_evidence.py
@@ -1,0 +1,272 @@
+"""Tests for the verification-evidence runner (D6).
+
+Execution-graph segments declare `verify_commands`; `ctl
+run-verification-evidence` executes them and captures exit codes + output
+into a ctl-owned artifact that auditors read instead of trusting an
+executor's narrative claim. Executors cannot write or doctor the artifact,
+and run-execution-finish refuses to advance while a declared verification
+is missing or failing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from lib_receipts import hash_file, read_receipt  # noqa: E402
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+from test_ctl import _run_ctl, _setup_task_dir  # noqa: E402
+
+
+def _add_verify_commands(task_dir: Path, seg_id: str, commands: list[dict]) -> None:
+    graph = json.loads((task_dir / "execution-graph.json").read_text())
+    for seg in graph["segments"]:
+        if seg["id"] == seg_id:
+            seg["verify_commands"] = commands
+    (task_dir / "execution-graph.json").write_text(json.dumps(graph, indent=2))
+
+
+def test_runner_captures_pass_and_writes_receipt(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path)
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "true", "criteria_ids": [1]},
+        {"id": "vc-2", "command": "echo checked"},
+    ])
+
+    result = _run_ctl("run-verification-evidence", str(task_dir))
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "verification_captured"
+
+    artifact_path = task_dir / "evidence" / "verification" / "seg-1.json"
+    artifact = json.loads(artifact_path.read_text())
+    assert artifact["all_passed"] is True
+    by_id = {r["id"]: r for r in artifact["results"]}
+    assert by_id["vc-1"]["exit_code"] == 0
+    assert by_id["vc-1"]["criteria_ids"] == [1]
+    assert "checked" in by_id["vc-2"]["stdout_tail"]
+
+    receipt = read_receipt(task_dir, "verification-evidence-seg-1")
+    assert receipt["artifact_sha256"] == hash_file(artifact_path)
+    assert receipt["all_passed"] is True
+    assert receipt["command_count"] == 2
+
+
+def test_runner_captures_failure_faithfully(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path)
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "echo broken >&2; exit 3"},
+    ])
+
+    result = _run_ctl("run-verification-evidence", str(task_dir))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "verification_failed"
+
+    artifact = json.loads(
+        (task_dir / "evidence" / "verification" / "seg-1.json").read_text()
+    )
+    record = artifact["results"][0]
+    assert record["exit_code"] == 3
+    assert record["passed"] is False
+    assert "broken" in record["stderr_tail"]
+    # The receipt records the failure — it does not certify success.
+    receipt = read_receipt(task_dir, "verification-evidence-seg-1")
+    assert receipt["all_passed"] is False
+
+
+def test_agent_roles_cannot_write_verification_evidence(tmp_path: Path) -> None:
+    task_dir = tmp_path / ".dynos" / "task-20260611-001"
+    task_dir.mkdir(parents=True)
+    target = task_dir / "evidence" / "verification" / "seg-1.json"
+    for role in ("backend-executor", "execute-inline", "testing-executor",
+                 "orchestrator", "planning", "audit-security"):
+        decision = decide_write(
+            WriteAttempt(
+                role=role,
+                task_dir=task_dir,
+                path=target,
+                operation="create",
+                source="agent",
+            )
+        )
+        assert decision.allowed is False, f"{role} doctored verification evidence"
+    ctl_decision = decide_write(
+        WriteAttempt(
+            role="ctl",
+            task_dir=task_dir,
+            path=target,
+            operation="create",
+            source="ctl",
+        )
+    )
+    assert ctl_decision.allowed is True
+
+
+def _finish_ready_task(tmp_path: Path) -> Path:
+    """A task at EXECUTION with all receipts/evidence in place (mirrors
+    test_ctl.test_run_execution_finish_transitions_when_no_pending_segments)."""
+    from lib_receipts import (
+        receipt_executor_done,
+        receipt_executor_routing,
+        receipt_plan_validated,
+        receipt_rules_check_passed,
+    )
+
+    task_dir = _setup_task_dir(tmp_path)
+    manifest_path = task_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["stage"] = "EXECUTION"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    os.environ["DYNOS_ALLOW_TEST_OVERRIDE"] = "1"
+    try:
+        receipt_plan_validated(task_dir, validation_passed_override=True)
+    finally:
+        os.environ.pop("DYNOS_ALLOW_TEST_OVERRIDE", None)
+
+    receipt_executor_routing(task_dir, [
+        {"segment_id": "seg-1", "executor": "backend-executor", "model": "sonnet",
+         "route_mode": "generic", "agent_path": None},
+        {"segment_id": "seg-2", "executor": "testing-executor", "model": "sonnet",
+         "route_mode": "generic", "agent_path": None},
+    ])
+
+    root = task_dir.parent.parent
+    for expected in ("src/a.py", "tests/test_a.py"):
+        target = root / expected
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# produced by execution\n")
+
+    evidence_dir = task_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for seg_id in ("seg-1", "seg-2"):
+        evidence_path = evidence_dir / f"{seg_id}.md"
+        evidence_path.write_text(f"{seg_id} evidence\n")
+        sidecar_dir = task_dir / "receipts" / "_injected-prompts"
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        digest = ("f" if seg_id == "seg-1" else "a") * 64
+        (sidecar_dir / f"{seg_id}.sha256").write_text(digest)
+        receipt_executor_done(
+            task_dir,
+            segment_id=seg_id,
+            executor_type="backend-executor" if seg_id == "seg-1" else "testing-executor",
+            model_used="sonnet",
+            injected_prompt_sha256=digest,
+            agent_name=None,
+            evidence_path=str(evidence_path),
+            tokens_used=5,
+            diff_verified_files=[],
+            no_op_justified=False,
+        )
+    receipt_rules_check_passed(task_dir, "all")
+    return task_dir
+
+
+def test_finish_blocks_until_declared_verification_passes(tmp_path: Path) -> None:
+    task_dir = _finish_ready_task(tmp_path)
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "true"},
+    ])
+
+    # 1. No verification record yet: finish must block.
+    result = _run_ctl("run-execution-finish", str(task_dir))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert any("verification evidence missing" in f for f in payload["failures"])
+
+    # 2. Capture the verification, then finish succeeds.
+    capture = _run_ctl("run-verification-evidence", str(task_dir))
+    assert capture.returncode == 0, capture.stdout + capture.stderr
+    result = _run_ctl("run-execution-finish", str(task_dir))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_finish_blocks_on_failing_verification(tmp_path: Path) -> None:
+    task_dir = _finish_ready_task(tmp_path)
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "exit 7"},
+    ])
+    capture = _run_ctl("run-verification-evidence", str(task_dir))
+    assert capture.returncode == 1
+
+    result = _run_ctl("run-execution-finish", str(task_dir))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert any("failed (exit 7)" in f for f in payload["failures"])
+
+
+def test_finish_blocks_on_stale_verification_record(tmp_path: Path) -> None:
+    """A record captured for a DIFFERENT command than the approved graph's
+    must not satisfy the gate (anti-substitution)."""
+    task_dir = _finish_ready_task(tmp_path)
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "true"},
+    ])
+    capture = _run_ctl("run-verification-evidence", str(task_dir))
+    assert capture.returncode == 0
+    # The graph's command changes after capture (e.g. plan amendment).
+    _add_verify_commands(task_dir, "seg-1", [
+        {"id": "vc-1", "command": "ruff check src"},
+    ])
+    result = _run_ctl("run-execution-finish", str(task_dir))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert any("different command" in f for f in payload["failures"])
+
+
+def test_write_execution_graph_normalizes_verify_commands(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path / "fresh")
+    graph = {
+        "segments": [
+            {
+                "id": "seg-1",
+                "executor": "backend-executor",
+                "description": "Build",
+                "files_expected": ["src/app.py"],
+                "criteria_ids": [1],
+                "depends_on": [],
+                "verify_commands": [
+                    {"id": "vc-1", "command": "ruff check src", "criteria_ids": [1]},
+                ],
+            }
+        ]
+    }
+    payload_path = tmp_path / "graph.json"
+    payload_path.write_text(json.dumps(graph))
+    result = _run_ctl("write-execution-graph", str(task_dir), "--from", str(payload_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+    persisted = json.loads((task_dir / "execution-graph.json").read_text())
+    assert persisted["segments"][0]["verify_commands"] == [
+        {"id": "vc-1", "command": "ruff check src", "criteria_ids": [1]}
+    ]
+
+
+def test_write_execution_graph_rejects_malformed_verify_commands(tmp_path: Path) -> None:
+    task_dir = _setup_task_dir(tmp_path / "fresh")
+    graph = {
+        "segments": [
+            {
+                "id": "seg-1",
+                "executor": "backend-executor",
+                "description": "Build",
+                "files_expected": ["src/app.py"],
+                "criteria_ids": [1],
+                "depends_on": [],
+                "verify_commands": [{"id": "", "command": ""}],
+            }
+        ]
+    }
+    payload_path = tmp_path / "graph.json"
+    payload_path.write_text(json.dumps(graph))
+    result = _run_ctl("write-execution-graph", str(task_dir), "--from", str(payload_path))
+    assert result.returncode == 1
+    assert "verify_commands" in result.stderr


### PR DESCRIPTION
## Summary

A real permissions-ON run (no `--dangerously-skip-permissions`, no blanket allow) showed the plugin denying actions its own skills prescribe: `/tmp` payload staging, `2>/dev/null` redirects, `rm active-segment-role`, orchestrator writes blocked by whatever role was last stamped for a subagent, and `run-execution-verify-evidence` hard-erroring after `run-execution-finish`.

This PR fixes the causes while tightening every guardrail it touches. Design rationale with file:line evidence: `docs/permissions-on-design.md`. Spec addendum: `docs/write-boundary-spec.md`. Full change list: CHANGELOG `[7.4.1]`.

## Highlights

- **Per-actor roles (D3):** SessionStart pins the orchestrator session (hook-owned); the main session always resolves to a least-privilege `orchestrator` role and never reads role files. Subagents consume single-use, allowlist-validated grants bound immutably per session. `ctl clear-role` replaces the policy-denied `rm`. Legacy role-file resolution preserved for unpinned sessions; degraded mode fails closed with a named diagnostic.
- **Verification evidence (D6):** segments declare `verify_commands`; ctl executes them and captures exit codes/output into executor-unwritable `evidence/verification/`, hash-bound by a receipt. The finish gate requires passing records; the spec-completion auditor cites the record instead of trusting executor narrative.
- **No raw writes prescribed anywhere:** stdin payloads (`--from -` heredocs), `.dynos/task-*/_scratch/` namespace, `ctl run-start-init`, `ctl tdd-receipt`, and the `dynos hook` funnel (no more `PYTHONPATH=` incantations). One allowlistable prefix: `<plugin-root>/bin/dynos`.
- **Quote-aware Bash detection (D5):** shlex tokenization + heredoc stripping; quoted `>` in prompt text can no longer be a "write destination". Denials self-identify as plugin guardrails and name the sanctioned alternative.
- **New hole closed (H1):** executor roles could write the installed plugin directory itself (hooks.json, write_policy.py, ctl.py) plus `~/.claude/plugins` and `~/.dynos` — now denied for all agent roles (developer mode exempts the plugin source repo only).
- **Drift-proofing:** `tests/test_skill_prose_policy_contract.py` runs every fenced command block in the pipeline skills through the production extractor + `decide_write`; any prescribed-but-denied action fails CI.

## Invariants preserved (with tests)

- No self-elevation: orchestrator denied `audit-reports/` even after granting an audit role (`test_actor_identity.py`); grants allowlist-only; pin/ledger/bindings are not agent-writable; plugin dir/settings unwritable (`test_self_modification_guard.py`)
- No forged receipts/evidence: `_scratch/` is proof-irrelevant by CI assertion; verification evidence is ctl-owned and hash-receipted; spawn-log cross-check untouched
- Human gates at spec/plan/TDD: `approve-stage` untouched, never absorbed into a run-* command
- Auditors never certify unverified claims: ACs without machine evidence remain BLOCKING exactly as before — they just have real evidence to read now

## Testing

- ~90 new tests across 10 new test files; full suite: 2544 passed, failure set byte-identical to the pre-change baseline (23 pre-existing failures in worktree/learning-runtime/registry areas untouched by this PR)
- `debug-module` suite: 175 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)