### PR TITLE
fix: make subagent write-roles work under Claude Code (orchestrator role adoption)

### DIFF
--- a/hooks/lib_log.py
+++ b/hooks/lib_log.py
@@ -88,6 +88,10 @@ DIAGNOSTIC_ONLY_EVENTS: frozenset[str] = frozenset({
     # state machine depends on these events.
     "pre_tool_use_audit_plan_missing",
     "pre_tool_use_audit_plan_invalid",
+    # Orchestrator adopted the stamped active-segment-role under a
+    # non-isolating harness (Claude Code; pre_tool_use.py _subagent_isolation
+    # = False). Forensic trace only — no gate depends on it.
+    "orchestrator_role_adopted",
     # Read-policy decision observability (read_policy gate, task-20260501-002).
     # Forensic trace recording allow/deny decisions for read attempts.
     # Observability only — no gate or state machine depends on these events.

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -33,6 +33,54 @@ _EXECUTOR_ROLE_ALLOWLIST: frozenset[str] = frozenset({
     "audit-performance", "audit-dead-code", "audit-db-schema", "audit-ui", "audit-claude-md",
 })
 
+
+def _subagent_isolation(task_dir: "Path | None") -> bool:
+    """True only when the host harness gives each subagent a DISTINCT
+    session_id, making per-subagent write-role enforcement meaningful.
+
+    Default False: Claude Code shares the orchestrator's session_id across
+    all subagents with no distinguishing field (GitHub issue #7881), so a
+    planner/executor/auditor subagent resolves as the orchestrator. With
+    isolation False the orchestrator is permitted to ADOPT the stamped
+    active-segment-role so it can act as that segment's role; otherwise no
+    subagent could ever author its role-scoped artifacts.
+
+    Set ``"subagent_isolation": true`` in
+    ``<project>/.dynos/config/policy.json`` ONLY on a harness that truly
+    isolates subagent sessions — that restores the strict D3 behavior where
+    the orchestrator never adopts a stamped role.
+    """
+    if task_dir is None:
+        return False
+    try:
+        cfg = task_dir.parent.parent / ".dynos" / "config" / "policy.json"
+        if not cfg.is_file():
+            return False
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+        return bool(isinstance(data, dict) and data.get("subagent_isolation", False))
+    except Exception:
+        return False
+
+
+def _adoptable_stamped_role(task_dir: "Path | None") -> "str | None":
+    """Return the stamped active-segment-role when it is a valid,
+    non-orchestrator executor/planning/audit role; else None. Lets the
+    orchestrator session adopt the current segment role under a
+    non-isolating harness (see ``_subagent_isolation``)."""
+    if task_dir is None:
+        return None
+    try:
+        rf = task_dir / "active-segment-role"
+        if not rf.is_file():
+            return None
+        val = rf.read_text(encoding="utf-8").strip()
+        if val and val != "orchestrator" and val in _EXECUTOR_ROLE_ALLOWLIST:
+            return val
+    except Exception:
+        return None
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Module-level imports for write_policy, read_policy, and lib_log.
 # These are resolved lazily at first-use inside main() so the hook can still
@@ -619,8 +667,37 @@ def main() -> int:
         # to the legacy chain wholesale (today's behavior, no regression).
         if task_dir is not None and actor_identity is not None and pin and session_id:
             if session_id == pin.get("session_id"):
-                role = "orchestrator"
-                role_missing = False
+                # Orchestrator session. Strict D3 (subagent_isolation=true):
+                # never adopt a stamped role — prevents self-escalation.
+                # Under a non-isolating harness like Claude Code (default),
+                # subagents share this session_id with no distinguisher
+                # (issue #7881), so the orchestrator MUST adopt the stamped
+                # active-segment-role to act as the planner/executor/auditor
+                # for the segment, else no subagent can author its
+                # role-scoped artifacts. Forgery defenses are unaffected:
+                # control-plane.json and the pin are denied to ALL roles,
+                # and audit-report writes remain cross-checked against
+                # spawn-log.jsonl at receipt time.
+                adopted = (
+                    None if _subagent_isolation(task_dir)
+                    else _adoptable_stamped_role(task_dir)
+                )
+                if adopted is not None:
+                    role = adopted
+                    role_missing = False
+                    try:
+                        if log_event is not None:
+                            log_event(
+                                task_dir.parent.parent,
+                                "orchestrator_role_adopted",
+                                task=task_dir.name,
+                                role=adopted,
+                            )
+                    except Exception:
+                        pass
+                else:
+                    role = "orchestrator"
+                    role_missing = False
             else:
                 bound = actor_identity.lookup_binding(task_dir, session_id)
                 if bound is None:

--- a/tests/test_actor_identity.py
+++ b/tests/test_actor_identity.py
@@ -1,7 +1,11 @@
 """Tests for per-actor role resolution (D3 in docs/permissions-on-design.md).
 
-The orchestrator session is pinned at SessionStart and ALWAYS resolves to the
-'orchestrator' role; subagent sessions consume single-use grants. The suite's
+The orchestrator session is pinned at SessionStart. On a harness that
+isolates subagent sessions (subagent_isolation=true) it ALWAYS resolves to the
+'orchestrator' role and never adopts a stamped role; under Claude Code (default
+subagent_isolation=false) it adopts the stamped active-segment-role so it can
+act as that segment's planner/executor/auditor. Subagent sessions, when the
+harness provides distinct ones, consume single-use grants. The suite's
 most important member is the self-elevation regression: granting an audit
 role must NOT let the orchestrator write audit-reports/.
 """
@@ -110,19 +114,68 @@ def test_orchestrator_cannot_write_audit_reports_even_with_audit_grant(
     assert "degraded actor resolution" in err
 
 
-def test_orchestrator_ignores_stamped_role_file(
+def test_orchestrator_adopts_stamped_role_when_not_isolated(
     project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The P1-a fix: stamping a subagent role no longer mutates the
-    orchestrator's own rights."""
+    """Claude Code default (subagent_isolation unset -> False): the orchestrator
+    session ADOPTS the stamped active-segment-role so it can author that
+    segment's artifacts. Required because Claude Code subagents share the
+    orchestrator session_id (issue #7881) and would otherwise never be able to
+    write their role-scoped outputs."""
     task_dir = _task_dir(project)
     (task_dir / "active-segment-role").write_text("planning")
-    # planning may write spec.md — the orchestrator must NOT inherit that.
+    # planning may write spec.md; the orchestrator now adopts that role.
     code, err = _run_hook(
         monkeypatch,
         session_id=ORCH_SESSION,
         tool_name="Write",
         tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 0, err
+
+
+def test_orchestrator_ignores_stamped_role_when_subagent_isolation(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Strict D3 mode (subagent_isolation=true): on a harness that isolates
+    subagent sessions, the orchestrator must NOT adopt a stamped role — the
+    original P1-a self-elevation defense is preserved as an opt-in."""
+    task_dir = _task_dir(project)
+    cfg = project / ".dynos" / "config"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "policy.json").write_text(json.dumps({"subagent_isolation": True}))
+    (task_dir / "active-segment-role").write_text("planning")
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={"file_path": str(task_dir / "spec.md"), "content": "# spec"},
+        cwd=project,
+    )
+    assert code == 2
+    assert "role=orchestrator" in err
+
+
+def test_orchestrator_audit_write_still_blocked_under_isolation(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even with adoption available, strict mode keeps the audit-report
+    self-elevation defense: under subagent_isolation, a stamped audit role is
+    NOT adopted by the orchestrator."""
+    task_dir = _task_dir(project)
+    cfg = project / ".dynos" / "config"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "policy.json").write_text(json.dumps({"subagent_isolation": True}))
+    (task_dir / "active-segment-role").write_text("audit-security")
+    code, err = _run_hook(
+        monkeypatch,
+        session_id=ORCH_SESSION,
+        tool_name="Write",
+        tool_input={
+            "file_path": str(task_dir / "audit-reports" / "security-1.json"),
+            "content": "{}",
+        },
         cwd=project,
     )
     assert code == 2


### PR DESCRIPTION
## Problem

dynos-work's actor model (D3) tells the orchestrator apart from subagents by `session_id`: the main session is pinned at SessionStart → `orchestrator`; any *other* session_id consumes a single-use role grant. **This assumes the harness gives each spawned subagent a distinct session_id.**

**Claude Code does not.** A subagent spawned via the Task/Agent tool makes tool calls carrying the *same* `session_id` and `transcript_path` as the orchestrator, with no documented distinguishing field ([claude-code#7881](https://github.com/anthropics/claude-code/issues/7881)). So every planner/executor/auditor subagent resolves as `orchestrator`, never consumes its grant, and `write_policy` denies its writes to role-scoped artifacts (`design-doc.md`/`spec.md`/`plan.md`, repo files, `evidence/`, `audit-reports/`).

Net effect: `/dynos-work:start` and `:execute` could only complete in fast-track **inline** mode; any delegated subagent was blocked. This was hit live trying to run `/dynos-work:start` — the planner could not persist `design-doc.md` and had to stage it to `_scratch/`.

## Fix

Add a `subagent_isolation` capability flag (read from `.dynos/config/policy.json`, **default `False`**):

- **isolation `False` (Claude Code, default):** the pinned orchestrator session **adopts** the stamped `active-segment-role`, so it can act as that segment's planner/executor/auditor. This makes the existing `ctl stamp-role` calls (already issued before every spawn) actually effective.
- **isolation `True`:** strict D3 preserved — the orchestrator never adopts a stamped role (opt-in for a harness that truly isolates subagent sessions).

Forgery defenses are unchanged and remain the real guard:
- `control-plane.json` and the orchestrator pin are denied to **all** roles.
- `audit-reports/` writes are still cross-checked against `spawn-log.jsonl` at receipt time — a stamped audit role can't fabricate a passing audit without a real receipted auditor spawn.

Adoption only grants what the stamped role legitimately may write; an unset/non-allowlisted role file still resolves to `orchestrator`.

## Why not the alternative ("promote from `_scratch`")

A first pass added a `ctl promote-artifact` command (subagent stages to `_scratch/`, control plane copies to canonical path). It was **reverted**: it violates the `_scratch` *proof-irrelevance* invariant (`test_no_control_plane_code_reads_scratch`) — no control-plane code may read `_scratch/`, or a scratch write could certify a stage. It's also redundant under this fix: with the stamped role adopted, the planner writes `spec.md`/`plan.md` directly.

## Tests

- `test_orchestrator_adopts_stamped_role_when_not_isolated` (default Claude path)
- `test_orchestrator_ignores_stamped_role_when_subagent_isolation` (strict mode)
- `test_orchestrator_audit_write_still_blocked_under_isolation` (self-elevation defense preserved)
- Replaces the now-conditional `test_orchestrator_ignores_stamped_role_file`; updates the module docstring.
- Allowlists the new diagnostic `orchestrator_role_adopted` event.

Touched actor/write-policy/role/scratch suites: **82 passed**. No new failures across the full suite (pre-existing failures are Python-3.9/git-worktree environment issues, confirmed against pristine HEAD).

## Deploy note

Live hooks run from the installed plugin cache, not the working tree — **this takes effect on plugin reinstall** (`git pull` + reinstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)