### PR TITLE
fix: harden write/grant/receipt guardrails — 7 security findings

### DIFF
--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -2591,6 +2591,13 @@ def cmd_spawn_prep(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # AC 5: Validate role immediately after task_dir guard — before any artifact
+    # parsing or grant logic.  Non-allowlisted roles are rejected here even on
+    # the continuation / resume path.
+    role = _validated_grant_role("spawn-prep", args.role)
+    if role is None:
+        return 1
+
     artifact_path = Path(args.artifact)
     basename = artifact_path.name
     m = _SPAWN_PREP_ARTIFACT_RE.match(basename)
@@ -2624,9 +2631,8 @@ def cmd_spawn_prep(args: argparse.Namespace) -> int:
         )
         return 1
 
-    role = args.role
-
     # AC 9: If artifact already exists with status='partial', return continuation.
+    # Continuation resumes without appending a new grant — no privilege escalation.
     if artifact_path.exists():
         try:
             existing = load_json(artifact_path)

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -258,10 +258,11 @@ def _extract_bash_destinations(command: str) -> list[str]:
         tok = tokens[i]
         # Redirection operator: next token is the destination. Punctuation
         # runs may glue a trailing newline onto the operator; normalize.
-        op = tok.strip()
+        # Strip backticks so tokens like `` `cp `` resolve correctly as verbs.
+        op = tok.strip().strip("`")
         if op in _REDIRECT_TOKENS:
             if i + 1 < n:
-                _add(tokens[i + 1])
+                _add(tokens[i + 1].strip("`"))
                 i += 2
                 continue
         # Write verb: collect its argv tail up to the next separator. The
@@ -274,7 +275,7 @@ def _extract_bash_destinations(command: str) -> list[str]:
             args: list[str] = []
             j = i + 1
             while j < n and tokens[j] not in _COMMAND_SEPARATOR_TOKENS:
-                t = tokens[j]
+                t = tokens[j].strip("`")
                 if t in _REDIRECT_TOKENS:
                     break
                 if t != "--" and not t.startswith("-"):
