### PR TITLE
fix: match retrospectives by model_used_by_agent so persistent retros are matchable (calibration generation)

### DIFF
--- a/memory/agent_generator.py
+++ b/memory/agent_generator.py
@@ -37,26 +37,47 @@ CATEGORY_INSTRUCTIONS: dict[str, str] = {
 def _matching_retrospectives(
     retrospectives: list[dict], role: str, task_type: str, root: Path
 ) -> list[dict]:
-    """Return retrospectives where *role* participated per the execution graph and task_type matches."""
+    """Return retrospectives where *role* participated and task_type matches.
+
+    Role participation is read primarily from the retrospective's own
+    ``model_used_by_agent`` mapping (keyed by role). That mapping lives inside
+    the flushed retrospective JSON, so it SURVIVES worktree removal. For
+    completeness / backward-compat it is unioned with the executors declared in
+    a sibling ``execution-graph.json`` when that file is present (the
+    in-worktree case).
+
+    Reading the execution graph ALONE was a bug: persistent retrospectives
+    (the post-worktree-removal case the DONE-edge flush exists for) have no
+    graph sibling — their ``_path`` points at ``.../retrospectives/{task}.json``
+    — so role matching always failed and the generator could never produce a
+    specialist even when signal was present.
+    """
     matched: list[dict] = []
     for retro in retrospectives:
         if retro.get("task_type") != task_type:
             continue
-        if "_path" not in retro:
-            continue
-        try:
-            task_dir = Path(retro["_path"]).parent
-            graph_path = task_dir / "execution-graph.json"
-            graph = json.loads(graph_path.read_text())
-            executors = {
-                seg.get("executor")
-                for seg in graph.get("segments", [])
-                if seg.get("executor")
-            }
-            if role in executors:
-                matched.append(retro)
-        except (json.JSONDecodeError, OSError, KeyError):
-            continue
+        participants: set[str] = set()
+        mua = retro.get("model_used_by_agent")
+        if isinstance(mua, dict):
+            participants.update(k for k in mua if isinstance(k, str))
+        # Union in execution-graph executors when a sibling graph is present
+        # (in-worktree retros). Absent graph (persistent retros) is expected —
+        # model_used_by_agent already carries participation.
+        path = retro.get("_path")
+        if path:
+            try:
+                graph_path = Path(path).parent / "execution-graph.json"
+                if graph_path.exists():
+                    graph = json.loads(graph_path.read_text())
+                    participants.update(
+                        seg.get("executor")
+                        for seg in graph.get("segments", [])
+                        if isinstance(seg, dict) and seg.get("executor")
+                    )
+            except (json.JSONDecodeError, OSError, KeyError):
+                pass
+        if role in participants:
+            matched.append(retro)
     return matched
 
 

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -150,6 +150,49 @@ def test_skips_retro_without_path(tmp_path: Path) -> None:
     assert len(matched) == 0
 
 
+def test_matches_persistent_retro_via_model_used_by_agent(tmp_path: Path) -> None:
+    """Regression: a PERSISTENT retro (flushed to .../retrospectives/, with NO
+    sibling execution-graph.json) must still match on its model_used_by_agent
+    role keys. Reading the absent graph alone made every persistent retro
+    unmatchable, so the generator could never produce a specialist."""
+    persist = tmp_path / "persistent" / "retrospectives"
+    persist.mkdir(parents=True)
+    retro_path = persist / "task-20260616-001.json"
+    retro = {
+        "task_id": "task-20260616-001",
+        "task_type": "bugfix",
+        "model_used_by_agent": {"planning": "opus", "backend-executor": "sonnet"},
+        "_path": str(retro_path),
+    }
+    retro_path.write_text(json.dumps(retro))
+    # No execution-graph.json sibling exists next to the persistent retro.
+    assert not (persist / "execution-graph.json").exists()
+
+    matched = _matching_retrospectives([retro], "backend-executor", "bugfix", tmp_path)
+    assert len(matched) == 1
+    assert matched[0]["task_id"] == "task-20260616-001"
+
+
+def test_excludes_persistent_retro_when_role_absent_from_model_used_by_agent(
+    tmp_path: Path,
+) -> None:
+    """A persistent retro whose model_used_by_agent does NOT include the role
+    (and has no graph sibling) is correctly excluded."""
+    persist = tmp_path / "persistent" / "retrospectives"
+    persist.mkdir(parents=True)
+    retro_path = persist / "task-20260616-002.json"
+    retro = {
+        "task_id": "task-20260616-002",
+        "task_type": "bugfix",
+        "model_used_by_agent": {"planning": "opus", "ui-executor": "sonnet"},
+        "_path": str(retro_path),
+    }
+    retro_path.write_text(json.dumps(retro))
+
+    matched = _matching_retrospectives([retro], "backend-executor", "bugfix", tmp_path)
+    assert len(matched) == 0
+
+
 # --- _build_agent_content restructure (criteria 3, 4, 5, 6, 11) ---
 
 def test_contains_imperative_rules_not_telemetry(tmp_path: Path) -> None:


### PR DESCRIPTION
## Bug (third in the calibration-pipeline chain surfaced by `/dynos-work:calibration`)
`memory/agent_generator.py::_matching_retrospectives` determined role participation **solely** by reading `execution-graph.json` as a sibling of the retrospective's `_path`. But for **persistent** retrospectives — the post-worktree-removal case the DONE-edge flush exists for, and the default after `collect_retrospectives`' persistent-wins dedup — `_path` is `.../retrospectives/{task}.json`, which has **no graph sibling**. So role matching always failed: the generator could never match any `(role, task_type)` slot and produced **0 specialists even with signal**, silently defeating calibration's purpose.

This is downstream of #219 (which fixed `collect_retrospectives` returning 0): once retros are *collected*, the matcher then dropped them all anyway.

## Fix
Read role participation from the retrospective's own `model_used_by_agent` mapping (keyed by role — it lives inside the flushed JSON and survives worktree removal), **unioned** with `execution-graph.json` executors when a sibling graph *is* present (in-worktree case, backward-compat). Also hardened against non-dict segments and missing `_path`.

## Verification
- Existing graph-based matching tests are unaffected — their retros carry no `model_used_by_agent`, so they fall back to graph-only behavior.
- Added regression tests: a persistent retro (model_used_by_agent has the role, **no** graph sibling) matches; one without the role is excluded.
- With the fix, the live generator now matches and generated 4 shadow specialists (`auto-backend-{refactor,feature,bugfix}`, `auto-docs-feature`) from real retrospective history — all in `shadow` mode (inert until benchmarked/promoted).
- Full suite **2807 passed, 9 skipped, 0 failed**.

## Pipeline status after this + #219 + #220
`collect_retrospectives` ✅ → generation gate ✅ → routing composites ✅ → **role matching ✅** → generation now produces shadow specialists. Calibration is functional end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)