### PR TITLE
Bind ensemble DONE gate escalation on finding_count, not blocking_count

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.8",
+      "version": "7.5.9",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.8",
+  "version": "7.5.9",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.8",
+  "version": "7.5.9",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.9] - 2026-06-22
+### Fixed
+- Ensemble DONE gate now binds escalation on `finding_count`, not just
+  `blocking_count`. The cascade protocol escalates to the deep tier (opus) on
+  **any** voting-model finding — a non-blocking nit at haiku still warrants opus
+  confirmation — but `_check_ensemble_voting` (`lib_core.py`) previously accepted
+  a clean-ish ensemble whenever every voting receipt was zero-*blocking*. That
+  left a seam: an auditor with non-blocking haiku findings could be run at sonnet
+  (or skip escalation entirely) and still pass the gate, silently dropping the
+  protocol-required opus shard while the prose rule was satisfied only on paper.
+  The gate now requires an opus escalation receipt whenever any voting-model
+  receipt reports `finding_count != 0`, so the documented cascade is enforced by
+  the harness instead of left to the spawning agent's discretion under token
+  pressure. Added regression coverage for the non-blocking-finding path
+  (`test_gate_done_ensemble.py`).
+
+---
+
 ## [7.5.8] - 2026-06-22
 ### Fixed
 - Auditors no longer run out of turns before writing their report. The auditor

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -701,22 +701,28 @@ def _check_ensemble_voting(
                     f"auditor {name} receipt model_used={mu} not in voting set"
                 )
 
-        # Acceptance rule: either every voting-model receipt is zero-blocking,
-        # or an escalation receipt exists.
+        # Acceptance rule: either every voting-model receipt found NOTHING
+        # (zero findings, blocking or not), or an escalation receipt exists.
+        # The cascade protocol escalates to the deep tier on ANY finding — a
+        # non-blocking nit at haiku still warrants opus confirmation — so the
+        # gate binds on finding_count, not just blocking_count. Keying the gate
+        # on blocking_count alone left a seam: an auditor with non-blocking
+        # haiku findings could be run at sonnet (or skip escalation entirely)
+        # and still pass, silently dropping the protocol-required opus shard.
         all_voting_present = all(m in per_model for m in voting_models)
         if all_voting_present:
-            all_zero_blocking = True
+            all_clean = True
             for m in voting_models:
                 r = per_model[m]
                 try:
-                    bc = int(r.get("blocking_count", -1))
+                    fc = int(r.get("finding_count", -1))
                 except (TypeError, ValueError):
-                    bc = -1
-                if bc != 0:
-                    all_zero_blocking = False
+                    fc = -1
+                if fc != 0:
+                    all_clean = False
                     break
-            if all_zero_blocking:
-                continue  # ensemble accepted via zero-blocking consensus
+            if all_clean:
+                continue  # ensemble accepted via zero-finding consensus
         # Fall through → need escalation receipt.
         if escalation_receipt is None:
             missing = [m for m in voting_models if m not in per_model]
@@ -727,8 +733,8 @@ def _check_ensemble_voting(
                 )
             else:
                 gaps.append(
-                    f"auditor {name} ensemble voting-model receipts disagree "
-                    f"(non-zero blocking) and no escalation receipt for {escalation_model!r}"
+                    f"auditor {name} ensemble voting-model receipts found issues "
+                    f"(non-zero findings) and no escalation receipt for {escalation_model!r}"
                 )
 
     return gaps
@@ -812,8 +818,10 @@ def require_receipts_for_done(task_dir: Path) -> list[str]:
          ``voting_models``. A collapsed ``audit-{name}`` receipt is not
          accepted for ensemble accounting.
          Accept iff EITHER every voting-model receipt reports
-         ``blocking_count == 0`` OR an escalation receipt exists whose
-         ``model_used == escalation_model``. Each found receipt's
+         ``finding_count == 0`` OR an escalation receipt exists whose
+         ``model_used == escalation_model``. The cascade escalates to the
+         deep tier on ANY finding (blocking or not), so the gate binds on
+         ``finding_count``, not ``blocking_count``. Each found receipt's
          ``model_used`` MUST be in ``voting_models ∪ {escalation_model}``;
          otherwise a gap error.
       d) Either ``postmortem-generated`` OR ``postmortem-skipped`` MUST be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.8",
+  "version": "7.5.9",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/tests/test_gate_done_ensemble.py
+++ b/tests/test_gate_done_ensemble.py
@@ -7,7 +7,7 @@ Cascade protocol (haiku → sonnet → opus):
   - haiku≠0 findings → skip sonnet, escalate directly to opus (haiku+opus receipts only)
 
 The gate accepts iff:
-  - all voting-model receipts present AND all blocking_count==0, OR
+  - all voting-model receipts present AND all finding_count==0, OR
   - an escalation receipt exists with model_used == escalation_model
     (sonnet receipt may be absent when haiku already escalated directly).
 model_used on every receipt must sit in voting_models ∪ {escalation_model}.
