### PR TITLE
chore: release 7.5.1 — deploy Claude subagent role-adoption fix (#212)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs \u2014 calibrates to your project over time.",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs \u2014 calibrates to your project over time.",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.1] - 2026-06-15
+### "Claude Subagent Compatibility": Stamped Roles Work Where Subagents Share a Session
+
+Claude Code spawns subagents that share the orchestrator's `session_id` and `transcript_path` with no distinguishing field (claude-code #7881), so the D3 per-session actor model resolved every planner/executor/auditor subagent as `orchestrator`. Their role grants went unconsumed and `write_policy` denied their role-scoped writes — the planning and execute pipelines could only complete in fast-track inline mode. (#212)
+
+### Fixed
+- **Orchestrator role adoption:** a new `subagent_isolation` capability flag (`.dynos/config/policy.json`, default `false`) lets the pinned orchestrator session adopt the stamped `active-segment-role` on harnesses that do not isolate subagent sessions (Claude Code), making the existing `ctl stamp-role` calls effective. Setting `subagent_isolation: true` restores strict D3 (the orchestrator never adopts a stamped role).
+- Forgery defenses unchanged: `control-plane.json` and the orchestrator-session pin remain denied to all roles; `audit-reports/` writes remain cross-checked against `spawn-log.jsonl` at receipt time.
+- New diagnostic event `orchestrator_role_adopted` allowlisted in `hooks/lib_log.py`.
+
+### Plugin / Distribution
+- Bump `.claude-plugin/plugin.json`, `package.json`, `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` to `7.5.1`.
+
+---
+
 ## [7.5.0] - 2026-06-12
 ### "Selection, Durability, Enforcement, Scope": Four-Layer Foundation for Audited Execution
 

--- a/docs/permissions-on-design.md
+++ b/docs/permissions-on-design.md
@@ -173,6 +173,32 @@ not, key on `transcript_path` (also harness-provided) instead. If *neither*
 distinguishes actors, fall back to a reduced design: keep the role file for subagents
 but exclude the orchestrator by D3-1/2 — that alone fixes P0-c and the worst of P1-a.
 
+**Update — 7.5.1 (orchestrator role adoption; PR #212).** The phase-0 verification
+above resolved to the worst case: **Claude Code subagents carry neither a distinct
+`session_id` nor a distinct `transcript_path`** (claude-code #7881; no separate
+subagent transcript file). The documented fallback ("keep the role file for subagents
+but exclude the orchestrator") does not help, because the subagent *is* the
+orchestrator session — D3-2's "*never* the role file" rule therefore made every
+planner/executor/auditor subagent resolve as `orchestrator` and denied all of its
+role-scoped writes (design-doc/spec/plan, repo source, `evidence/`, `audit-reports/`).
+The pipeline only completed in fast-track inline mode.
+
+The shipped resolution amends D3-2 with a `subagent_isolation` capability flag
+(`.dynos/config/policy.json`, default **false**):
+- **`false` (Claude Code default):** the pinned orchestrator session *adopts* the
+  stamped `active-segment-role` (validated against the executor/planning/audit
+  allowlist; an unset or non-allowlisted role file still resolves to `orchestrator`),
+  so the `ctl stamp-role` calls already issued before every spawn become effective.
+- **`true`:** strict D3 is preserved — the orchestrator never adopts a stamped role
+  (for a future harness that genuinely isolates subagent sessions).
+
+The self-elevation analysis still holds: `control-plane.json` and the
+orchestrator-session pin are denied to all roles regardless, and
+`receipt_audit_done`'s spawn-log cross-check still rejects any `audit-reports/` write
+not backed by a real receipted spawn — adoption moves provenance enforcement to
+receipt time, it does not weaken it. Implementation:
+`hooks/pre_tool_use.py` (`_subagent_isolation`, `_adoptable_stamped_role`).
+
 **Self-elevation analysis.**
 - Roles still come only from the ctl allowlist; sessions never name their own role.
 - The orchestrator cannot consume a grant (its session is pinned first, at startup).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone \u2014 no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",


### PR DESCRIPTION
Bumps the version to **7.5.1** across `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `package.json`, plus a CHANGELOG entry.

**Why:** #212 (the subagent role-adoption fix) is already on `main`, but `marketplace.json` still said `7.5.0`. The plugin update flow keys on version, so `/plugin` update would treat 7.5.0 as already installed and never pull the fix. This bump makes it deployable.

No code changes — version + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)