@@ -403,6 +404,20 @@ def _watchdog_targets_artifact(
                 except Exception:
                     if dest == artifact_abs:
                         return True
+    elif tool_name == "MultiEdit":
+        for edit in tool_input.get("edits", []):
+            if not isinstance(edit, dict):
+                continue
+            raw = edit.get("file_path", edit.get("path", ""))
+            if not raw:
+                continue
+            try:
+                if Path(raw).resolve() == Path(artifact_abs).resolve():
+                    return True
+            except Exception:
+                pass
+            if raw == artifact_abs or os.path.abspath(raw) == artifact_abs:
+                return True
     return False
 
 

--- a/hooks/read_policy.py
+++ b/hooks/read_policy.py
@@ -195,6 +195,11 @@ def _handle_dead_code_grep_quota(attempt: ReadAttempt) -> ReadDecision:
             # allow. The quota state is corrupt (slot consumed but not
             # persisted); subsequent calls would re-read the old count and
             # over-grant. Spec AC 9 mandates fail-closed on quota corruption.
+            # AC 8: clean up the stray .tmp file if os.replace raised
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
             return ReadDecision(
                 allowed=False,
                 reason="read-policy: quota state unwritable; denying repo-wide grep",

--- a/hooks/receipts/core.py
+++ b/hooks/receipts/core.py
@@ -123,12 +123,13 @@ MIN_VERSION_PER_STEP: dict[str, int] = {
     # invariant as human-approval receipts. v5 receipts on disk remain
     # readable; only new auto-approval-* writes carry contract_version=6.
     "auto-approval-*": 6,
-    # v6 -> v7 bump (task-20260611-001): spawn receipts now carry
-    # {host, tier, resolved_model} v7 fields. The floor ensures consumers
-    # that depend on host/tier/resolved_model fields reject pre-v7 spawn
-    # receipts that lack these fields. Pre-v7 spawn receipts on disk remain
-    # readable by callers that pass min_version=1; only new spawn-* writes
-    # carry contract_version=7.
+    # spawn-* floor matches only spawn-budget-paused / spawn-budget-resumed
+    # receipts, which do NOT carry host/tier/resolved_model fields. The floor
+    # value 7 does NOT enforce v7 host/tier/resolved_model field presence for
+    # spawn receipts — that enforcement is handled at write time by
+    # RECEIPT_CONTRACT_VERSION for executor-*/audit-* receipts, not by this
+    # floor. Callers that need to gate on v7 fields must pass min_version=7
+    # explicitly rather than relying on this spawn-* floor entry.
     "spawn-*": 7,
 }
 
@@ -304,11 +305,11 @@ def write_receipt(task_dir: Path, step_name: str, **payload: Any) -> Path:
     receipts.mkdir(parents=True, exist_ok=True)
 
     receipt = {
+        **payload,
         "step": step_name,
         "ts": now_iso(),
         "valid": True,
         "contract_version": RECEIPT_CONTRACT_VERSION,
-        **payload,
     }
 
     receipt_path = receipts / f"{step_name}.json"

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -119,6 +119,52 @@ def _task_relative(path: Path, task_dir: Path | None) -> Path | None:
         return None
 
 
+def _owning_task_dir(path: Path) -> Path | None:
+    """Walk path.resolve().parents; return the first parent p where
+    p.parent.name == ".dynos" and p.name.startswith("task-").
+    Pure path operations — no I/O.
+    """
+    resolved = path.resolve()
+    for p in resolved.parents:
+        if p.parent.name == ".dynos" and p.name.startswith("task-"):
+            return p
+    return None
+
+
+def _is_cross_task_control_plane(rel_posix: str) -> bool:
+    """Return True iff rel_posix names a control-plane artifact within a task dir.
+
+    Covers: _CONTROL_PLANE_EXACT names, _WRAPPER_REQUIRED keys,
+    audit-summary.json / audit-plan.json, and the path prefixes
+    receipts/, audit-reports/, evidence/verification/, and
+    handoff-*.json patterns.
+
+    Case-insensitive: on case-insensitive filesystems (macOS/Windows),
+    Path.resolve().name preserves the on-disk casing the caller typed
+    (e.g. MANIFEST.JSON), but the OS still writes the real control-plane
+    file. We case-fold the input once and match against the
+    (already-lowercase) sets and prefixes so a mixed-case spelling cannot
+    bypass the cross-task guard. All _CONTROL_PLANE_EXACT and
+    _WRAPPER_REQUIRED keys are lowercase, so the lowercased compare is exact.
+    """
+    r = rel_posix.lower()
+    if r in _CONTROL_PLANE_EXACT:
+        return True
+    if r in _WRAPPER_REQUIRED:
+        return True
+    if r in {"audit-summary.json", "audit-plan.json"}:
+        return True
+    if r.startswith("receipts/"):
+        return True
+    if r.startswith("audit-reports/"):
+        return True
+    if r.startswith("evidence/verification/"):
+        return True
+    if r.startswith("handoff-") and r.endswith(".json"):
+        return True
+    return False
+
+
 def _matches_role(role: str, pattern: str) -> bool:
     if pattern.endswith("*"):
         return role.startswith(pattern[:-1])
@@ -364,6 +410,24 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
         if attempt.role == "daemon":
             return WriteDecision(True, ".dynos/.rules_corrupt allowed for daemon role", "direct")
         return WriteDecision(False, ".dynos/.rules_corrupt is daemon-owned kill-switch state; agent writes denied", "deny")
+    # FINDING #1: cross-task control-plane write bypass guard.
+    # Agent roles (execute-inline, *-executor) must not write control-plane
+    # artifacts that belong to a DIFFERENT task directory, regardless of which
+    # task directory the role is bound to.  _FRAMEWORK_ROLES are exempt because
+    # they are deterministic code, not LLM tool calls.
+    if attempt.role not in _FRAMEWORK_ROLES:
+        target = _owning_task_dir(path)
+        if target is not None and (
+            attempt.task_dir is None
+            or target.resolve() != attempt.task_dir.resolve()
+        ):
+            tgt_rel = path.resolve().relative_to(target.resolve()).as_posix()
+            if _is_cross_task_control_plane(tgt_rel):
+                return WriteDecision(
+                    False,
+                    f"cross-task control-plane write denied: {path.name}",
+                    "deny",
+                )
     rel = _task_relative(path, attempt.task_dir)
     rel_posix = rel.as_posix() if rel is not None else None
 

--- a/tests/test_ctl_spawn_prep.py
+++ b/tests/test_ctl_spawn_prep.py
@@ -1,0 +1,112 @@
+"""TDD-first regression tests for finding #6 — spawn-prep grant allowlist enforcement.
+
+AC 5: cmd_spawn_prep must call _validated_grant_role before any artifact
+parsing or grant-append logic, returning exit code 1 (with a stderr message
+containing "not in the role allowlist") for any role absent from
+_STAMP_ROLE_ALLOWLIST.
+
+These tests use the same subprocess pattern established in tests/test_spawn_prep.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CTL_PY = ROOT / "hooks" / "ctl.py"
+
+
+def _make_task_dir(tmp_path: Path, task_id: str = "task-20260615-002-ctl-test") -> Path:
+    """Create a minimal task directory with role-grants.json."""
+    project = tmp_path / "project"
+    task_dir = project / ".dynos" / task_id
+    task_dir.mkdir(parents=True)
+    manifest = {
+        "task_id": task_id,
+        "stage": "CHECKPOINT_AUDIT",
+        "fast_track": False,
+        "created_at": "2026-06-15T00:00:00Z",
+        "raw_input": "allowlist enforcement test",
+    }
+    (task_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (task_dir / "role-grants.json").write_text(
+        json.dumps({"grants": []}), encoding="utf-8"
+    )
+    (task_dir / "audit-reports").mkdir(exist_ok=True)
+    return task_dir
+
+
+def _run_spawn_prep(
+    task_dir: Path,
+    role: str,
+    artifact_name: str = "audit-security-sonnet-attempt-1.json",
+) -> subprocess.CompletedProcess:
+    """Invoke `python3 ctl.py spawn-prep <task_dir> --role <role> --artifact <path>`."""
+    artifact_path = str(task_dir / artifact_name)
+    cmd = [
+        sys.executable,
+        str(CTL_PY),
+        "spawn-prep",
+        str(task_dir),
+        "--role", role,
+        "--artifact", artifact_path,
+    ]
+    return subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 5: spawn-prep rejects non-allowlisted roles
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_prep_rejects_unknown_role(tmp_path: Path) -> None:
+    """AC 5: spawn-prep with a non-allowlisted role exits 1 and prints allowlist error.
+
+    The role 'super-admin' is guaranteed absent from _STAMP_ROLE_ALLOWLIST.
+    After the fix, cmd_spawn_prep calls _validated_grant_role immediately after
+    the task_dir.is_dir() check, so NO entry is appended to role-grants.json.
+    """
+    task_dir = _make_task_dir(tmp_path)
+    grants_before = json.loads((task_dir / "role-grants.json").read_text())["grants"]
+
+    result = _run_spawn_prep(task_dir, role="super-admin")
+
+    assert result.returncode == 1, (
+        f"spawn-prep with non-allowlisted role must exit 1; got {result.returncode}.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "not in the role allowlist" in result.stderr, (
+        f"stderr must contain 'not in the role allowlist'; got: {result.stderr!r}"
+    )
+
+    # Confirm NO grant was appended
+    grants_after = json.loads((task_dir / "role-grants.json").read_text())["grants"]
+    assert len(grants_after) == len(grants_before), (
+        f"role-grants.json must not be modified on rejection; "
+        f"before={len(grants_before)} after={len(grants_after)}"
+    )
+
+
+def test_spawn_prep_accepts_allowlisted_role(tmp_path: Path) -> None:
+    """AC 5: spawn-prep with a role in _STAMP_ROLE_ALLOWLIST exits 0.
+
+    Uses 'audit-security' which is confirmed present in _STAMP_ROLE_ALLOWLIST
+    (ctl.py line ~2273).
+    """
+    task_dir = _make_task_dir(tmp_path)
+
+    result = _run_spawn_prep(task_dir, role="audit-security")
+
+    assert result.returncode == 0, (
+        f"spawn-prep with allowlisted role 'audit-security' must exit 0; "
+        f"got {result.returncode}.\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )

--- a/tests/test_pre_tool_use.py
+++ b/tests/test_pre_tool_use.py
@@ -1,0 +1,91 @@
+"""TDD-first regression tests for findings #36 and #37 — MultiEdit watchdog branch
+and backtick verb strip in _extract_bash_destinations.
+
+AC 6: _watchdog_targets_artifact must return True when tool_name == "MultiEdit"
+and the edits list contains a matching file_path.
+
+AC 7: _extract_bash_destinations must detect the write destination when the
+verb token has leading/trailing backticks (e.g. from `cp a /dst`).
+
+References _watchdog_targets_artifact and _extract_bash_destinations INSIDE
+function bodies so that import/collection never errors if those symbols exist
+but are not yet implemented correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+
+# ---------------------------------------------------------------------------
+# AC 6: MultiEdit watchdog branch
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_targets_artifact_multiedit_hit() -> None:
+    """AC 6: _watchdog_targets_artifact returns True for MultiEdit with matching file_path.
+
+    The new elif tool_name == "MultiEdit": branch (inserted after the Bash
+    branch) must iterate edits and return True when any edit's file_path
+    resolves to the artifact_abs.
+    """
+    import pre_tool_use as _ptu
+
+    fn = getattr(_ptu, "_watchdog_targets_artifact", None)
+    assert fn is not None, "_watchdog_targets_artifact must exist in pre_tool_use"
+
+    artifact = "/path/to/artifact.json"
+    tool_input = {"edits": [{"file_path": artifact}]}
+    result = fn("MultiEdit", tool_input, artifact)
+    assert result is True, (
+        f"_watchdog_targets_artifact must return True for MultiEdit with matching file_path; "
+        f"got {result!r}"
+    )
+
+
+def test_watchdog_targets_artifact_multiedit_miss() -> None:
+    """AC 6: _watchdog_targets_artifact returns False for MultiEdit with non-matching file_path."""
+    import pre_tool_use as _ptu
+
+    fn = getattr(_ptu, "_watchdog_targets_artifact", None)
+    assert fn is not None, "_watchdog_targets_artifact must exist in pre_tool_use"
+
+    artifact = "/path/to/artifact.json"
+    tool_input = {"edits": [{"file_path": "/path/to/other_file.json"}]}
+    result = fn("MultiEdit", tool_input, artifact)
+    assert result is False, (
+        f"_watchdog_targets_artifact must return False for MultiEdit with non-matching file_path; "
+        f"got {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 7: Backtick verb strip in _extract_bash_destinations
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bash_backtick_verb_detected() -> None:
+    """AC 7: _extract_bash_destinations detects the destination from a backtick-wrapped verb.
+
+    The command ``echo `cp a /task/b.json``` should yield /task/b.json because
+    the token `cp is stripped of its leading backtick, revealing the 'cp' verb
+    which is in _WRITE_VERB_DEST, and /task/b.json is its second argument.
+    """
+    import pre_tool_use as _ptu
+
+    fn = getattr(_ptu, "_extract_bash_destinations", None)
+    assert fn is not None, "_extract_bash_destinations must exist in pre_tool_use"
+
+    command = "echo `cp a /task/b.json`"
+    destinations = fn(command)
+    assert isinstance(destinations, list), (
+        f"_extract_bash_destinations must return a list; got {type(destinations)!r}"
+    )
+    assert "/task/b.json" in destinations, (
+        f"_extract_bash_destinations must detect /task/b.json from backtick-wrapped cp; "
+        f"got {destinations!r}"
+    )

--- a/tests/test_read_policy.py
+++ b/tests/test_read_policy.py
@@ -846,3 +846,65 @@ def test_non_audit_role_decide_read_passthrough(tmp_path: Path) -> None:
         f"Expected non-audit role to always get allowed=True from decide_read; "
         f"got allowed={decision.allowed}, reason={decision.reason!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TDD-first regression — task-20260615-002 — AC 8
+# ---------------------------------------------------------------------------
+
+
+def test_quota_tempfile_cleaned_up_on_replace_failure(tmp_path: Path) -> None:
+    """AC 8: When os.replace raises OSError, the .tmp file must be unlinked and
+    ReadDecision.allowed must be False (fail-closed).
+
+    References _handle_dead_code_grep_quota INSIDE the function body so that
+    collection never errors if the fix isn't yet implemented.
+    """
+    import sys
+    import os
+    import importlib
+    from unittest.mock import patch
+
+    hooks_str = str(ROOT / "hooks")
+    if hooks_str not in sys.path:
+        sys.path.insert(0, hooks_str)
+    rp = importlib.import_module("read_policy")
+
+    fn = getattr(rp, "_handle_dead_code_grep_quota", None)
+    assert fn is not None, "_handle_dead_code_grep_quota must exist in read_policy"
+
+    _, task_dir = _make_task_dir(tmp_path)
+
+    attempt = rp.ReadAttempt(
+        role="audit-dead-code",
+        task_dir=task_dir,
+        target=tmp_path / "hooks" / "some_module.py",
+        tool_name="Grep",
+        raw_pattern=None,
+    )
+
+    # Capture the tmp_path that _handle_dead_code_grep_quota creates so we can
+    # assert it was cleaned up. We intercept os.replace to raise after the
+    # NamedTemporaryFile has been created and closed (delete=False).
+    created_tmp_files: list[str] = []
+    original_replace = os.replace
+
+    def _raising_replace(src: str, dst: str) -> None:
+        created_tmp_files.append(src)
+        raise OSError("injected failure for test")
+
+    with patch.object(rp.os, "replace", side_effect=_raising_replace):
+        decision = fn(attempt)
+
+    assert decision.allowed is False, (
+        f"ReadDecision must be fail-closed (allowed=False) when os.replace raises; "
+        f"got {decision.allowed!r}"
+    )
+    assert len(created_tmp_files) > 0, (
+        "os.replace must have been called (i.e. the NamedTemporaryFile was created)"
+    )
+    tmp_file_path = created_tmp_files[0]
+    assert not os.path.exists(tmp_file_path), (
+        f"The .tmp file {tmp_file_path!r} must be unlinked after os.replace failure; "
+        "it still exists, indicating the cleanup fix is missing"
+    )

--- a/tests/test_receipts_integrity.py
+++ b/tests/test_receipts_integrity.py
@@ -1,0 +1,121 @@
+"""TDD-first regression tests for findings #56 and #57 — receipt comment correctness
+and write_receipt integrity-field override protection.
+
+AC 9: The misleading comment 'spawn receipts now carry' must be absent from
+hooks/receipts/core.py; the spawn-* floor value 7 must remain unchanged.
+
+AC 10: write_receipt must NOT allow callers to override step, ts, valid, or
+contract_version via **payload. After the dict-reorder fix these keys are
+placed AFTER **payload so canonical values always win.
+
+These tests are RED by design until the production fixes are applied.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from lib_receipts import write_receipt, RECEIPT_CONTRACT_VERSION  # noqa: E402
+
+
+def _task_dir(tmp_path: Path) -> Path:
+    """Create a minimal task dir that write_receipt can use."""
+    project = tmp_path / "project"
+    td = project / ".dynos" / "task-20260615-002-integrity"
+    td.mkdir(parents=True)
+    return td
+
+
+# ---------------------------------------------------------------------------
+# AC 9: Receipt comment correctness
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_floor_comment_corrected() -> None:
+    """AC 9: The misleading old comment must be absent; spawn-budget must appear;
+    the spawn-* floor value must remain 7.
+
+    This is a documentation-correctness test: reads the raw source text of
+    hooks/receipts/core.py and asserts on comment content.
+    """
+    core_source = (ROOT / "hooks" / "receipts" / "core.py").read_text(encoding="utf-8")
+
+    # The old misleading claim must be GONE
+    assert "spawn receipts now carry" not in core_source, (
+        "The misleading claim 'spawn receipts now carry' must be removed from core.py. "
+        "It falsely attributes host/tier/resolved_model v7 protection to the spawn-* "
+        "floor entry when in fact the floor only matches spawn-budget-paused/resumed."
+    )
+
+    # A corrected reference to spawn-budget must appear in its place
+    assert "spawn-budget" in core_source, (
+        "A corrected reference to 'spawn-budget' (or 'spawn-budget-paused') must appear "
+        "in the comment replacing the misleading old text."
+    )
+
+    # The floor value itself must remain 7 — do not accidentally change it
+    assert '"spawn-*": 7' in core_source, (
+        "The spawn-* floor value must remain 7 (unchanged by the comment-only fix)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 10: write_receipt integrity-field override protection
+# ---------------------------------------------------------------------------
+
+
+def test_write_receipt_contract_version_not_overridden_by_payload(
+    tmp_path: Path,
+) -> None:
+    """AC 10: Passing contract_version=999 in payload must NOT override the canonical value.
+
+    After the dict reorder fix:
+        receipt = {**payload, "step": ..., "contract_version": RECEIPT_CONTRACT_VERSION}
+    the canonical RECEIPT_CONTRACT_VERSION wins over any value in payload.
+    """
+    td = _task_dir(tmp_path)
+    receipt_path = write_receipt(td, "executor-seg1", contract_version=999)
+
+    on_disk = json.loads(receipt_path.read_text())
+    assert on_disk["contract_version"] == RECEIPT_CONTRACT_VERSION, (
+        f"contract_version in receipt must equal RECEIPT_CONTRACT_VERSION "
+        f"({RECEIPT_CONTRACT_VERSION}), not a payload-supplied 999. "
+        f"Got: {on_disk['contract_version']!r}. "
+        f"The dict-reorder fix is missing — payload is currently overriding the "
+        f"canonical integrity field."
+    )
+
+
+def test_write_receipt_valid_not_overridden_by_payload(tmp_path: Path) -> None:
+    """AC 10: Passing valid=False in payload must NOT override the canonical True value."""
+    td = _task_dir(tmp_path)
+    receipt_path = write_receipt(td, "executor-seg1", valid=False)
+
+    on_disk = json.loads(receipt_path.read_text())
+    assert on_disk["valid"] is True, (
+        f"valid in receipt must always be True (canonical); "
+        f"got {on_disk['valid']!r}. "
+        f"The dict-reorder fix is missing — payload valid=False is currently winning."
+    )
+
+
+def test_write_receipt_step_not_overridden_by_payload(tmp_path: Path) -> None:
+    """AC 10: Passing step='injected-step' in payload must NOT override the step_name argument."""
+    td = _task_dir(tmp_path)
+    receipt_path = write_receipt(td, "executor-seg1", step="injected-step")
+
+    on_disk = json.loads(receipt_path.read_text())
+    assert on_disk["step"] == "executor-seg1", (
+        f"step in receipt must equal the step_name argument ('executor-seg1'), "
+        f"not a payload-supplied 'injected-step'. Got: {on_disk['step']!r}. "
+        f"The dict-reorder fix is missing — payload step is currently overriding."
+    )
+    # Also confirm that other non-conflicting payload fields ARE preserved
+    # (the **payload spread must still be present after the fix)
+    # We pass step= in payload above; since step conflicts it should be overridden.
+    # A separate non-conflicting key (not passed here) would be preserved.

--- a/tests/test_spawn_prep.py
+++ b/tests/test_spawn_prep.py
@@ -207,7 +207,7 @@ def test_resume_spawn_prep_output(tmp_path: Path) -> None:
     ledger = {
         "grants": [
             {
-                "role": "audit-sc",
+                "role": "audit-security",
                 "granted_at": now - 100,
                 "expires_at": now + 3500,
                 "consumed_by": "session-sub-001",
@@ -220,10 +220,11 @@ def test_resume_spawn_prep_output(tmp_path: Path) -> None:
     }
     (task_dir / "role-grants.json").write_text(json.dumps(ledger), encoding="utf-8")
 
-    # Call spawn-prep — should detect status=partial and return continuation=True
+    # Call spawn-prep — should detect status=partial and return continuation=True.
+    # Role must be allowlisted; validation now runs before artifact parsing (AC 5).
     r = _run_spawn_prep(
         task_dir,
-        role="audit-sc",
+        role="audit-security",
         artifact_path=str(artifact_path),
         model="haiku",  # noqa: model-literal
     )

--- a/tests/test_write_policy.py
+++ b/tests/test_write_policy.py
@@ -219,3 +219,236 @@ def test_ctl_json_write_emits_policy_event(tmp_path: Path) -> None:
         and line.get("path") == f".dynos/{task_dir.name}/manifest.json"
         for line in events
     )
+
+
+# ---------------------------------------------------------------------------
+# TDD-first regression suite — task-20260615-002 — ACs 1-4
+# ---------------------------------------------------------------------------
+# All tests in this block reference _owning_task_dir and
+# _is_cross_task_control_plane INSIDE the function body so that pytest
+# collection never errors even when those symbols don't yet exist.
+# ---------------------------------------------------------------------------
+
+
+def _two_task_dirs(tmp_path: Path):
+    """Return (task_a_dir, task_b_dir) under the same .dynos parent."""
+    dynos = tmp_path / ".dynos"
+    task_a = dynos / "task-A"
+    task_b = dynos / "task-B"
+    task_a.mkdir(parents=True)
+    task_b.mkdir(parents=True)
+    return task_a, task_b
+
+
+# --- AC 1: executor writing sibling task's manifest.json is denied ----------
+
+def test_executor_cannot_write_sibling_task_manifest(tmp_path: Path) -> None:
+    """AC 1: task-A executor → task-B/manifest.json must be denied with cross-task reason."""
+    task_a, task_b = _two_task_dirs(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="ui-executor",
+            task_dir=task_a,
+            path=task_b / "manifest.json",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task manifest write must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
+# --- AC 2: same-task ctl write is not denied by the new guard ---------------
+
+def test_ctl_same_task_write_still_allowed(tmp_path: Path) -> None:
+    """AC 2a: ctl role writing its OWN task's manifest.json must still be allowed."""
+    task_a, _ = _two_task_dirs(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="ctl",
+            task_dir=task_a,
+            path=task_a / "manifest.json",
+            operation="modify",
+            source="ctl",
+        )
+    )
+    assert decision.allowed is True, (
+        f"ctl same-task manifest write must remain allowed; got: {decision!r}"
+    )
+
+
+def test_executor_repo_file_write_still_allowed(tmp_path: Path) -> None:
+    """AC 2c: executor writing a repo source file outside .dynos is still allowed."""
+    task_a, _ = _two_task_dirs(tmp_path)
+    # A file completely outside .dynos/ — _owning_task_dir should return None
+    repo_file = tmp_path / "src" / "foo.py"
+    repo_file.parent.mkdir(parents=True, exist_ok=True)
+    repo_file.write_text("# placeholder")
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_a,
+            path=repo_file,
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is True, (
+        f"executor repo file write must remain allowed; got: {decision!r}"
+    )
+
+
+def test_is_cross_task_control_plane_evidence_md_not_cp(tmp_path: Path) -> None:
+    """AC 2e: evidence/changes.md is NOT a control-plane path."""
+    import write_policy as _wp
+    fn = getattr(_wp, "_is_cross_task_control_plane", None)
+    assert fn is not None, "_is_cross_task_control_plane must exist in write_policy"
+    result = fn("evidence/changes.md")
+    assert result is False, (
+        f"evidence/changes.md must NOT be classified as control-plane; got {result}"
+    )
+
+
+# --- AC 3: additional cross-task deny cases ----------------------------------
+
+def test_executor_with_no_task_dir_cannot_write_task_manifest(tmp_path: Path) -> None:
+    """AC 3: executor with task_dir=None writing any task manifest is denied."""
+    dynos = tmp_path / ".dynos"
+    task_x = dynos / "task-X"
+    task_x.mkdir(parents=True)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=None,
+            path=task_x / "manifest.json",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "no-task-dir executor must be denied cross-task manifest write"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
+def test_executor_cannot_forge_sibling_task_receipt(tmp_path: Path) -> None:
+    """AC 3: task-A executor → task-B/receipts/executor-seg1.json must be denied."""
+    task_a, task_b = _two_task_dirs(tmp_path)
+    (task_b / "receipts").mkdir(exist_ok=True)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_a,
+            path=task_b / "receipts" / "executor-seg1.json",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task receipt forge must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
+def test_executor_cannot_write_sibling_role_grants(tmp_path: Path) -> None:
+    """AC 3: task-A executor → task-B/role-grants.json must be denied."""
+    task_a, task_b = _two_task_dirs(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="testing-executor",
+            task_dir=task_a,
+            path=task_b / "role-grants.json",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task role-grants write must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
+def test_executor_cannot_write_sibling_spawn_log(tmp_path: Path) -> None:
+    """AC 3: task-A executor → task-B/spawn-log.jsonl must be denied."""
+    task_a, task_b = _two_task_dirs(tmp_path)
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_a,
+            path=task_b / "spawn-log.jsonl",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task spawn-log write must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
+# --- AC 4: unit tests for the two new helper functions ----------------------
+
+def test_owning_task_dir_returns_task_dir(tmp_path: Path) -> None:
+    """AC 4: _owning_task_dir on a nested task path returns the task-X dir."""
+    import write_policy as _wp
+    fn = getattr(_wp, "_owning_task_dir", None)
+    assert fn is not None, "_owning_task_dir must exist in write_policy"
+
+    # Build a real on-disk path so .resolve() works
+    dynos = tmp_path / ".dynos"
+    task_x = dynos / "task-X"
+    (task_x / "receipts").mkdir(parents=True)
+    nested = task_x / "receipts" / "foo.json"
+    nested.write_text("{}")
+
+    result = fn(nested)
+    assert result is not None, "_owning_task_dir must return a Path, not None"
+    assert result.name == "task-X", (
+        f"_owning_task_dir must return the task-X dir; got name={result.name!r}"
+    )
+
+
+def test_owning_task_dir_returns_none_for_root_level(tmp_path: Path) -> None:
+    """AC 4: _owning_task_dir on a .dynos root-level file returns None."""
+    import write_policy as _wp
+    fn = getattr(_wp, "_owning_task_dir", None)
+    assert fn is not None, "_owning_task_dir must exist in write_policy"
+
+    dynos = tmp_path / ".dynos"
+    dynos.mkdir(parents=True)
+    root_file = dynos / "events.jsonl"
+    root_file.write_text("")
+
+    result = fn(root_file)
+    assert result is None, (
+        f"_owning_task_dir must return None for root-level .dynos file; got {result!r}"
+    )
+
+
+def test_is_cross_task_control_plane_exact(tmp_path: Path) -> None:
+    """AC 4: _is_cross_task_control_plane('manifest.json') returns True."""
+    import write_policy as _wp
+    fn = getattr(_wp, "_is_cross_task_control_plane", None)
+    assert fn is not None, "_is_cross_task_control_plane must exist in write_policy"
+    result = fn("manifest.json")
+    assert result is True, (
+        f"manifest.json must be classified as control-plane; got {result}"
+    )
+
+
+def test_is_cross_task_control_plane_receipts_prefix(tmp_path: Path) -> None:
+    """AC 4: _is_cross_task_control_plane('receipts/executor-seg1.json') returns True."""
+    import write_policy as _wp
+    fn = getattr(_wp, "_is_cross_task_control_plane", None)
+    assert fn is not None, "_is_cross_task_control_plane must exist in write_policy"
+    result = fn("receipts/executor-seg1.json")
+    assert result is True, (
+        f"receipts/ prefix must be classified as control-plane; got {result}"
+    )

--- a/tests/test_write_policy.py
+++ b/tests/test_write_policy.py
@@ -355,6 +355,48 @@ def test_executor_cannot_forge_sibling_task_receipt(tmp_path: Path) -> None:
     )
 
 
+def test_cross_task_uppercase_control_plane_denied(tmp_path: Path) -> None:
+    """sec-cross-task-caseinsensitive: on a case-insensitive filesystem the
+    on-disk casing (MANIFEST.JSON, RECEIPTS/x.JSON) the executor typed is
+    preserved by Path.resolve().name, but the OS still writes the real
+    manifest.json / receipts/ control-plane file. The cross-task guard must
+    case-fold and DENY these, not fall through to the executor ALLOW branch.
+    """
+    task_a, task_b = _two_task_dirs(tmp_path)
+
+    # Uppercase exact control-plane name.
+    decision = decide_write(
+        WriteAttempt(
+            role="ui-executor",
+            task_dir=task_a,
+            path=task_b / "MANIFEST.JSON",
+            operation="modify",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task MANIFEST.JSON write must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+    # Uppercase prefixed control-plane path (receipts/).
+    decision = decide_write(
+        WriteAttempt(
+            role="backend-executor",
+            task_dir=task_a,
+            path=task_b / "RECEIPTS" / "x.JSON",
+            operation="create",
+            source="agent",
+        )
+    )
+    assert decision.allowed is False, "cross-task RECEIPTS/x.JSON forge must be denied"
+    assert decision.mode == "deny"
+    assert "cross-task" in decision.reason, (
+        f"reason must contain 'cross-task'; got: {decision.reason!r}"
+    )
+
+
 def test_executor_cannot_write_sibling_role_grants(tmp_path: Path) -> None:
     """AC 3: task-A executor → task-B/role-grants.json must be denied."""
     task_a, task_b = _two_task_dirs(tmp_path)


### PR DESCRIPTION
## Summary

Fixes all 7 SECURITY findings from the pristine audit's write/grant/receipt surface, driven through the full dynos-work foundry pipeline (spec → plan → TDD-first → execute → audit→DONE). The TDD suite was committed RED first (`c55523d`), then the production fixes turn it GREEN (`ba1ea01`). **Full suite: 2744 passed, 9 skipped, 0 failures.**

| Finding | File | Fix |
|---|---|---|
| **#1 CRITICAL** — cross-task control-plane write bypass | `hooks/write_policy.py` | `_owning_task_dir` + `_is_cross_task_control_plane` + cross-task deny block in `decide_write`; an `execute-inline`/`*-executor` bound to task-A can no longer forge task-B's manifest/receipts/role-grants/role-bindings/spawn-log/audit-reports/active-segment-role/handoff. Framework roles exempt; resolved-vs-resolved path compare. |
| **#6 HIGH** — spawn-prep mints grants without allowlist | `hooks/ctl.py` | `cmd_spawn_prep` validates via `_validated_grant_role` before any grant mint **and before any artifact parsing** (spec AC 5); non-allowlisted → exit 1, no grant. |
| #36 / #37 | `hooks/pre_tool_use.py` | MultiEdit branch in `_watchdog_targets_artifact`; backtick-strip on the verb token in `_extract_bash_destinations`. |
| #38 | `hooks/read_policy.py` | `_handle_dead_code_grep_quota` unlinks its tempfile on `os.replace` failure (still fail-closed). |
| #56 / #57 | `hooks/receipts/core.py` | `write_receipt` builds integrity fields last so payload can't override `step`/`ts`/`valid`/`contract_version`; corrected the inert v7 `spawn-*` floor comment (floor value unchanged — v6 receipts exist on disk). |

## Audit phase caught two more defects (both fixed + re-audited clean)

The **opus ensemble deep-tier** found a real **case-insensitive-filesystem bypass** of the #1 fix that the haiku/sonnet tiers missed: `_is_cross_task_control_plane` matched case-sensitively, and `Path('.../task-B/MANIFEST.JSON').resolve().name` preserves case on macOS/Windows — so the guard returned False and the OS overwrote the real `manifest.json`, re-opening the CRITICAL hole. Fixed by case-folding the target-relative path before classification (+ a dedicated regression test). Spec-completion also flagged the #6 validation placement (after artifact parsing), now moved before it (resume test updated to an allowlisted role).

## Tests
- Regression suite across `tests/test_write_policy.py`, `test_ctl_spawn_prep.py`, `test_pre_tool_use.py`, `test_read_policy.py`, `test_receipts_integrity.py`, including the uppercase cross-task bypass.
- `python3 -m pytest tests/` → **2744 passed, 9 skipped, 0 failures.**

## Note
These hooks are the live write guardrail. The change is validated by pytest (working-tree import); it becomes the enforced guardrail only after the next plugin release + cache refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)