### PR TITLE
chore: sync marketplace.json version to 7.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "dynos-work",
-      "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.2.0",
+      "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs \u2014 calibrates to your project over time.",
+      "version": "7.4.1",
       "source": "./",
       "author": {
         "name": "dynos.fit",


### PR DESCRIPTION
One-line metadata sync: the marketplace manifest was stale at 7.2.0 while plugin.json moved to 7.4.1. The installer reads plugin.json so nothing broke — this just removes the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)