### PR TITLE
fix: remaining advisories — CommandPalette 'R' refresh re-render + write-boundary daemon role doc

### DIFF
--- a/docs/write-boundary-spec.md
+++ b/docs/write-boundary-spec.md
@@ -178,7 +178,7 @@ The unconditional Class B control-plane guarantee is enforced inside `decide_wri
 
 - **`_is_cross_task_control_plane(rel_posix: str) -> bool`** — classifies the target path by its own task-relative name (case-folded). Returns `True` if the relative name matches a Class B control-plane filename (e.g., `manifest.json`, `receipts/`, `handoff-*.json`). The case-fold prevents bypasses like `MANIFEST.JSON`.
 
-- **`_FRAMEWORK_ROLES`** — a `frozenset` of roles (`ctl`, `scheduler`, `receipt-writer`, `eventbus`, `system`) that are unconditionally exempt from cross-task control-plane denial. These are the only roles whose writes bypass `_owning_task_dir` and `_is_cross_task_control_plane` checking inside `decide_write`.
+- **`_FRAMEWORK_ROLES`** — a `frozenset` of roles (`ctl`, `scheduler`, `receipt-writer`, `eventbus`, `system`, `daemon`) that are unconditionally exempt from cross-task control-plane denial. These are the only roles whose writes bypass `_owning_task_dir` and `_is_cross_task_control_plane` checking inside `decide_write`.
 
 Together, these three pieces ensure that the Class B guarantee is unconditional for non-framework roles: even if a role's prompt is compromised and it claims a different `task_dir`, the path-derived `_owning_task_dir` logic and name-based `_is_cross_task_control_plane` classify the write correctly.
 
@@ -205,6 +205,7 @@ Initial role set:
 - `receipt-writer`
 - `eventbus`
 - `system`
+- `daemon`
 
 ## Initial Allowlist Matrix
 

--- a/hooks/dashboard-ui/src/__tests__/refresh_setpaletteindex.test.tsx
+++ b/hooks/dashboard-ui/src/__tests__/refresh_setpaletteindex.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Regression test for AC1 of task-20260616-004.
+ *
+ * Verifies that the 'r'/'R' keyboard refresh handler in CommandPalette.tsx
+ * calls setPaletteIndex(data) within the same .then() block that assigns
+ * paletteCache = data.
+ *
+ * WHY source-analysis: the refresh handler uses a floating async fetch chain
+ * inside a keydown listener registered in useEffect. The floating promise is
+ * not flushable into the rendered DOM under jsdom+RTL (documented in
+ * .dynos/task-20260616-001/evidence/tdd-tests-repair.md; the AC8 tests there
+ * use the same source-analysis approach). A behavioral render test cannot
+ * observe the result, so we inspect the source directly — the same pattern
+ * used for AC8 and AC10 in bugfix.test.tsx.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+describe("AC1 (task-20260616-004) — 'r' refresh handler calls setPaletteIndex after paletteCache = data", () => {
+  let src: string;
+
+  // Read the source once using vi.importActual (same pattern as AC8/AC10 in bugfix.test.tsx).
+  // vi.mock("node:fs") is hoisted file-wide in bugfix.test.tsx only; here we
+  // have no top-level vi.mock, so vi.importActual gives us the real fs module.
+  beforeEach(async () => {
+    const fs = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const path = await vi.importActual<typeof import("node:path")>("node:path");
+    src = (fs as typeof import("node:fs")).readFileSync(
+      (path as typeof import("node:path")).resolve(
+        __dirname,
+        "../components/CommandPalette.tsx"
+      ),
+      "utf8"
+    );
+  });
+
+  it("refresh handler block contains both paletteCache = data and setPaletteIndex( in the same .then(", () => {
+    /**
+     * The bug (before fix): the 'r' handler assigned paletteCache = data in
+     * the second .then() but never called setPaletteIndex(), so React state
+     * was never updated and the results list remained empty after refresh.
+     *
+     * The fix: the second .then() must contain BOTH:
+     *   paletteCache = data;
+     *   setPaletteIndex(data);
+     *
+     * We locate the refresh handler block, extract the .then( that contains
+     * 'paletteCache = data', and assert setPaletteIndex( appears within it.
+     */
+
+    // Locate the 'r' keydown handler block — identified by the 'r'/'R' key
+    // guard and the paletteCache = null reset preceding the fetch chain.
+    const handlerStart = src.indexOf("paletteCache = null");
+    expect(handlerStart).toBeGreaterThan(-1, "refresh handler must reset paletteCache to null");
+
+    // Find the first .then( after the paletteCache = null reset
+    const thenStart = src.indexOf(".then((data:", handlerStart);
+    expect(thenStart).toBeGreaterThan(-1, "refresh handler must have a .then((data:...) arm after paletteCache = null");
+
+    // Find the closing brace of that .then( block — it ends before the next
+    // chained .catch( call. We extract the substring between .then( and .catch(
+    const catchAfterThen = src.indexOf(".catch(", thenStart);
+    expect(catchAfterThen).toBeGreaterThan(-1, ".then( must be followed by a .catch(");
+
+    const thenBlock = src.slice(thenStart, catchAfterThen);
+
+    // Assert paletteCache = data is inside this .then( block
+    expect(thenBlock).toContain("paletteCache = data");
+
+    // Assert setPaletteIndex( is called inside the SAME .then( block
+    expect(thenBlock).toMatch(/setPaletteIndex\s*\(/);
+  });
+
+  it("setPaletteIndex( call in refresh .then( receives 'data' as its argument", () => {
+    /**
+     * Stronger assertion: the call is setPaletteIndex(data), not some other
+     * argument, ensuring the fetched index is committed to React state.
+     */
+    const handlerStart = src.indexOf("paletteCache = null");
+    expect(handlerStart).toBeGreaterThan(-1);
+
+    const thenStart = src.indexOf(".then((data:", handlerStart);
+    expect(thenStart).toBeGreaterThan(-1);
+
+    const catchAfterThen = src.indexOf(".catch(", thenStart);
+    expect(catchAfterThen).toBeGreaterThan(-1);
+
+    const thenBlock = src.slice(thenStart, catchAfterThen);
+
+    // Must contain setPaletteIndex(data) — the exact argument that was missing
+    expect(thenBlock).toMatch(/setPaletteIndex\s*\(\s*data\s*\)/);
+  });
+
+  it("paletteCache = data assignment appears before setPaletteIndex( in the same .then( block", () => {
+    /**
+     * Order guard: the fix must assign the module-level cache first, then
+     * commit to React state. This matches the loadIndex() pattern in the
+     * first-open handler (paletteCache = ...; setPaletteIndex(paletteCache)).
+     */
+    const handlerStart = src.indexOf("paletteCache = null");
+    expect(handlerStart).toBeGreaterThan(-1);
+
+    const thenStart = src.indexOf(".then((data:", handlerStart);
+    expect(thenStart).toBeGreaterThan(-1);
+
+    const catchAfterThen = src.indexOf(".catch(", thenStart);
+    expect(catchAfterThen).toBeGreaterThan(-1);
+
+    const thenBlock = src.slice(thenStart, catchAfterThen);
+
+    const cacheAssignPos = thenBlock.indexOf("paletteCache = data");
+    const setPaletteIndexPos = thenBlock.search(/setPaletteIndex\s*\(/);
+
+    expect(cacheAssignPos).toBeGreaterThan(-1);
+    expect(setPaletteIndexPos).toBeGreaterThan(-1);
+    // paletteCache assignment comes first (or at same position is impossible —
+    // they are different statements)
+    expect(cacheAssignPos).toBeLessThan(setPaletteIndexPos);
+  });
+});

--- a/hooks/dashboard-ui/src/components/CommandPalette.tsx
+++ b/hooks/dashboard-ui/src/components/CommandPalette.tsx
@@ -212,6 +212,7 @@ export default function CommandPalette() {
           .then(res => res.ok ? res.json() : Promise.reject(new Error('Failed')))
           .then((data: PaletteIndex) => {
             paletteCache = data;
+            setPaletteIndex(data);
           })
           .catch(() => setFetchError('Refresh failed'))
           .finally(() => setLoading(false));

--- a/tests/test_doc_staleness_fixes.py
+++ b/tests/test_doc_staleness_fixes.py
@@ -364,3 +364,137 @@ class TestAC6ReadmeRegressionGuard:
         assert not matches, (
             f"{self.DYNOS_BIN} must not have a 'global)' arm: {matches}"
         )
+
+
+# ===========================================================================
+# AC7 — docs/write-boundary-spec.md + hooks/write_policy.py  (#task-20260616-004)
+# ===========================================================================
+
+class TestAC7WriteBoundaryDaemonRole:
+    """AC7 (task-20260616-004): 'daemon' is enumerated in both doc sites and is a
+    member of _FRAMEWORK_ROLES in hooks/write_policy.py.
+
+    Two doc enumeration sites must list 'daemon':
+      1. The _FRAMEWORK_ROLES bullet in the Enforcement subsection (line ~181).
+      2. The "Initial role set" list in the Role-Based Policy section (line ~208).
+
+    And the code must back this up: 'daemon' is in _FRAMEWORK_ROLES.
+    """
+
+    DOC = "docs/write-boundary-spec.md"
+    SOURCE = "hooks/write_policy.py"
+
+    def test_doc_enforcement_subsection_lists_daemon(self):
+        """The _FRAMEWORK_ROLES bullet in the Enforcement subsection names 'daemon'.
+
+        The Enforcement subsection describes _FRAMEWORK_ROLES as a frozenset
+        whose members are listed inline in backtick code spans. The fixed state
+        must include 'daemon' in that enumeration.
+        """
+        text = _read(self.DOC)
+        # Locate the _FRAMEWORK_ROLES bullet — it contains the inline role list
+        framework_roles_lines = [
+            line for line in text.splitlines() if "_FRAMEWORK_ROLES" in line
+        ]
+        assert framework_roles_lines, (
+            f"{self.DOC} must contain at least one line referencing _FRAMEWORK_ROLES"
+        )
+        # At least one of those lines must mention 'daemon'
+        daemon_in_framework_roles = any("daemon" in line for line in framework_roles_lines)
+        assert daemon_in_framework_roles, (
+            f"{self.DOC}: the _FRAMEWORK_ROLES description must enumerate 'daemon'. "
+            f"Lines found: {framework_roles_lines}"
+        )
+
+    def test_doc_role_based_policy_section_lists_daemon(self):
+        """The Initial role set list in the Role-Based Policy section includes 'daemon'.
+
+        The role-based policy section enumerates every recognized role as a
+        markdown list item. 'daemon' must appear as one of those items after the
+        fix. This is the second enumeration site.
+        """
+        text = _read(self.DOC)
+        lines = text.splitlines()
+
+        # Find the Role-Based Policy section header
+        role_section_idx = None
+        for i, line in enumerate(lines):
+            if re.search(r"^#{1,6}\s+Role-Based Policy", line, re.IGNORECASE):
+                role_section_idx = i
+                break
+
+        assert role_section_idx is not None, (
+            f"{self.DOC} must contain a 'Role-Based Policy' section header"
+        )
+
+        # Collect lines from that section until the next same-level or higher header
+        section_header_level = len(lines[role_section_idx]) - len(lines[role_section_idx].lstrip("#"))
+        section_lines = []
+        for line in lines[role_section_idx + 1:]:
+            m = re.match(r"^(#{1,6})\s+", line)
+            if m and len(m.group(1)) <= section_header_level:
+                break
+            section_lines.append(line)
+
+        section_text = "\n".join(section_lines)
+        assert "daemon" in section_text, (
+            f"{self.DOC}: the Role-Based Policy 'Initial role set' list must include 'daemon'. "
+            f"Section text (first 400 chars): {section_text[:400]!r}"
+        )
+
+    def test_write_policy_FRAMEWORK_ROLES_contains_daemon(self):
+        """doc-matches-code: 'daemon' is a member of _FRAMEWORK_ROLES in hooks/write_policy.py.
+
+        We parse the _FRAMEWORK_ROLES frozenset literal from the source text to
+        confirm membership. Source parsing avoids Python-version-specific importlib
+        issues with `from __future__ import annotations` and is sufficient because
+        _FRAMEWORK_ROLES is a simple frozenset literal at module scope.
+        """
+        source = _read(self.SOURCE)
+
+        # Locate the _FRAMEWORK_ROLES = frozenset({...}) block
+        match = re.search(
+            r"_FRAMEWORK_ROLES\s*=\s*frozenset\s*\(\s*\{([^}]+)\}\s*\)",
+            source,
+        )
+        assert match is not None, (
+            f"{self.SOURCE} must define _FRAMEWORK_ROLES as a frozenset literal"
+        )
+
+        # Extract the contents of the frozenset and collect string literals
+        frozenset_body = match.group(1)
+        members = re.findall(r'"([^"]+)"|\'([^\']+)\'', frozenset_body)
+        role_names = {m[0] or m[1] for m in members}
+
+        assert "daemon" in role_names, (
+            f"{self.SOURCE}: 'daemon' must be a member of _FRAMEWORK_ROLES. "
+            f"Parsed members from frozenset literal: {sorted(role_names)}"
+        )
+
+    def test_write_policy_FRAMEWORK_ROLES_is_frozenset_with_expected_core_roles(self):
+        """_FRAMEWORK_ROLES literal contains all six expected core roles.
+
+        Regression guard: adding 'daemon' must not remove the original core roles
+        (ctl, scheduler, receipt-writer, eventbus, system). All six must be present.
+        Uses source-text parsing to avoid importlib/Python-version issues.
+        """
+        source = _read(self.SOURCE)
+
+        match = re.search(
+            r"_FRAMEWORK_ROLES\s*=\s*frozenset\s*\(\s*\{([^}]+)\}\s*\)",
+            source,
+        )
+        assert match is not None, (
+            f"{self.SOURCE} must define _FRAMEWORK_ROLES as a frozenset literal"
+        )
+
+        frozenset_body = match.group(1)
+        members = re.findall(r'"([^"]+)"|\'([^\']+)\'', frozenset_body)
+        role_names = {m[0] or m[1] for m in members}
+
+        required = {"ctl", "scheduler", "receipt-writer", "eventbus", "system", "daemon"}
+        missing = required - role_names
+        assert not missing, (
+            f"_FRAMEWORK_ROLES is missing required roles: {missing}. "
+            f"Parsed members from frozenset literal: {sorted(role_names)}"
+        )


### PR DESCRIPTION
## Summary
Closes the last loose-end audit findings (task-20260616-004). Two were real one-line advisories; three were verified already-fixed.

| Item | Status | Fix |
|------|--------|-----|
| CommandPalette 'R' refresh (Task-4 advisory) | fixed | The cache-bust refresh handler set `paletteCache = data` but not the `paletteIndex` React state, so a manual refresh didn't re-render (the results `useMemo` reads `paletteIndex`). Added `setPaletteIndex(data)`, mirroring `loadIndex`. |
| write-boundary-spec.md `daemon` role (Task-6 advisory) | fixed | The `_FRAMEWORK_ROLES` enumeration omitted `daemon` at both doc sites; added it to match the live `write_policy.py:284-285` frozenset. |
| #6 spawn-prep allowlist | already-fixed | `cmd_spawn_prep` now validates via `_validated_grant_role`. |
| #27 apply-auto-approve-veto allowlist | already-fixed | The `source_auditor_allowlist` ceiling is enforced (ctl.py:1668-9). |
| #46 ghost-test allowlist | already-fixed | The `test_source_filter_downstream` guard is in `_GHOST_TEST_ALLOWLIST`. |

The three already-fixed findings were closed by prior security PRs since the audit snapshot; verified by direct code inspection, regression-context only.

## Testing
- `hooks/dashboard-ui/src/__tests__/refresh_setpaletteindex.test.tsx` — 3 vitest **source-analysis** tests (the component's floating-async-in-`useEffect` render is unflushable under jsdom+RTL, documented in the prior task; the test asserts the 'r' handler's `.then` contains `setPaletteIndex(data)` after `paletteCache = data`).
- `tests/test_doc_staleness_fixes.py` AC7 — 4 pytest source-text tests (doc lists `daemon` at both sites + `write_policy.py` frozenset includes it).
- vitest **3/3**, pytest **34/34**, tsc clean.

## Audit
spec-completion + security + ui + code-quality auditors, **0 blocking**, quality **0.9** (claude-md/perf/dead-code skipped by the router for this tiny low-risk diff).

## Process note
The external-solution gate false-triggered on the word "cache" (the in-component `paletteCache` var); satisfied legitimately with a WebSearch on React state-setter re-render semantics (which confirmed the AC1 rationale) + the search receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)