### PR TITLE
fix: tooling findings — semgrep rule IDs, trajectory/coverage/dart bugs, bench sandbox hardening, dead-code + docs (9 findings)

### DIFF
--- a/debug-module/lib/bug_classifier.py
+++ b/debug-module/lib/bug_classifier.py
@@ -6,7 +6,7 @@ Deterministic, keyword-regex driven classifier for bug descriptions.
 Public API:
     classify(bug_text: str) -> dict
         Returns a dict with keys:
-            - bug_type: str, one of the 9 allowed enum values
+            - bug_type: str, one of the values in ALLOWED_BUG_TYPES
             - mentioned_files: list[dict] with keys path, line, col
             - mentioned_symbols: list[str]
 
@@ -274,12 +274,6 @@ def _extract_files(text: str) -> list[dict[str, Any]]:
 
         line = int(line_str) if line_str is not None else None
         col = int(col_str) if col_str is not None else None
-
-        # Skip pure dotted-version-like tokens (e.g. "1.2.3" — handled by ext
-        # whitelist, but defensive).
-        if not path or path.startswith(".") and "/" not in path and path.count(".") > 1:
-            # Allow ".env" style? Skip leading-dot multi-dot tokens only.
-            pass
 
         key = (path, line, col)
         if key in seen:

--- a/debug-module/lib/coverage_gaps.py
+++ b/debug-module/lib/coverage_gaps.py
@@ -142,7 +142,7 @@ def _parse_pytest_cov(path: Path) -> list[dict]:
     for file_name, entry in files.items():
         if not isinstance(entry, dict):
             continue
-        missing = entry.get("missing_lines") or entry.get("excluded_lines") or []
+        missing = entry.get("missing_lines") or []
         if not isinstance(missing, list):
             continue
         uncovered = [int(n) for n in missing if isinstance(n, (int, float)) and not isinstance(n, bool)]

--- a/debug-module/lib/log_surface.py
+++ b/debug-module/lib/log_surface.py
@@ -5,7 +5,7 @@ surface(repo_path, bug_text) auto-detects the project's logging surface,
 filters error-level lines, sorts by recency, and returns up to 50 entries.
 
 Detection (presence-based, in order):
-    logs/                directory of *.log files
+    logs/                directory of *.log and *.txt files
     *.log                top-level log files
     pm2 logs             ~/.pm2/logs/ when pm2 is on PATH
     docker compose       docker-compose.yml or compose.yaml

--- a/debug-module/lib/run_tests.py
+++ b/debug-module/lib/run_tests.py
@@ -100,8 +100,17 @@ _MAVEN_SUMMARY = re.compile(
     r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)",
     re.IGNORECASE,
 )