@@ -53,14 +53,21 @@ def _mock_empty_registry(monkeypatch):
 
 
 def _write_audit_receipt(td: Path, step: str, *, model_used: str,
-                         blocking_count: int = 0, contract_version: int = 3) -> Path:
-    """Hand-write an audit-* receipt with the full v3 schema the gate reads."""
+                         blocking_count: int = 0, finding_count: int | None = None,
+                         contract_version: int = 3) -> Path:
+    """Hand-write an audit-* receipt with the full v3 schema the gate reads.
+
+    ``finding_count`` defaults to ``blocking_count`` (the common case); pass it
+    explicitly to model a non-blocking finding (finding_count > 0, blocking=0).
+    """
+    if finding_count is None:
+        finding_count = blocking_count
     return write_receipt(
         td,
         step,
         auditor_name=step.split("-", 1)[1] if "-" in step else step,
         model_used=model_used,
-        finding_count=blocking_count,
+        finding_count=finding_count,
         blocking_count=blocking_count,
         report_path=None,
         report_sha256=None,
@@ -89,6 +96,57 @@ def test_ensemble_zero_blocking_consensus_passes(tmp_path: Path, monkeypatch):
     _write_audit_receipt(td, "audit-sec-sonnet", model_used="sonnet", blocking_count=0)
     gaps = require_receipts_for_done(td)
     assert not any("sec" in g for g in gaps), f"unexpected ensemble gap(s): {gaps}"
+
+
+def test_ensemble_nonblocking_finding_no_escalation_refuses(tmp_path: Path, monkeypatch):
+    """Cascade binds on finding_count, not blocking_count.
+
+    A voting model that finds a NON-blocking issue (finding_count>0, blocking=0)
+    must still escalate to opus. Running it at sonnet with both shards zero-
+    blocking used to pass (the closed seam) — now it must produce a gap.
+    """
+    _mock_empty_registry(monkeypatch)
+    td = _setup_task(tmp_path)
+    receipt_audit_routing(td, [{
+        "name": "sec",
+        "action": "spawn",
+        "ensemble": True,
+        "ensemble_voting_models": ["haiku", "sonnet"],
+        "ensemble_escalation_model": "opus",
+        "route_mode": "generic",
+        "agent_path": None,
+        "injected_agent_sha256": None,
+    }])
+    # haiku reports a non-blocking finding; sonnet clean; no opus escalation.
+    _write_audit_receipt(td, "audit-sec-haiku", model_used="haiku",
+                         blocking_count=0, finding_count=2)
+    _write_audit_receipt(td, "audit-sec-sonnet", model_used="sonnet", blocking_count=0)
+    gaps = require_receipts_for_done(td)
+    assert any("sec" in g and "non-zero findings" in g for g in gaps), \
+        f"expected escalation gap for non-blocking haiku finding: {gaps}"
+
+
+def test_ensemble_nonblocking_finding_with_opus_passes(tmp_path: Path, monkeypatch):
+    """Non-blocking haiku finding + opus escalation shard → accepted."""
+    _mock_empty_registry(monkeypatch)
+    td = _setup_task(tmp_path)
+    receipt_audit_routing(td, [{
+        "name": "sec",
+        "action": "spawn",
+        "ensemble": True,
+        "ensemble_voting_models": ["haiku", "sonnet"],
+        "ensemble_escalation_model": "opus",
+        "route_mode": "generic",
+        "agent_path": None,
+        "injected_agent_sha256": None,
+    }])
+    _write_audit_receipt(td, "audit-sec-haiku", model_used="haiku",
+                         blocking_count=0, finding_count=2)
+    _write_audit_receipt(td, "audit-sec-opus", model_used="opus",
+                         blocking_count=0, finding_count=0)
+    gaps = require_receipts_for_done(td)
+    assert not any("sec" in g for g in gaps), \
+        f"unexpected gap with opus escalation on non-blocking finding: {gaps}"
 
 
 def test_ensemble_haiku_finds_issues_no_escalation_refuses(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Problem

The ensemble cascade protocol (auditor prompts + the `test_gate_done_ensemble.py` docstring) escalates an ensemble auditor to the deep tier (opus) on **any** voting-model finding — a non-blocking nit at haiku still warrants opus confirmation. But the DONE gate (`_check_ensemble_voting`, `hooks/lib_core.py`) only forced an opus escalation when a voting receipt reported `blocking_count != 0`.

That gap was a cheating seam: an auditor with non-blocking haiku findings could be run at sonnet — or skip escalation entirely — and still pass the gate, silently dropping the protocol-required opus shard while the prose rule was satisfied only on paper. Under token pressure, the locally-rational move (cut the opus escalation, rationalize in prose) reliably found this seam. The blocking-only path was closed by 36f66f5; the any-finding path was not.

## Fix

`_check_ensemble_voting` now keys acceptance on `finding_count`: an ensemble auditor passes only if every voting-model receipt reports `finding_count == 0`, otherwise an opus escalation receipt is required. `finding_count` is already on the receipt schema, so the gate change is small and load-bearing. Prose and gate now agree, enforced by the harness instead of left to the spawning agent's discretion.

## Tests

- Extended the `test_gate_done_ensemble.py` helper to decouple finding/blocking counts.
- Added `test_ensemble_nonblocking_finding_no_escalation_refuses` (the closed seam — now a gap) and `test_ensemble_nonblocking_finding_with_opus_passes`.
- Full gate/ensemble/receipt/done slice: 691 passed, 4 skipped.

## Release

- Version 7.5.8 → 7.5.9 across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`.
- CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)