### PR TITLE
Make task-id allocation collision-resistant across worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.6",
+      "version": "7.5.7",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.7] - 2026-06-22
+### Fixed
+- Task-id allocation is now collision-resistant across concurrent worktrees.
+  The previous `task-{YYYYMMDD}-{seq}` scheme derived the sequence by globbing
+  the local, root-relative `.dynos/`, so worktrees that branched at once each
+  saw an empty set, all landed on `seq=001`, and produced identical ids —
+  causing last-writer-wins clobbering in the shared persistent project store
+  (keyed by task_id). Ids now carry a 32-bit CSPRNG entropy suffix
+  (`task-{YYYYMMDD}-{seq:03d}-{hex}`) via a single shared
+  `lib_core.allocate_task_id` helper used by both `ctl.py` and
+  `manual_pipeline.py`, which also unifies the date segment on UTC and claims
+  the task dir atomically with retry. Strict `\d{3}$` task-id matchers in
+  `lib_tokens_hook.py` and the dashboard vite-plugin were widened to accept the
+  optional suffix while still rejecting path traversal.
+
+---
+
 ## [7.5.6] - 2026-06-21
 ### Fixed
 - Enforce per-model ensemble audit receipt accounting by requiring `audit-{auditor}-{model}` shard receipts, rejecting pre-prefixed `audit-*` shard names, and documenting the required audit skill invocation.

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -22,6 +22,7 @@ from lib_core import (
     VALID_CLASSIFICATION_TYPES,
     VALID_DOMAINS,
     VALID_RISK_LEVELS,
+    allocate_task_id,
     find_active_tasks,
     get_tdd_required,
     load_json,
@@ -2294,8 +2295,6 @@ def cmd_run_start_init(args: argparse.Namespace) -> int:
     The task description arrives via --description, or stdin when
     `--description -` (heredoc-friendly for long inputs).
     """
-    import time as _time
-
     root = Path(args.root or ".").resolve()
     description = args.description or ""
     if description == "-":
@@ -2321,15 +2320,11 @@ def cmd_run_start_init(args: argparse.Namespace) -> int:
         except Exception:
             pass
 
-    today = _time.strftime("%Y%m%d", _time.gmtime())
-    seq = 1
-    for existing in sorted(dynos_dir.glob(f"task-{today}-*")):
-        suffix = existing.name.rsplit("-", 1)[-1]
-        if suffix.isdigit():
-            seq = max(seq, int(suffix) + 1)
-    task_id = f"task-{today}-{seq:03d}"
-    task_dir = dynos_dir / task_id
-    task_dir.mkdir()
+    # Collision-resistant allocation: the id carries CSPRNG entropy so
+    # concurrent allocations from separate worktrees (each with its own
+    # .dynos/) cannot collide on the date+counter and clobber each other in the
+    # shared persistent project store (which is keyed by task_id).
+    task_id, task_dir = allocate_task_id(dynos_dir)
 
     input_type = args.input_type or "text"
     manifest = {

--- a/hooks/dashboard-ui/src/__tests__/vite-plugin/dynos-api.test.ts
+++ b/hooks/dashboard-ui/src/__tests__/vite-plugin/dynos-api.test.ts
@@ -476,23 +476,27 @@ describe("POST /api/daemon/:action", () => {
 // ============================================================
 describe("path traversal prevention", () => {
   it("rejects task IDs that do not match the expected pattern", () => {
-    const validPattern = /^task-\d{8}-\d{3}$/;
+    const validPattern = /^task-\d{8}-\d{3}(?:-[0-9a-f]+)?$/;
 
-    // Valid task IDs
+    // Valid task IDs (legacy unsuffixed and new entropy-suffixed)
     expect(validPattern.test("task-20260406-001")).toBe(true);
     expect(validPattern.test("task-20260101-999")).toBe(true);
+    expect(validPattern.test("task-20260622-001-deadbeef")).toBe(true);
 
     // Malicious task IDs - path traversal attempts
     expect(validPattern.test("../../../etc/passwd")).toBe(false);
     expect(validPattern.test("task-20260406-001/../../etc")).toBe(false);
     expect(validPattern.test("task-20260406-001; rm -rf /")).toBe(false);
+    // The optional suffix must not become a traversal foothold.
+    expect(validPattern.test("task-20260622-001-../../etc")).toBe(false);
+    expect(validPattern.test("task-20260622-001-DEAD/beef")).toBe(false);
     expect(validPattern.test("")).toBe(false);
     expect(validPattern.test("task-abc-001")).toBe(false);
   });
 
   it("returns 400 for path traversal attempts in task ID", () => {
     const maliciousId = "../../../etc/passwd";
-    const validPattern = /^task-\d{8}-\d{3}$/;
+    const validPattern = /^task-\d{8}-\d{3}(?:-[0-9a-f]+)?$/;
     const isValid = validPattern.test(maliciousId);
     expect(isValid).toBe(false);
     // Expected response: 400 { error: "Invalid task ID" }

--- a/hooks/dashboard-ui/src/vite-plugin/dynos-api.ts
+++ b/hooks/dashboard-ui/src/vite-plugin/dynos-api.ts
@@ -5,7 +5,11 @@ import { exec } from "node:child_process";
 import { homedir } from "node:os";
 import { URL } from "node:url";
 
-const TASK_ID_PATTERN = /^task-\d{8}-\d{3}$/;
+// Matches ``task-YYYYMMDD-NNN`` with an optional ``-<hex>`` entropy suffix.
+// The suffix makes ids collision-resistant across concurrent worktrees; the
+// group is optional so legacy unsuffixed ids still validate. Keep in lockstep
+// with lib_core._TASK_ID_ALLOC_RE / is_safe_task_id.
+const TASK_ID_PATTERN = /^task-\d{8}-\d{3}(?:-[0-9a-f]+)?$/;
 
 function computeSlug(projectPath: string): string {
   return projectPath.replace(/^\//, "").replace(/\//g, "-");

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -8,6 +8,7 @@ import functools
 import json
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import sys
@@ -307,6 +308,66 @@ def is_safe_task_id(task_id: object) -> bool:
     update _TASK_ID_SLUG_RE in lockstep.
     """
     return isinstance(task_id, str) and bool(_TASK_ID_SLUG_RE.match(task_id))
+
+
+# Parses an allocated task id back into its (date, seq) fields. The entropy
+# suffix is optional so this also reads legacy ``task-YYYYMMDD-NNN`` dirs that
+# predate the suffix — they still contribute to the local seq high-water mark.
+_TASK_ID_ALLOC_RE: "re.Pattern[str]" = re.compile(
+    r"^task-(\d{8})-(\d{3})(?:-[0-9a-f]+)?$"
+)
+
+
+def allocate_task_id(
+    dynos_dir: Path,
+    *,
+    now: "datetime | None" = None,
+    rand=None,
+) -> "tuple[str, Path]":
+    """Atomically allocate a unique task id and create its dir under ``dynos_dir``.
+
+    Returns ``(task_id, task_dir)`` where ``task_id`` has the form
+    ``task-{YYYYMMDD}-{seq:03d}-{rand}``:
+
+    - ``YYYYMMDD`` is the **UTC** date. All allocators must agree on UTC so two
+      callers near midnight never disagree on the date segment.
+    - ``seq`` is a best-effort, *local* monotonic counter derived from sibling
+      task dirs in *this* ``dynos_dir``. It is NOT a global uniqueness
+      guarantee: concurrent allocations from separate worktrees (each with its
+      own root-relative ``.dynos/``) cannot see each other's dirs and will
+      reuse the same ``seq``. It exists only for human readability.
+    - ``rand`` is 8 hex chars (32 bits) of CSPRNG entropy. This is what makes
+      the id collision-resistant across independent ``.dynos`` roots AND the
+      shared persistent project store (``~/.dynos/projects/{uuid}/``, keyed by
+      task_id), which is what last-writer-wins clobbered when the old
+      date+counter scheme handed concurrent worktrees the same id.
+
+    The dir is claimed with ``mkdir()`` (atomic, no ``exist_ok``) inside a
+    retry loop; on the rare local entropy clash the suffix is re-rolled. The
+    returned id always satisfies :func:`is_safe_task_id`.
+
+    ``now``/``rand`` are injectable for deterministic tests.
+    """
+    dynos_dir.mkdir(parents=True, exist_ok=True)
+    when = now or datetime.now(timezone.utc)
+    today = when.strftime("%Y%m%d")
+    seq = 1
+    for existing in dynos_dir.glob(f"task-{today}-*"):
+        match = _TASK_ID_ALLOC_RE.match(existing.name)
+        if match and match.group(1) == today:
+            seq = max(seq, int(match.group(2)) + 1)
+    rand_fn = rand or (lambda: secrets.token_hex(4))
+    for _ in range(64):
+        task_id = f"task-{today}-{seq:03d}-{rand_fn()}"
+        task_dir = dynos_dir / task_id
+        try:
+            task_dir.mkdir()
+        except FileExistsError:
+            continue
+        return task_id, task_dir
+    raise RuntimeError(
+        f"could not allocate a unique task id for {today} after 64 attempts"
+    )
 
 
 def _persistent_project_dir(root: Path) -> Path:

--- a/hooks/lib_tokens_hook.py
+++ b/hooks/lib_tokens_hook.py
@@ -52,7 +52,10 @@ def _attribution_window_seconds() -> float:
 def _active_tasks_from_manifests(dynos: Path) -> list[tuple[float, Path]]:
     candidates: list[tuple[float, Path]] = []
     for td in dynos.iterdir():
-        if not td.is_dir() or not re.match(r"task-\d{8}-\d{3}$", td.name):
+        # Accept the optional ``-<hex>`` entropy suffix added to task ids for
+        # cross-worktree collision resistance, while still matching legacy
+        # ``task-YYYYMMDD-NNN`` dirs.
+        if not td.is_dir() or not re.match(r"task-\d{8}-\d{3}(?:-[0-9a-f]+)?$", td.name):
             continue
         manifest_path = td / "manifest.json"
         if not manifest_path.exists():

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/tests/test_task_id_allocation.py
+++ b/tests/test_task_id_allocation.py
@@ -1,0 +1,111 @@
+"""Regression coverage for ``lib_core.allocate_task_id``.
+
+Background: task ids used to be ``task-{YYYYMMDD}-{seq:03d}`` where ``seq`` was
+derived by globbing the *local* ``.dynos/``. Each worktree has its own
+``.dynos/``, so concurrent worktrees that branched from origin/main at once all
+globbed an empty set, all landed on ``seq=1``, and all produced
+``task-20260622-001``. The persistent project store
+(``~/.dynos/projects/{uuid}/``) is shared across worktrees and keyed by
+task_id, so last-writer-wins clobbered every retrospective but one.
+
+The fix appends 32 bits of CSPRNG entropy to the id, making it
+collision-resistant regardless of which ``.dynos`` root allocated it, while
+keeping a human-readable (best-effort, local) sequence prefix. These tests pin
+the format, the local monotonic seq, and — the actual bug — uniqueness across
+both same-root and separate-root (worktree) concurrent allocation.
+"""
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from lib_core import allocate_task_id, is_safe_task_id  # noqa: E402
+
+_FIXED_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_format_and_safe_slug(tmp_path: Path) -> None:
+    task_id, task_dir = allocate_task_id(tmp_path / ".dynos", now=_FIXED_NOW)
+    assert task_id.startswith("task-20260622-001-")
+    # date(8) + seq(3) + entropy(8 hex)
+    _, date, seq, ent = task_id.split("-")
+    assert date == "20260622"
+    assert seq == "001"
+    assert len(ent) == 8 and all(c in "0123456789abcdef" for c in ent)
+    # Must pass the path-traversal slug gate that guards every task_id->path join.
+    assert is_safe_task_id(task_id) is True
+    # The dir is claimed atomically as part of allocation.
+    assert task_dir.is_dir() and task_dir.name == task_id
+
+
+def test_local_seq_is_monotonic(tmp_path: Path) -> None:
+    dynos = tmp_path / ".dynos"
+    ids = [allocate_task_id(dynos, now=_FIXED_NOW)[0] for _ in range(3)]
+    seqs = [i.split("-")[2] for i in ids]
+    assert seqs == ["001", "002", "003"]
+    assert len(set(ids)) == 3
+
+
+def test_reads_legacy_unsuffixed_dirs_for_seq(tmp_path: Path) -> None:
+    """A pre-fix ``task-YYYYMMDD-NNN`` dir (no entropy suffix) must still raise
+    the local high-water mark so a new allocation does not reuse its seq."""
+    dynos = tmp_path / ".dynos"
+    (dynos / "task-20260622-007").mkdir(parents=True)
+    task_id, _ = allocate_task_id(dynos, now=_FIXED_NOW)
+    assert task_id.split("-")[2] == "008"
+
+
+def test_retries_and_rerolls_on_entropy_collision(tmp_path: Path) -> None:
+    """The glob/mkdir TOCTOU: another allocator created the candidate dir after
+    we computed seq but before our mkdir. allocation must re-roll the entropy
+    suffix rather than crash or clobber. We reproduce the race deterministically
+    by having the first ``rand()`` plant the colliding dir as a side effect."""
+    dynos = tmp_path / ".dynos"
+    dynos.mkdir(parents=True)
+    state = {"raced": False}
+
+    def rand() -> str:
+        if not state["raced"]:
+            # Simulate a concurrent allocator winning the seq=001 slot in the
+            # window between our glob (already done) and our mkdir.
+            (dynos / "task-20260622-001-deadbeef").mkdir()
+            state["raced"] = True
+            return "deadbeef"
+        return "feedface"
+
+    task_id, task_dir = allocate_task_id(dynos, now=_FIXED_NOW, rand=rand)
+    assert task_id == "task-20260622-001-feedface"
+    assert task_dir.is_dir()
+
+
+def test_concurrent_same_dynos_unique(tmp_path: Path) -> None:
+    dynos = tmp_path / ".dynos"
+    dynos.mkdir(parents=True)
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        ids = list(pool.map(lambda _: allocate_task_id(dynos)[0], range(64)))
+    assert len(set(ids)) == 64
+    for tid in ids:
+        assert (dynos / tid).is_dir()
+
+
+def test_concurrent_separate_dynos_unique(tmp_path: Path) -> None:
+    """The reported bug: concurrent allocations in *separate* .dynos roots
+    (each simulating a worktree) must not collide on the same id. The seq
+    prefix WILL repeat (each root globs only itself) — entropy is what keeps
+    the full id unique across roots, exactly as the shared persistent store
+    requires."""
+    def alloc(i: int) -> str:
+        return allocate_task_id(tmp_path / f"wt{i}" / ".dynos", now=_FIXED_NOW)[0]
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        ids = list(pool.map(alloc, range(32)))
+
+    # Every seq prefix is 001 (the old bug's collision point)...
+    assert all(i.split("-")[2] == "001" for i in ids)
+    # ...yet every full id is distinct because of the entropy suffix.
+    assert len(set(ids)) == 32

--- a/tools/manual_pipeline.py
+++ b/tools/manual_pipeline.py
@@ -58,19 +58,15 @@ def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subproce
 
 
 def generate_task_id(root: Path) -> str:
-    prefix = datetime.now().strftime("task-%Y%m%d-")
-    dynos_dir = root / ".dynos"
-    dynos_dir.mkdir(parents=True, exist_ok=True)
-    existing = {
-        path.name
-        for path in dynos_dir.glob(f"{prefix}*")
-        if path.is_dir() and path.name.startswith(prefix)
-    }
-    for idx in range(1, 1000):
-        candidate = f"{prefix}{idx:03d}"
-        if candidate not in existing:
-            return candidate
-    raise RuntimeError(f"could not allocate task id for prefix {prefix}")
+    # Delegate to the shared allocator so this tool and ctl.py agree on the id
+    # format and the UTC date segment, and so the dir is claimed atomically with
+    # entropy rather than via a local-only counter that collides across
+    # worktrees. allocate_task_id creates the dir; create_task's later
+    # mkdir(exist_ok=True) is then a harmless no-op.
+    from lib_core import allocate_task_id  # noqa: PLC0415
+
+    task_id, _task_dir = allocate_task_id(root / ".dynos")
+    return task_id
 
 
 def ensure_project_bootstrap(root: Path) -> list[str]:


### PR DESCRIPTION
## Problem
Task ids were `task-{YYYYMMDD}-{seq:03d}`, with `seq` derived by globbing the **root-relative `.dynos/`**. Each worktree has its own `.dynos/`, so concurrent worktrees that branched from `origin/main` at once each globbed an empty set, all landed on `seq=001`, and produced the **same** `task-20260622-001`. The shared persistent project store (`~/.dynos/projects/{uuid}/`, keyed by `task_id`) then clobbered all but the last writer — stranding distinct retrospectives under one filename.

Two secondary defects in the same path:
- Allocation was check-then-`mkdir` with **no retry** — even within one `.dynos`, two concurrent `start`s would crash the loser instead of advancing the counter.
- The manual allocator used local-tz `datetime.now()` (vs ctl's UTC) and `mkdir(exist_ok=True)`, silently reusing a colliding dir.

## Fix
- **`hooks/lib_core.py`** — new shared `allocate_task_id(dynos_dir)`: appends 32 bits of CSPRNG entropy → `task-{YYYYMMDD}-{seq:03d}-{hex}`. The entropy (not the local counter) is what guarantees uniqueness across independent `.dynos` roots and the shared store. Unifies the date segment on **UTC** and claims the dir with an **atomic `mkdir` retry loop** that re-rolls on the rare clash. The existing slug regex already permits this format.
- **`hooks/ctl.py`** & **`tools/manual_pipeline.py`** — both route through the one helper (kills the tz divergence and silent reuse).
- **`hooks/lib_tokens_hook.py`** & **dashboard `dynos-api.ts`** — widened their strict `\d{3}$` matchers to accept the optional suffix. The TS one is a path-traversal gate; suffix-traversal (e.g. `task-...-../../etc`) is still rejected (covered by tests).

## Tests
- New `tests/test_task_id_allocation.py`: format/slug-safety, local monotonic seq, legacy unsuffixed-dir reads, the glob/mkdir TOCTOU retry, and the **cross-worktree regression** — concurrent allocation across separate `.dynos` roots all keep `seq=001` yet every full id is distinct.
- Updated dashboard vite-plugin tests for the suffix + traversal cases.
- Full suite green: **2900 passed, 9 skipped** (Python) + **21 passed** (dashboard TS).

## Release
- Bumped `7.5.6` → `7.5.7` across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, with a `CHANGELOG.md` entry.

## Not covered (separate concern)
This prevents *future* collisions; it does not recover the already-clobbered retrospectives. `git worktree list` shows only the main checkout, so those worktrees appear already removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)