### PR TITLE
Fix write boundary project scope

### DIFF
--- a/docs/write-boundary-spec.md
+++ b/docs/write-boundary-spec.md
@@ -172,6 +172,18 @@ def allowed_globs_for_role(role: str, task_dir: Path | None) -> list[str]: ...
 
 ### Enforcement
 
+The write boundary governs dynos-work project artifacts only: the active
+project root (the repository containing `.dynos/`), the active task directory
+under that root, and the project's persistent state directory under
+`~/.dynos/projects/<project-id>/`. A write target outside those roots is
+outside dynos-work project scope and is allowed directly by this policy.
+
+This project-scope carve-out is applied only after the global guardrail
+self-modification check. Writes under the installed plugin root,
+`~/.claude/plugins/`, `~/.claude/settings.json`,
+`~/.claude/settings.local.json`, and `~/.dynos/` remain protected globally
+for all agent roles even when those paths are outside the active project.
+
 The unconditional Class B control-plane guarantee is enforced inside `decide_write` in `hooks/write_policy.py` via three internal helpers:
 
 - **`_owning_task_dir(path: Path) -> Path | None`** — computes the task directory that *owns* a given path based on the path itself, independent of the caller's bound `task_dir`. This means an executor bound to `task-A` cannot claim that a path under `task-B` belongs to its own task dir.

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -341,6 +342,67 @@ def _self_modification_denial(attempt: WriteAttempt, path: Path) -> WriteDecisio
     return None
 
 
+def _nearest_project_root_from_cwd(cwd: Path) -> Path | None:
+    """Return nearest ancestor containing .dynos, or None if not in a project."""
+    resolved = cwd.resolve()
+    for candidate in (resolved, *resolved.parents):
+        if (candidate / ".dynos").is_dir():
+            return candidate
+    return None
+
+
+def _persistent_project_root(project_root: Path) -> Path | None:
+    """Resolve the persistent project dir without importing lib_core.
+
+    write_policy is imported by lib_core, so importing _persistent_project_dir
+    here would create a cycle. This mirrors lib_core's pure path derivation and
+    intentionally swallows identity-resolution failures: inability to compute a
+    persistence path must not widen the governed project scope.
+    """
+    try:
+        from lib_project_id import resolve_project_id  # noqa: PLC0415
+
+        dynos_home = Path(os.environ.get("DYNOS_HOME", str(Path.home() / ".dynos")))
+        return (dynos_home / "projects" / resolve_project_id(project_root)).resolve()
+    except Exception:
+        return None
+
+
+def _project_scope_roots(attempt: WriteAttempt) -> tuple[Path, ...]:
+    """Return roots governed by dynos-work for this attempt."""
+    project_root: Path | None = None
+    roots: list[Path] = []
+    if attempt.task_dir is not None:
+        task_dir = attempt.task_dir.resolve()
+        project_root = task_dir.parent.parent.resolve()
+        roots.extend([project_root, task_dir])
+    else:
+        project_root = _nearest_project_root_from_cwd(Path.cwd())
+        if project_root is not None:
+            roots.append(project_root.resolve())
+
+    if project_root is not None:
+        persistent = _persistent_project_root(project_root)
+        if persistent is not None:
+            roots.append(persistent)
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        key = str(root)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(root)
+    return tuple(deduped)
+
+
+def _is_inside_project_scope(attempt: WriteAttempt, path: Path) -> bool:
+    roots = _project_scope_roots(attempt)
+    if not roots:
+        return True
+    return any(path == root or _is_under(path, root) for root in roots)
+
+
 # Task-root files the orchestrator authors directly: logs, escalation notes,
 # the audit-context sidecar, the raw task input, and the discovery/design Q&A
 # records it appends user answers to. spec.md / plan.md / audit-reports /
@@ -428,6 +490,12 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
                     f"cross-task control-plane write denied: {path.name}",
                     "deny",
                 )
+    if not _is_inside_project_scope(attempt, path):
+        return WriteDecision(
+            True,
+            "outside dynos-work project scope - not governed",
+            "direct",
+        )
     rel = _task_relative(path, attempt.task_dir)
     rel_posix = rel.as_posix() if rel is not None else None
 

--- a/tests/test_write_policy.py
+++ b/tests/test_write_policy.py
@@ -130,6 +130,94 @@ def test_task_scoped_role_cannot_escape_task_boundary(tmp_path: Path) -> None:
     assert "escapes task boundary" in decision.reason
 
 
+def test_orchestrator_outside_project_scope_is_allowed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    task_dir = _task_dir(tmp_path / "project")
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    targets = [
+        fake_home / ".claude" / "skills" / "ruthless-review" / "SKILL.md",
+        Path("/tmp") / "dynos-write-policy-outside.txt",
+        tmp_path / "unrelated-repo" / "src" / "main.py",
+    ]
+    for target in targets:
+        decision = decide_write(
+            WriteAttempt(
+                role="orchestrator",
+                task_dir=task_dir,
+                path=target,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is True, f"{target} should be out of scope"
+        assert decision.mode == "direct"
+        assert "outside dynos-work project scope" in decision.reason
+
+
+def test_executor_outside_project_scope_is_allowed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    task_dir = _task_dir(tmp_path / "project")
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    for target in (
+        fake_home / ".claude" / "skills" / "ruthless-review" / "SKILL.md",
+        Path("/tmp") / "dynos-executor-outside.txt",
+        tmp_path / "other-repo" / "tests" / "test_example.py",
+    ):
+        decision = decide_write(
+            WriteAttempt(
+                role="backend-executor",
+                task_dir=task_dir,
+                path=target,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is True, f"{target} should be out of scope"
+        assert decision.mode == "direct"
+        assert "outside dynos-work project scope" in decision.reason
+
+
+def test_outside_scope_carveout_does_not_bypass_self_modification(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import write_policy
+
+    task_dir = _task_dir(tmp_path / "project")
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    plugin_root = tmp_path / "installed-plugin" / "dynos-work"
+    (plugin_root / "hooks").mkdir(parents=True)
+    monkeypatch.setattr(write_policy, "_PLUGIN_ROOT", plugin_root.resolve())
+
+    protected_targets = [
+        fake_home / ".claude" / "settings.json",
+        fake_home / ".claude" / "plugins" / "dynos-work" / "hooks.json",
+        plugin_root / "hooks" / "pre_tool_use.py",
+        fake_home / ".dynos" / "x",
+    ]
+    for target in protected_targets:
+        decision = decide_write(
+            WriteAttempt(
+                role="orchestrator",
+                task_dir=task_dir,
+                path=target,
+                operation="modify",
+                source="agent",
+            )
+        )
+        assert decision.allowed is False, f"{target} must remain protected"
+        assert "self-modification" in decision.reason
+
+
 def test_require_write_allowed_emits_denial_event(tmp_path: Path) -> None:
     task_dir = _task_dir(tmp_path)
     events = task_dir / "events.jsonl"


### PR DESCRIPTION
## Summary
- add a central project-scope carve-out in write_policy.decide_write for out-of-project paths
- keep self-modification, hook-owned .dynos files, and cross-task control-plane denials ahead of the carve-out
- add regression tests for ~/.claude/skills, /tmp, unrelated repos, and protected guardrail paths
- document that the write boundary applies to project roots and persistent project state, while guardrail paths remain globally protected

## Verification
- python3 -m pytest tests/ -k write_policy
- python3 -m pytest tests/test_self_modification_guard.py

## Runtime note
The live hook runs from the installed plugin cache, so dynos-work must be rebuilt/reinstalled for this source change to affect active sessions.