### PR TITLE
fix: route retrospective_flushed to global events.jsonl (unblocks calibration/learning)

### DIFF
--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -1262,10 +1262,17 @@ def _flush_retrospective_on_done(*, task_dir: Path, manifest: dict) -> None:
         dst_hash = ""
     try:
         from lib_log import log_event as _log_flush
+        # NOTE: do NOT pass task=task_id here. log_event routes events with a
+        # `task` arg to the TASK-SCOPED .dynos/{task}/events.jsonl, but the
+        # SEC-003 verifier `_flushed_sha_by_task_id` reads only the GLOBAL
+        # .dynos/events.jsonl. Routing this event task-scoped made every
+        # persistent retrospective `persistent-unverified`, so
+        # collect_retrospectives() filtered them all out and calibration's
+        # generation gate could never see them. The task_id is still recorded
+        # in the payload below for the verifier's {task_id: sha256} map.
         _log_flush(
             root,
             "retrospective_flushed",
-            task=task_id,
             task_id=task_id,
             source=str(src),
             destination=str(dst),

--- a/tests/test_retrospective_flush.py
+++ b/tests/test_retrospective_flush.py
@@ -113,6 +113,17 @@ def _read_events(td: Path) -> list[dict]:
     return [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
 
 
+def _read_global_events(root: Path) -> list[dict]:
+    """Read the GLOBAL .dynos/events.jsonl (root-scoped). The
+    `retrospective_flushed` event MUST land here (not in the task-scoped
+    .dynos/{task}/events.jsonl) because the SEC-003 verifier
+    `_flushed_sha_by_task_id` reads only this global file."""
+    events_path = root / ".dynos" / "events.jsonl"
+    if not events_path.exists():
+        return []
+    return [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Success path
 # ---------------------------------------------------------------------------
@@ -197,22 +208,83 @@ def test_flush_rejects_path_traversal_task_id(tmp_path: Path) -> None:
 def test_flush_emits_success_event(tmp_path: Path,
                                     monkeypatch: pytest.MonkeyPatch) -> None:
     """Successful DONE flush emits a `retrospective_flushed` event with
-    task_id, source, destination, and sha256 fields populated."""
+    task_id, source, destination, and sha256 fields populated.
+
+    The event MUST be written to the GLOBAL .dynos/events.jsonl (NOT the
+    task-scoped .dynos/{task}/events.jsonl), because that is the only file
+    the SEC-003 verifier `_flushed_sha_by_task_id` reads. (Regression: it
+    was previously routed task-scoped via task=task_id, which made every
+    persistent retro `persistent-unverified` and silently disabled the
+    calibration generation gate.)"""
     _install_dynos_home(monkeypatch, tmp_path)
     td = _setup_done_ready(tmp_path, slug="FLUSH-EVT")
+    root = td.parent.parent
 
     transition_task(td, "DONE")
 
-    events = _read_events(td)
+    events = _read_global_events(root)
     flushed = [e for e in events if e.get("event") == "retrospective_flushed"]
     assert len(flushed) >= 1, (
-        f"expected a retrospective_flushed event — got events: "
-        f"{[e.get('event') for e in events]}"
+        f"expected a retrospective_flushed event in the GLOBAL events.jsonl — "
+        f"got events: {[e.get('event') for e in events]}"
     )
     ev = flushed[0]
     assert ev.get("task_id") == td.name
     assert str(ev.get("source", "")).endswith("task-retrospective.json")
     assert str(ev.get("destination", "")).endswith(f"{td.name}.json")
+    assert ev.get("sha256"), "flush event must carry the destination sha256"
+
+    # The task-scoped events file must NOT carry the flush event — routing
+    # it there is exactly the bug this regression guards against.
+    task_scoped = [e for e in _read_events(td)
+                   if e.get("event") == "retrospective_flushed"]
+    assert not task_scoped, (
+        "retrospective_flushed must NOT be in the task-scoped events.jsonl — "
+        "the SEC-003 verifier only reads the global file"
+    )
+
+
+def test_flush_event_verifies_persistent_retro_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: after a DONE flush, the SEC-003 verifier finds the
+    sha and `collect_retrospectives` returns the persistent retro as
+    VERIFIED (not filtered as `persistent-unverified`).
+
+    This is the bug's real-world symptom: with the event mis-routed to the
+    task-scoped file, `_flushed_sha_by_task_id(root)` returned {} → every
+    persistent retro was `persistent-unverified` → `collect_retrospectives`
+    (default) filtered them all → calibration's generation gate saw 0
+    retrospectives and could never fire."""
+    from lib_core import _flushed_sha_by_task_id, collect_retrospectives
+    from lib_receipts import hash_file
+
+    _install_dynos_home(monkeypatch, tmp_path)
+    td = _setup_done_ready(tmp_path, slug="FLUSH-E2E")
+    root = td.parent.parent
+
+    transition_task(td, "DONE")
+
+    # 1) The verifier reads the global file and finds this task's sha.
+    flushed = _flushed_sha_by_task_id(root)
+    assert td.name in flushed, (
+        f"_flushed_sha_by_task_id must find {td.name} — got {list(flushed)}"
+    )
+    persistent = _persistent_project_dir(root) / "retrospectives" / f"{td.name}.json"
+    assert flushed[td.name] == hash_file(persistent), (
+        "recorded sha must match the persistent file's current hash"
+    )
+
+    # 2) The default (verified-only) collection includes the persistent retro,
+    #    proving it was NOT filtered as persistent-unverified.
+    retros = collect_retrospectives(root)
+    mine = [r for r in retros if r.get("task_id") == td.name]
+    assert mine, (
+        "collect_retrospectives() (verified-only) must include the flushed "
+        "retro — if empty, the SEC-003 verification failed and calibration "
+        "would see 0 retrospectives"
+    )
+    assert mine[0].get("_source") != "persistent-unverified"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug (surfaced by `/dynos-work:calibration`)
Calibration's generation gate was permanently seeing **0 retrospectives** despite 5 valid ones on disk — because the entire learn/calibrate pipeline was silently disabled by an event-routing mismatch.

`_flush_retrospective_on_done` (hooks/lib_core.py) copies `task-retrospective.json` into the persistent project dir on the DONE edge, then logs a `retrospective_flushed` event carrying the destination sha256. It called:

```python
log_event(root, "retrospective_flushed", task=task_id, task_id=task_id, ...)
```

`lib_log.log_event` routes any event with a `task` arg to the **task-scoped** `.dynos/{task}/events.jsonl`. But the SEC-003 verifier `_flushed_sha_by_task_id` reads **only** the global `.dynos/events.jsonl`. So:

1. The flush event landed in `.dynos/{task}/events.jsonl`, never the global file.
2. `_flushed_sha_by_task_id(root)` returned `{}` → no persistent retro could be verified.
3. Every persistent retro was labelled `persistent-unverified` and (in dedup) shadowed its worktree copy.
4. `collect_retrospectives()` filters `persistent-unverified` by default → returned **0**.
5. `memory/agent_generator.py auto` hit its gate: `insufficient retrospectives: 0 < 5` → no agents, no routing, no benchmarks. Forever.

Verified on the live repo: all 5 task retros were `persistent-unverified`, 0 `retrospective_flushed` events in the global file, but the per-task files each had one — and the recorded sha matched the persistent file's current hash (`ba423c1c…`), i.e. the data was fine; only the read path was wrong. The docstrings (lib_core.py:1195, ctl.py:2243) already state the event belongs in `.dynos/events.jsonl`.

## The fix
Drop the `task=task_id` routing arg (keep `task_id=task_id` in the payload) so the event is written to the global `.dynos/events.jsonl` where the verifier reads it. One-line behavioral change + an explanatory comment.

## Tests
- **Corrected** `test_flush_emits_success_event` — it read the **task-scoped** events file, which matched the buggy behavior and is exactly why the bug shipped. It now asserts the **global** location and that the event is absent from the task-scoped file.
- **Added** `test_flush_event_verifies_persistent_retro_end_to_end` — proves `_flushed_sha_by_task_id` finds the sha and `collect_retrospectives()` (verified-only) returns the retro as non-`persistent-unverified`. This fails pre-fix, passes post-fix.
- Full suite: **2805 passed, 9 skipped, 0 failed**.

## Notes / follow-ups
- **Forward-looking:** existing retros' flush events remain in their per-task files, so they stay unverified until re-flushed; new DONE transitions will verify correctly. A one-off backfill (re-emit the 5 events to the global file) could retroactively unblock calibration on this repo if desired.
- **Separate bug (not in this PR):** `hooks/route.py` raises `ImportError: cannot import name 'route' from sandbox.calibration` — the routing impl appears to have been moved/renamed without updating the wrapper (no `sandbox/calibration/route.py`). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)