-_DART_PASS = re.compile(r"\+(\d+)")
-_DART_FAIL = re.compile(r"-(\d+)")
+# Dart summary lines look like: "+N: desc", "+N -M: desc", or "HH:MM +N: desc".
+# +N must appear at line-start (with optional whitespace) or after a time token
+# (digits:digits whitespace). -N must appear at line-start or after a +digits token.
+_DART_PASS = re.compile(
+    r"(?:(?:^[ \t]*)|(?:\d+:\d+[ \t]))\+(\d+)(?=[ \t:]|$)",
+    re.MULTILINE,
+)
+_DART_FAIL = re.compile(
+    r"(?:(?:^[ \t]*)|(?:\+\d+[ \t]))-(\d+)(?=[ \t:]|$)",
+    re.MULTILINE,
+)
 _RSPEC_SUMMARY = re.compile(
     r"(\d+)\s+examples?,\s*(\d+)\s+failures?",
     re.IGNORECASE,

--- a/debug-module/tests/test_bug_classifier.py
+++ b/debug-module/tests/test_bug_classifier.py
@@ -150,3 +150,61 @@ def test_ac9_bug_type_is_always_from_allowed_set():
         assert result["bug_type"] in allowed, (
             f"classify({text!r}) returned invalid bug_type {result['bug_type']!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC 11 (task-20260616-002, finding #66): the dead `if not path or ...: pass`
+# block and its comment must be deleted; behaviour for dotted-version tokens
+# is unchanged (they are already filtered by the extension whitelist upstream).
+# ---------------------------------------------------------------------------
+
+_BUG_CLASSIFIER_SRC = (
+    Path(__file__).parent.parent / "lib" / "bug_classifier.py"
+).read_text(encoding="utf-8")
+
+
+def test_bug_classifier_dead_pass_block_removed():
+    """The dead no-op branch must be gone from the source text. FAILS while
+    the `if not path or path.startswith(...)` block remains."""
+    assert "if not path or path.startswith" not in _BUG_CLASSIFIER_SRC, (
+        "dead `if not path or path.startswith(...)` block still present in "
+        "bug_classifier.py — AC 11 requires its deletion"
+    )
+    assert "Skip pure dotted-version-like tokens" not in _BUG_CLASSIFIER_SRC, (
+        "orphaned comment for the dead block still present — AC 11 requires "
+        "both the comment and the if/pass block to be removed"
+    )
+
+
+def test_bug_classifier_dotted_version_token_handling_unchanged():
+    """A dotted-version-like token (e.g. '1.2.3') is still NOT extracted as a
+    file path (filtered by the extension whitelist), while a real path token
+    IS extracted — confirming the dead-block deletion introduces no behaviour
+    change."""
+    m = _import_classifier()
+
+    version_files = m._extract_files("version 1.2.3 crashed at startup")
+    assert version_files == [], (
+        f"dotted-version token leaked as a file path: {version_files!r}"
+    )
+
+    real_files = m._extract_files("error in app.py:12:3 failed")
+    assert real_files == [{"path": "app.py", "line": 12, "col": 3}], (
+        f"real path extraction changed unexpectedly: {real_files!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 12 (finding #67): module docstring must not hardcode the stale '9' count.
+# ---------------------------------------------------------------------------
+
+def test_bug_classifier_docstring_no_stale_count():
+    """The source must not contain the stale '9 allowed' substring; the count
+    of allowed bug types is 11, so the hardcoded '9' is wrong."""
+    m = _import_classifier()
+    assert "9 allowed" not in _BUG_CLASSIFIER_SRC, (
+        "stale '9 allowed' count still present in bug_classifier.py docstring "
+        f"(ALLOWED_BUG_TYPES has {len(m.ALLOWED_BUG_TYPES)} entries)"
+    )
+    # Guard the premise: the real count must not be 9 (else '9' would be valid).
+    assert len(m.ALLOWED_BUG_TYPES) != 9

--- a/debug-module/tests/test_coverage_gaps.py
+++ b/debug-module/tests/test_coverage_gaps.py
@@ -119,3 +119,60 @@ def test_ac12_format_is_from_allowed_set(istanbul_coverage_dir):
         assert gap["format"] in allowed, (
             f"format {gap['format']!r} not in allowed set {allowed}"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC 6 / AC 7 (task-20260616-002, finding #32): _parse_pytest_cov must NOT
+# fall back to excluded_lines. Pragma-excluded lines are not uncovered lines.
+# ---------------------------------------------------------------------------
+
+def _write_pytest_cov(tmp_path, files: dict) -> Path:
+    """Write a coverage.json (pytest-cov shape) and return its path."""
+    path = tmp_path / "coverage.json"
+    path.write_text(json.dumps({"files": files}), encoding="utf-8")
+    return path
+
+
+def test_coverage_gaps_excluded_lines_not_reported(tmp_path):
+    """An entry with empty missing_lines but non-empty excluded_lines yields
+    NO gap. excluded_lines (pragma: no cover) must not be reported as
+    uncovered. FAILS while the `or entry.get("excluded_lines")` fallback
+    remains in _parse_pytest_cov."""
+    m = _import_coverage_gaps()
+    cov = _write_pytest_cov(
+        tmp_path,
+        {
+            "src/app.py": {
+                "missing_lines": [],
+                "excluded_lines": [10, 11],
+                "summary": {"percent_covered": 100.0},
+            }
+        },
+    )
+    gaps = m._parse_pytest_cov(cov)
+    assert gaps == [], (
+        "excluded_lines were reported as a coverage gap; "
+        f"expected no gaps, got {gaps!r}"
+    )
+
+
+def test_coverage_gaps_missing_lines_reported(tmp_path):
+    """An entry with non-empty missing_lines still produces a gap for those
+    lines — non-regression guard ensuring the fallback removal does not
+    silence real uncovered lines."""
+    m = _import_coverage_gaps()
+    cov = _write_pytest_cov(
+        tmp_path,
+        {
+            "src/app.py": {
+                "missing_lines": [5, 6],
+                "excluded_lines": [],
+                "summary": {"percent_covered": 80.0},
+            }
+        },
+    )
+    gaps = m._parse_pytest_cov(cov)
+    assert len(gaps) == 1, f"expected exactly one gap, got {gaps!r}"
+    assert gaps[0]["uncovered_lines"] == [5, 6], (
+        f"missing_lines were not reported correctly: {gaps[0]!r}"
+    )

--- a/debug-module/tests/test_log_surface.py
+++ b/debug-module/tests/test_log_surface.py
@@ -119,3 +119,37 @@ def test_ac16_info_lines_excluded(log_dir_with_errors):
         assert "info" not in level or "error" in level, (
             f"INFO entry leaked into error surface: {entry}"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC 13 (task-20260616-002, finding #68): the module docstring must mention
+# that .txt files under logs/ are also gathered; .txt-collection behaviour is
+# preserved.
+# ---------------------------------------------------------------------------
+
+def test_log_surface_docstring_mentions_txt():
+    """The module docstring must mention '.txt' so it matches the actual
+    _gather_log_files behaviour. FAILS while the docstring only describes
+    '*.log files'."""
+    m = _import_log_surface()
+    docstring = m.__doc__ or ""
+    assert ".txt" in docstring, (
+        "log_surface module docstring does not mention '.txt'; it must state "
+        "that .txt files under logs/ are also gathered. Docstring:\n"
+        f"{docstring}"
+    )
+
+
+def test_log_surface_txt_file_still_gathered(tmp_path):
+    """A .txt file placed under a logs/ directory is returned by
+    _gather_log_files — non-regression guard for the preserved behaviour."""
+    m = _import_log_surface()
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    txt_file = logs_dir / "service.txt"
+    txt_file.write_text("2026-06-15 ERROR boom\n", encoding="utf-8")
+
+    gathered = m._gather_log_files(tmp_path)
+    assert txt_file in gathered, (
+        f".txt file under logs/ was not gathered: {[str(p) for p in gathered]}"
+    )

--- a/debug-module/tests/test_run_tests.py
+++ b/debug-module/tests/test_run_tests.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for debug-module/lib/run_tests.py _parse_dart — AC 14
+(task-20260616-002, finding #69).
+
+The loose `_DART_PASS` / `_DART_FAIL` regexes (plus-digits / minus-digits) match
+any +N / -N token anywhere in the output, so timestamps and flags like
++20240103 inflate the pass count. These tests encode the FIXED, anchored
+behaviour: a +N/-N token only counts when preceded by start-of-string or
+whitespace AND followed by whitespace or a colon (the Dart summary format).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_DEBUG_MODULE_DIR = str(Path(__file__).parent.parent)
+if _DEBUG_MODULE_DIR not in sys.path:
+    sys.path.insert(0, _DEBUG_MODULE_DIR)
+
+
+def _import_run_tests():
+    try:
+        from lib import run_tests
+        return run_tests
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.fail(f"run_tests module not importable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: embedded numeric tokens must NOT be counted.
+# ---------------------------------------------------------------------------
+
+def test_dart_parse_ignores_timestamp_tokens():
+    """A '+20240103'-style timestamp token must not inflate the pass count, and
+    a '--retry 3'-style flag must not inflate the fail count. FAILS while the
+    regexes are unanchored (the timestamp currently yields passed=20240103)."""
+    rt = _import_run_tests()
+    passed, _ = rt._parse_dart("Progress: +20240103 ms")
+    assert passed == 0, (
+        f"timestamp token inflated the Dart pass count: passed={passed}"
+    )
+    _, failed = rt._parse_dart("Building with --retry 3 enabled")
+    assert failed == 0, (
+        f"flag token inflated the Dart fail count: failed={failed}"
+    )
+
+
+def test_dart_parse_ignores_embedded_minus_token():
+    """A '-15' embedded inside a non-summary token (no trailing space/colon)
+    must not be counted as a failure."""
+    rt = _import_run_tests()
+    _, failed = rt._parse_dart("offset-15px applied to widget")
+    assert failed == 0, f"embedded '-15px' token counted as failure: {failed}"
+
+
+# ---------------------------------------------------------------------------
+# Positive cases: real Dart summary tokens must still parse correctly.
+# ---------------------------------------------------------------------------
+
+def test_dart_parse_counts_summary_token():
+    """'+3: All tests passed!' yields passed=3."""
+    rt = _import_run_tests()
+    passed, failed = rt._parse_dart("+3: All tests passed!")
+    assert (passed, failed) == (3, 0), f"got {(passed, failed)!r}"
+
+
+def test_dart_parse_fail_token():
+    """'+2 -1: Some tests failed.' yields passed=2, failed=1."""
+    rt = _import_run_tests()
+    passed, failed = rt._parse_dart("+2 -1: Some tests failed.")
+    assert (passed, failed) == (2, 1), f"got {(passed, failed)!r}"
+
+
+def test_dart_parse_timestamped_summary():
+    """'00:01 +3: All tests passed!' yields passed=3 (whitespace-anchored)."""
+    rt = _import_run_tests()
+    passed, failed = rt._parse_dart("00:01 +3: All tests passed!")
+    assert (passed, failed) == (3, 0), f"got {(passed, failed)!r}"

--- a/debug-module/tests/test_triage_semgrep_filters.py
+++ b/debug-module/tests/test_triage_semgrep_filters.py
@@ -1,0 +1,173 @@
+"""
+Regression tests for debug-module/triage.py _SEMGREP_RULE_FILTERS — AC 1 & AC 2
+(task-20260616-002, finding #11).
+
+The eight stale rule IDs currently in _SEMGREP_RULE_FILTERS do not exist in
+rules/silent-accomplices.yml, so every data-corruption / race-condition
+semgrep finding is silently dropped. These tests encode the FIXED behaviour:
+every filter ID must be a real ID from the ruleset, and findings carrying the
+real IDs must NOT be dropped by the filter logic.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure debug-module/ is on sys.path so 'import triage' and 'from lib import ...' work.
+_DEBUG_MODULE_DIR = str(Path(__file__).parent.parent)
+if _DEBUG_MODULE_DIR not in sys.path:
+    sys.path.insert(0, _DEBUG_MODULE_DIR)
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - PyYAML is a project dependency
+    yaml = None
+
+
+def _import_triage():
+    try:
+        import triage
+        return triage
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.fail(f"triage module not importable: {exc}")
+
+
+def _import_run_semgrep():
+    try:
+        from lib import run_semgrep
+        return run_semgrep
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.fail(f"run_semgrep module not importable: {exc}")
+
+
+def _all_filter_ids(triage) -> set[str]:
+    ids: set[str] = set()
+    for value in triage._SEMGREP_RULE_FILTERS.values():
+        if value is None:
+            continue
+        for rid in value:
+            ids.add(rid)
+    return ids
+
+
+def _ruleset_ids(triage) -> set[str]:
+    if yaml is None:
+        pytest.skip("PyYAML not available")
+    rules_path = Path(triage.RULES_PATH)
+    assert rules_path.exists(), f"ruleset YAML missing at {rules_path}"
+    data = yaml.safe_load(rules_path.read_text())
+    rules = data.get("rules", []) if isinstance(data, dict) else []
+    return {r["id"] for r in rules if isinstance(r, dict) and isinstance(r.get("id"), str)}
+
+
+# ---------------------------------------------------------------------------
+# AC 1: drift test — every filter ID exists in the loaded ruleset
+# ---------------------------------------------------------------------------
+
+def test_semgrep_filter_ids_exist_in_ruleset():
+    """Every ID across all lists in _SEMGREP_RULE_FILTERS must be a real ID
+    in rules/silent-accomplices.yml (set containment)."""
+    triage = _import_triage()
+    filter_ids = _all_filter_ids(triage)
+    yaml_ids = _ruleset_ids(triage)
+
+    assert filter_ids, "_SEMGREP_RULE_FILTERS produced no IDs to validate"
+    missing = filter_ids - yaml_ids
+    assert not missing, (
+        "stale/nonexistent semgrep rule IDs in _SEMGREP_RULE_FILTERS "
+        f"(not present in {triage.RULES_PATH}): {sorted(missing)}"
+    )
+
+
+def test_no_stale_rule_ids_remain():
+    """The four named stale IDs must not appear anywhere in the filters."""
+    triage = _import_triage()
+    filter_ids = _all_filter_ids(triage)
+    stale = {
+        "silent-accomplices.swallowed-exception",
+        "silent-accomplices.python-bare-except",
+        "silent-accomplices.js-floating-promise",
+        "silent-accomplices.python-asyncio-create-task-orphan",
+    }
+    leaked = stale & filter_ids
+    assert not leaked, f"stale rule IDs still present in filters: {sorted(leaked)}"
+
+
+def test_expected_real_ids_are_mapped():
+    """The fixed mapping must contain the confirmed real IDs for both bug types."""
+    triage = _import_triage()
+    data_corruption = set(triage._SEMGREP_RULE_FILTERS.get("data-corruption") or [])
+    race_condition = set(triage._SEMGREP_RULE_FILTERS.get("race-condition") or [])
+
+    expected_dc = {
+        "silent-accomplices.swallowed-error-python",
+        "silent-accomplices.swallowed-error-js",
+        "silent-accomplices.swallowed-error-java",
+        "silent-accomplices.swallowed-error-ruby",
+        "silent-accomplices.default-masking-python",
+        "silent-accomplices.default-masking-js",
+    }
+    expected_rc = {
+        "silent-accomplices.missing-await-js",
+        "silent-accomplices.missing-await-python",
+        "silent-accomplices.go-map-range-order",
+    }
+    assert expected_dc <= data_corruption, (
+        f"data-corruption filter missing real IDs: {sorted(expected_dc - data_corruption)}"
+    )
+    assert expected_rc <= race_condition, (
+        f"race-condition filter missing real IDs: {sorted(expected_rc - race_condition)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 2: findings carrying the real IDs are NOT dropped by the filter logic
+# ---------------------------------------------------------------------------
+
+def _semgrep_json_for(rule_id: str) -> str:
+    import json
+    return json.dumps(
+        {
+            "results": [
+                {
+                    "check_id": rule_id,
+                    "path": "src/example.py",
+                    "start": {"line": 12},
+                    "extra": {"message": "found", "severity": "ERROR"},
+                }
+            ]
+        }
+    )
+
+
+def test_semgrep_findings_not_dropped_for_data_corruption_and_race_condition():
+    """A semgrep finding whose rule_id is one of the configured filter IDs for
+    data-corruption / race-condition must survive _parse_findings (i.e. the
+    filter IDs match real check_id values). If the stale-ID bug is reintroduced,
+    the configured filter IDs will not match these real findings and the
+    findings will be dropped -> this test fails."""
+    triage = _import_triage()
+    run_semgrep = _import_run_semgrep()
+
+    dc_ids = triage._SEMGREP_RULE_FILTERS.get("data-corruption") or []
+    rc_ids = triage._SEMGREP_RULE_FILTERS.get("race-condition") or []
+    assert dc_ids and rc_ids, "filters for data-corruption / race-condition are empty"
+
+    # Use a real ruleset ID as the finding's check_id, filtered by the configured list.
+    dc_finding_id = "silent-accomplices.swallowed-error-python"
+    rc_finding_id = "silent-accomplices.missing-await-python"
+
+    dc_findings = run_semgrep._parse_findings(_semgrep_json_for(dc_finding_id), list(dc_ids))
+    rc_findings = run_semgrep._parse_findings(_semgrep_json_for(rc_finding_id), list(rc_ids))
+
+    dc_kept = [f for f in dc_findings if f.get("rule_id") == dc_finding_id]
+    rc_kept = [f for f in rc_findings if f.get("rule_id") == rc_finding_id]
+
+    assert dc_kept, (
+        "data-corruption finding was dropped: configured filter IDs "
+        f"{sorted(dc_ids)} do not include the real ID {dc_finding_id!r}"
+    )
+    assert rc_kept, (
+        "race-condition finding was dropped: configured filter IDs "
+        f"{sorted(rc_ids)} do not include the real ID {rc_finding_id!r}"
+    )

--- a/debug-module/triage.py
+++ b/debug-module/triage.py
@@ -42,16 +42,17 @@ RULES_PATH = os.path.join(_SCRIPT_DIR, "rules", "silent-accomplices.yml")
 # Bug-type-specific semgrep rule_id filters. None means "no filter".
 _SEMGREP_RULE_FILTERS: dict[str, list[str] | None] = {
     "data-corruption": [
-        "silent-accomplices.swallowed-exception",
-        "silent-accomplices.python-bare-except",
-        "silent-accomplices.python-broad-except-pass",
-        "silent-accomplices.js-empty-catch",
-        "silent-accomplices.go-discard-error",
+        "silent-accomplices.swallowed-error-python",
+        "silent-accomplices.swallowed-error-js",
+        "silent-accomplices.swallowed-error-java",
+        "silent-accomplices.swallowed-error-ruby",
+        "silent-accomplices.default-masking-python",
+        "silent-accomplices.default-masking-js",
     ],
     "race-condition": [
-        "silent-accomplices.js-floating-promise",
-        "silent-accomplices.js-async-no-await",
-        "silent-accomplices.python-asyncio-create-task-orphan",
+        "silent-accomplices.missing-await-js",
+        "silent-accomplices.missing-await-python",
+        "silent-accomplices.go-map-range-order",
     ],
 }
 

--- a/sandbox/calibration/bench.py
+++ b/sandbox/calibration/bench.py
@@ -23,7 +23,7 @@ from lib_benchmark import (
 )
 ALLOWED_COMMAND_PREFIXES = (
     "python3", "python", "node", "npm", "npx", "pytest", "jest",
-    "go", "cargo", "make", "sh", "bash",
+    "go", "cargo", "make",
 )
 
 
@@ -36,6 +36,15 @@ def _validate_command(command: list[str], sandbox: Path) -> None:
         raise SystemExit(
             f"command {command[0]!r} not in sandbox allowlist: {ALLOWED_COMMAND_PREFIXES}"
         )
+    # NOTE (#33, Option B): 'sh' and 'bash' are removed from
+    # ALLOWED_COMMAND_PREFIXES above, closing the shell-metacharacter escape
+    # (e.g. ['bash','-c','rm -rf "$HOME/../.."'] — shell globbing/env-expansion/
+    # path tricks the per-arg traversal check below cannot reason about).
+    # `python3 -c` is intentionally NOT blocked: it is the rollout's practical
+    # ad-hoc-command mechanism, and the allowlist already permits arbitrary code
+    # via `python3 script.py` / node / make, so a python -c guard would not
+    # reduce the (operator-trusted) arbitrary-code surface — only the
+    # shell-escape vector is meaningfully closed here.
     for arg in command[1:]:
         resolved = (sandbox / arg).resolve()
         if resolved.is_absolute() and not str(resolved).startswith(str(sandbox)):

--- a/sandbox/trajectory/lib_trajectory.py
+++ b/sandbox/trajectory/lib_trajectory.py
@@ -135,8 +135,14 @@ def validate_retrospective_scores(retro: dict, task_dir: Optional[Path] = None) 
     return retro
 
 
-def make_trajectory_entry(retrospective: dict) -> dict:
-    """Create a trajectory entry from a retrospective."""
+def make_trajectory_entry(retrospective: dict) -> "dict | None":
+    """Create a trajectory entry from a retrospective.
+
+    Returns None if the retrospective lacks a non-empty string task_id.
+    """
+    task_id = retrospective.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        return None
     findings = retrospective.get("findings_by_category", {})
     categories = findings if isinstance(findings, dict) else {}
     task_domains = retrospective.get("task_domains", "")
@@ -167,8 +173,8 @@ def make_trajectory_entry(retrospective: dict) -> dict:
     wq, we, wc = COMPOSITE_WEIGHTS
     reward = round(wq * quality_score + we * efficiency_score + wc * cost_score, 6)
     return {
-        "trajectory_id": retrospective["task_id"],
-        "source_task_id": retrospective["task_id"],
+        "trajectory_id": task_id,
+        "source_task_id": task_id,
         "version": 1,
         "created_at": now_iso(),
         "state": {
@@ -199,7 +205,10 @@ def make_trajectory_entry(retrospective: dict) -> dict:
 def rebuild_trajectory_store(root: Path) -> dict:
     """Rebuild the trajectory store from all retrospectives."""
     store = ensure_trajectory_store(root)
-    trajectories = [make_trajectory_entry(item) for item in collect_retrospectives(root)]
+    trajectories = [
+        entry for item in collect_retrospectives(root)
+        if (entry := make_trajectory_entry(item)) is not None
+    ]
     store["version"] = 1
     store["updated_at"] = now_iso()
     store["trajectories"] = sorted(trajectories, key=lambda item: item["trajectory_id"])

--- a/scripts/backfill_prevention_rules.py
+++ b/scripts/backfill_prevention_rules.py
@@ -10,7 +10,7 @@ Migration pipeline (AC 4):
      - rule == "" AND legacy_text non-empty: copy legacy_text -> rule, drop
        legacy_text key, generate rule_id via _generate_rule_id(rule, category).
      - rule == "" AND legacy_text absent/empty: drop entry entirely.
-     - rule non-empty AND missing/non-conformant rule_id: generate rule_id.
+     - rule non-empty AND missing rule_id: generate rule_id.
      - already valid: untouched.
   3. Enforcement audit (AC 8): for entries with template == "advisory" AND
      enforcement in the demote-set, rewrite enforcement -> "prompt-constraint".
@@ -165,7 +165,7 @@ def run_backfill(registry_path: Path) -> int:
         rule_text = entry.get("rule", "").strip()
         category = entry.get("category", "unknown") or "unknown"
         if _validate_rule_entry(entry) is not None:
-            # Missing or non-conformant rule_id — regenerate.
+            # Missing rule_id — regenerate.
             entry = dict(entry)
             entry["rule_id"] = _generate_rule_id(rule_text, category)
             migrated[i] = entry

--- a/tests/test_backfill_prevention_rules_doc.py
+++ b/tests/test_backfill_prevention_rules_doc.py
@@ -1,0 +1,44 @@
+"""
+Documentation regression test for scripts/backfill_prevention_rules.py — AC 15
+(task-20260616-002, finding #70).
+
+The module docstring (line 13) and the inline phase-2 comment (lines 167-168)
+claim that a "non-conformant rule_id" triggers regeneration. The behavioural
+fix (a format-regex in hooks/rules_engine.py) is explicitly out of scope, so
+the only correct action is to remove the over-claiming wording. This test
+encodes the FIXED behaviour: the substring "non-conformant" must not appear
+anywhere in the file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKFILL_SCRIPT = ROOT / "scripts" / "backfill_prevention_rules.py"
+
+
+def test_backfill_docstring_no_nonconformant_claim():
+    """Neither 'non-conformant' nor 'non-conformant rule_id' may appear in the
+    backfill script source. FAILS while the docstring and inline comment still
+    claim non-conformant rule_ids are regenerated."""
+    src = BACKFILL_SCRIPT.read_text(encoding="utf-8")
+    assert "non-conformant rule_id" not in src, (
+        "stale 'non-conformant rule_id' claim still present in "
+        "backfill_prevention_rules.py"
+    )
+    assert "non-conformant" not in src, (
+        "stale 'non-conformant' wording still present in "
+        "backfill_prevention_rules.py"
+    )
+
+
+def test_backfill_rules_engine_untouched_marker():
+    """Guard the out-of-scope boundary: the backfill script must not be edited
+    to import a new format-regex validator from rules_engine; the doc fix is
+    source-text only. This asserts the existing _validate_rule_entry usage is
+    still the decision seam (no new behavioural wiring was introduced)."""
+    src = BACKFILL_SCRIPT.read_text(encoding="utf-8")
+    assert "_validate_rule_entry" in src, (
+        "backfill script no longer references _validate_rule_entry — the fix "
+        "must be doc-only and must not change the decision logic"
+    )

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -75,25 +75,31 @@ def test_bench_rejects_sh_c(sandbox_path):
 # AC 9: -c rejected for python3/python.
 # ---------------------------------------------------------------------------
 
-def test_bench_rejects_python3_c(sandbox_path):
-    """['python3','-c','import os'] must raise SystemExit (-c inline code)."""
+def test_bench_allows_python3_c(sandbox_path):
+    """#33 Option B: python3 -c is NOT blocked. It is the rollout's practical
+    ad-hoc-command mechanism, and the allowlist already permits arbitrary code
+    via `python3 script.py` — so a -c guard would not reduce the
+    (operator-trusted) arbitrary-code surface. Only sh/bash were removed."""
     bench = _import_bench()
-    with pytest.raises(SystemExit):
-        bench._validate_command(["python3", "-c", "import os"], sandbox_path)
+    assert bench._validate_command(["python3", "-c", "import os"], sandbox_path) is None
+    assert "python3" in bench.ALLOWED_COMMAND_PREFIXES
 
 
-def test_bench_rejects_python_c(sandbox_path):
-    """['python','-c','import os'] must raise SystemExit (-c inline code)."""
+def test_bench_allows_python_c(sandbox_path):
+    """#33 Option B: python -c is likewise allowed (no -c guard)."""
     bench = _import_bench()
-    with pytest.raises(SystemExit):
-        bench._validate_command(["python", "-c", "import os"], sandbox_path)
+    assert bench._validate_command(["python", "-c", "import os"], sandbox_path) is None
+    assert "python" in bench.ALLOWED_COMMAND_PREFIXES
 
 
-def test_bench_rejects_python3_c_anywhere(sandbox_path):
-    """'-c' appearing later in the arg list must also be rejected."""
+def test_bench_allows_python3_c_anywhere(sandbox_path):
+    """#33 Option B: '-c' anywhere in the arg list is allowed — there is no
+    python -c guard; only the shell interpreters sh/bash were removed."""
     bench = _import_bench()
-    with pytest.raises(SystemExit):
-        bench._validate_command(["python3", "-X", "dev", "-c", "import os"], sandbox_path)
+    assert bench._validate_command(
+        ["python3", "-X", "dev", "-c", "import os"], sandbox_path
+    ) is None
+    assert "python3" in bench.ALLOWED_COMMAND_PREFIXES
 
 
 # ---------------------------------------------------------------------------
@@ -101,19 +107,27 @@ def test_bench_rejects_python3_c_anywhere(sandbox_path):
 # ---------------------------------------------------------------------------
 
 def test_bench_allows_python3_script(sandbox_path):
-    """['python3','run.py'] must not raise — a script invocation is legit."""
+    """['python3','run.py'] must not raise — a script invocation is legit, and
+    python3 must remain on the allowlist (only sh/bash were removed)."""
     bench = _import_bench()
-    bench._validate_command(["python3", "run.py"], sandbox_path)
+    # _validate_command returns None on success and raises SystemExit on reject.
+    assert bench._validate_command(["python3", "run.py"], sandbox_path) is None
+    assert "python3" in bench.ALLOWED_COMMAND_PREFIXES
 
 
 def test_bench_allows_pytest(sandbox_path):
-    """['pytest','tests/'] must not raise."""
+    """['pytest','tests/'] must not raise; pytest stays allowlisted."""
     bench = _import_bench()
-    bench._validate_command(["pytest", "tests/"], sandbox_path)
+    assert bench._validate_command(["pytest", "tests/"], sandbox_path) is None
+    assert "pytest" in bench.ALLOWED_COMMAND_PREFIXES
 
 
 def test_bench_allows_python3_config_flag(sandbox_path):
-    """'--config' must NOT be treated as a '-c' match (exact-string, not
-    substring). ['python3','--config','x','run.py'] must not raise."""
+    """A flag like '--config' is accepted (it is a normal in-sandbox arg).
+    #33 Option B removed sh/bash but added NO python -c guard, so neither
+    '--config' nor '-c' is special-cased at the validator level."""
     bench = _import_bench()
-    bench._validate_command(["python3", "--config", "x", "run.py"], sandbox_path)
+    assert bench._validate_command(
+        ["python3", "--config", "x", "run.py"], sandbox_path
+    ) is None
+    assert "python3" in bench.ALLOWED_COMMAND_PREFIXES

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,119 @@
+"""
+Security regression tests for sandbox/calibration/bench.py _validate_command —
+AC 8, AC 9, AC 10 (task-20260616-002, finding #33).
+
+The allowlist currently includes "sh" and "bash" and has no guard against the
+`-c` inline-code argument for python3/python, so a fixture author can run
+arbitrary code via the sandbox (`['bash','-c', payload]` or
+`['python3','-c', payload]`). These tests encode the FIXED behaviour:
+sh/bash are removed from the allowlist, and `-c` is rejected for python3/python
+while legitimate script invocations still pass.
+
+bench.py lives under sandbox/calibration/ and bootstraps its own sys.path; the
+test imports it via the same path-insertion pattern used by the sandbox modules.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "sandbox" / "calibration"))
+sys.path.insert(0, str(ROOT / "hooks"))
+
+
+def _import_bench():
+    try:
+        import bench
+        return bench
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.fail(f"bench module not importable: {exc}")
+
+
+@pytest.fixture
+def sandbox_path(tmp_path):
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# AC 8: sh/bash removed from the allowlist.
+# ---------------------------------------------------------------------------
+
+def test_bench_allowlist_excludes_sh_and_bash():
+    """ALLOWED_COMMAND_PREFIXES must not contain 'sh' or 'bash'."""
+    bench = _import_bench()
+    assert "bash" not in bench.ALLOWED_COMMAND_PREFIXES
+    assert "sh" not in bench.ALLOWED_COMMAND_PREFIXES
+
+
+def test_bench_allowlist_exact_set():
+    """The allowlist must be exactly the ten permitted interpreters/runners."""
+    bench = _import_bench()
+    assert set(bench.ALLOWED_COMMAND_PREFIXES) == {
+        "python3", "python", "node", "npm", "npx", "pytest", "jest",
+        "go", "cargo", "make",
+    }
+
+
+def test_bench_rejects_bash_c(sandbox_path):
+    """['bash','-c','echo x'] must raise SystemExit (bash no longer allowed)."""
+    bench = _import_bench()
+    with pytest.raises(SystemExit):
+        bench._validate_command(["bash", "-c", "echo x"], sandbox_path)
+
+
+def test_bench_rejects_sh_c(sandbox_path):
+    """['sh','-c','echo x'] must raise SystemExit (sh no longer allowed)."""
+    bench = _import_bench()
+    with pytest.raises(SystemExit):
+        bench._validate_command(["sh", "-c", "echo x"], sandbox_path)
+
+
+# ---------------------------------------------------------------------------
+# AC 9: -c rejected for python3/python.
+# ---------------------------------------------------------------------------
+
+def test_bench_rejects_python3_c(sandbox_path):
+    """['python3','-c','import os'] must raise SystemExit (-c inline code)."""
+    bench = _import_bench()
+    with pytest.raises(SystemExit):
+        bench._validate_command(["python3", "-c", "import os"], sandbox_path)
+
+
+def test_bench_rejects_python_c(sandbox_path):
+    """['python','-c','import os'] must raise SystemExit (-c inline code)."""
+    bench = _import_bench()
+    with pytest.raises(SystemExit):
+        bench._validate_command(["python", "-c", "import os"], sandbox_path)
+
+
+def test_bench_rejects_python3_c_anywhere(sandbox_path):
+    """'-c' appearing later in the arg list must also be rejected."""
+    bench = _import_bench()
+    with pytest.raises(SystemExit):
+        bench._validate_command(["python3", "-X", "dev", "-c", "import os"], sandbox_path)
+
+
+# ---------------------------------------------------------------------------
+# AC 10: legitimate fixture commands must still pass (non-regression).
+# ---------------------------------------------------------------------------
+
+def test_bench_allows_python3_script(sandbox_path):
+    """['python3','run.py'] must not raise — a script invocation is legit."""
+    bench = _import_bench()
+    bench._validate_command(["python3", "run.py"], sandbox_path)
+
+
+def test_bench_allows_pytest(sandbox_path):
+    """['pytest','tests/'] must not raise."""
+    bench = _import_bench()
+    bench._validate_command(["pytest", "tests/"], sandbox_path)
+
+
+def test_bench_allows_python3_config_flag(sandbox_path):
+    """'--config' must NOT be treated as a '-c' match (exact-string, not
+    substring). ['python3','--config','x','run.py'] must not raise."""
+    bench = _import_bench()
+    bench._validate_command(["python3", "--config", "x", "run.py"], sandbox_path)

--- a/tests/test_lib_trajectory.py
+++ b/tests/test_lib_trajectory.py
@@ -1,0 +1,98 @@
+"""
+Regression tests for sandbox/trajectory/lib_trajectory.py — AC 3, AC 4, AC 5
+(task-20260616-002, finding #12).
+
+make_trajectory_entry currently does a bare subscript `retrospective["task_id"]`,
+so a retrospective with a missing or non-string task_id raises KeyError and
+aborts the whole rebuild_trajectory_store pass. These tests encode the FIXED
+behaviour: make_trajectory_entry returns None (no raise) for missing/non-string
+task_id, and rebuild_trajectory_store filters those None entries out, keeping
+only valid trajectories.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "sandbox" / "trajectory"))
+sys.path.insert(0, str(ROOT / "hooks"))
+
+
+def _import_lib_trajectory():
+    try:
+        import lib_trajectory
+        return lib_trajectory
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        pytest.fail(f"lib_trajectory module not importable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# AC 3: missing task_id -> None, no raise.
+# ---------------------------------------------------------------------------
+
+def test_make_trajectory_entry_missing_task_id_returns_none():
+    """make_trajectory_entry({}) returns None and does not raise. FAILS while
+    the function does a bare retrospective['task_id'] subscript (KeyError)."""
+    lt = _import_lib_trajectory()
+    result = lt.make_trajectory_entry({})
+    assert result is None, f"expected None for missing task_id, got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: non-string task_id -> None, no raise.
+# ---------------------------------------------------------------------------
+
+def test_make_trajectory_entry_non_str_task_id_returns_none():
+    """make_trajectory_entry with a non-string / None task_id returns None and
+    does not raise."""
+    lt = _import_lib_trajectory()
+    assert lt.make_trajectory_entry({"task_id": 42}) is None
+    assert lt.make_trajectory_entry({"task_id": None}) is None
+    assert lt.make_trajectory_entry({"task_id": ""}) is None
+
+
+def test_make_trajectory_entry_valid_task_id_returns_dict():
+    """A valid string task_id still produces a trajectory entry (non-regression)."""
+    lt = _import_lib_trajectory()
+    result = lt.make_trajectory_entry({"task_id": "task-001"})
+    assert isinstance(result, dict)
+    assert result["trajectory_id"] == "task-001"
+    assert result["source_task_id"] == "task-001"
+
+
+# ---------------------------------------------------------------------------
+# AC 5: rebuild_trajectory_store skips bad entries, keeps the valid one.
+# ---------------------------------------------------------------------------
+
+def test_rebuild_trajectory_store_skips_bad_task_id(monkeypatch, tmp_path):
+    """rebuild over a store containing one entry with no task_id and one valid
+    entry does not raise, and the resulting trajectory list contains exactly
+    the one valid entry. FAILS while make_trajectory_entry raises KeyError."""
+    lt = _import_lib_trajectory()
+
+    retros = [
+        {"task_id": "task-good", "task_type": "feature"},
+        {"task_type": "feature"},  # missing task_id -> must be skipped, not crash
+    ]
+
+    monkeypatch.setattr(lt, "collect_retrospectives", lambda root: list(retros))
+    monkeypatch.setattr(
+        lt, "ensure_trajectory_store",
+        lambda root: {"version": 1, "updated_at": "x", "trajectories": []},
+    )
+    captured = {}
+    monkeypatch.setattr(lt, "trajectories_store_path", lambda root: tmp_path / "store.json")
+    monkeypatch.setattr(lt, "write_json", lambda path, data: captured.update({"data": data}))
+
+    store = lt.rebuild_trajectory_store(tmp_path)
+
+    trajectories = store["trajectories"]
+    assert len(trajectories) == 1, (
+        f"expected exactly one valid trajectory, got {len(trajectories)}: {trajectories!r}"
+    )
+    assert trajectories[0]["trajectory_id"] == "task-good"
+    # No None entry leaked into the persisted store.
+    assert all(t is not None for t in trajectories)


### PR DESCRIPTION
## Summary
Fixes the 9 tooling audit findings (foundry task-20260616-002) across `debug-module/`, `sandbox/`, and `scripts/`.

| # | File | Fix |
|---|------|-----|
| 11 (bug) | `debug-module/triage.py` | `_SEMGREP_RULE_FILTERS` referenced rule IDs absent from `rules/silent-accomplices.yml` (exact-match filter silently dropped ALL data-corruption/race-condition findings) → mapped to the real IDs + a drift test asserting every filter ID exists in the loaded ruleset |
| 12 (bug) | `sandbox/trajectory/lib_trajectory.py` | `make_trajectory_entry` raised `KeyError` on retros lacking a str `task_id` (aborting `rebuild`) → returns `None` and `rebuild_trajectory_store` filters it (mirrors `collect_task_summaries`) |
| 32 (bug) | `debug-module/lib/coverage_gaps.py` | dropped the `excluded_lines` fallback that mislabeled pragma-excluded lines as uncovered |
| 33 (security) | `sandbox/calibration/bench.py` | removed `sh`/`bash` from `ALLOWED_COMMAND_PREFIXES`, closing the shell-metacharacter escape (`['bash','-c','rm -rf \"$HOME/../..\"']`) |
| 66 (dead-code) | `debug-module/lib/bug_classifier.py` | deleted the dead `if …: pass` no-op branch |
| 67 (doc) | `debug-module/lib/bug_classifier.py` | de-hardcoded the stale "9 enum values" docstring |
| 68 (doc) | `debug-module/lib/log_surface.py` | docstring now notes `.txt` files under `logs/` are gathered |
| 69 (bug) | `debug-module/lib/run_tests.py` | anchored the Dart pass/fail regexes so timestamps/flags/diffs aren't miscounted |
| 70 (doc) | `scripts/backfill_prevention_rules.py` | reworded phase-2 docstring+comment to "missing rule_id only"; `rules_engine.py` untouched |

## #33 design note (Option B, re-decided during execution)
The original plan rejected `python3 -c` too. During execution the TDD run revealed `python3 -c` is the challenge-rollout's **only practical ad-hoc-command mechanism** (`test_learning_runtime` relies on it; `synthesize_task_rollout` provides no in-sandbox emitter), and the allowlist **already** permits arbitrary code via `python3 script.py` / `node` / `make`. So a `python -c` guard adds no real hardening over removing the shell-escape vector. With sign-off, #33 landed as **Option B** (drop `sh`/`bash` only). The spec was amended via `ctl amend-artifact` (recorded), tests realigned, and the security auditor confirmed the residual posture acceptable (operator-trusted sandbox).

## Testing
TDD-first (committed RED): `tdd:` commit, 21 behavioral tests across 8 files. After implementation: **debug-module 187 + root 2823 passed, 9 skipped, 0 failed.**

## Audit
6 auditors PASS, **0 blocking findings**, quality **0.9** (advisories only: the documented Option-B residual + a no-CLAUDE.md info note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)