### PR TITLE
Fix .dynos project-root hijack; green the test tree (7.5.11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.10",
+      "version": "7.5.11",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.11] - 2026-07-15
+### Fixed
+- Project-root detection no longer treats the framework home (`~/.dynos` /
+  `$DYNOS_HOME`) or a stray orphan `.dynos` as a project control plane. The
+  `.dynos` name is overloaded — it is both the framework home and each
+  project's control plane — so the old bare-name ancestor walk resolved `$HOME`
+  (which always contains `~/.dynos`) as one giant project, pulling every
+  unrelated repository under it into governance and producing spurious
+  write-policy denials in folders that are not dynos projects. A new shared
+  discriminator (`hooks/lib_dynos_root.is_project_dynos_dir`) rejects the
+  framework home outright and requires a candidate `.dynos` to be a registered
+  project root (or to carry on-disk project state) before it can govern its
+  parent. Applied to every ancestor walk in `write_policy` and `pre_tool_use`,
+  and the out-of-scope write path now decides from the target location instead
+  of governing-when-unsure. Adds `tests/test_dynos_root_scope.py`.
+- Cleared six pre-existing red tests on `main`. Five were stale fixtures that
+  built task directories without a `manifest.json` and so were dropped by the
+  stale-binding hardening (7.5.10) before role/scope resolution ran; their
+  helpers now write a non-terminal manifest as a real task dir always would
+  (`test_role_file_fallback`, `test_bash_destination_extraction`). The sixth
+  was a genuine model-literal lint violation: an escalation comment in
+  `hooks/lib_core.py` named vendor model tiers directly; it now uses the
+  cheap/mid/deep-tier vocabulary already used elsewhere in the file.
+
+---
+
 ## [7.5.10] - 2026-06-23
 ### Fixed
 - Terminal task transitions now clear per-session task bindings, so a completed

--- a/hooks/lib_core.py
+++ b/hooks/lib_core.py
@@ -704,11 +704,12 @@ def _check_ensemble_voting(
         # Acceptance rule: either every voting-model receipt found NOTHING
         # (zero findings, blocking or not), or an escalation receipt exists.
         # The cascade protocol escalates to the deep tier on ANY finding — a
-        # non-blocking nit at haiku still warrants opus confirmation — so the
-        # gate binds on finding_count, not just blocking_count. Keying the gate
-        # on blocking_count alone left a seam: an auditor with non-blocking
-        # haiku findings could be run at sonnet (or skip escalation entirely)
-        # and still pass, silently dropping the protocol-required opus shard.
+        # non-blocking nit at the cheap tier still warrants deep-tier
+        # confirmation — so the gate binds on finding_count, not just
+        # blocking_count. Keying the gate on blocking_count alone left a seam:
+        # an auditor with non-blocking cheap-tier findings could be run at the
+        # mid tier (or skip escalation entirely) and still pass, silently
+        # dropping the protocol-required deep-tier shard.
         all_voting_present = all(m in per_model for m in voting_models)
         if all_voting_present:
             all_clean = True

--- a/hooks/lib_dynos_root.py
+++ b/hooks/lib_dynos_root.py
@@ -1,0 +1,130 @@
+"""Shared project-root discrimination for `.dynos` ancestor walks.
+
+The directory name ``.dynos`` is overloaded: it names BOTH the framework home
+(``~/.dynos`` or ``$DYNOS_HOME``) and each project's control plane
+(``<repo>/.dynos``). Every governance decision resolves a "project root" by
+walking upward from the current path and stopping at the first ancestor that
+contains a ``.dynos`` directory.
+
+That bare-name match has two failure modes, both observed in the field:
+
+  1. The framework home itself. ``~/.dynos`` always exists, so a walk from any
+     folder under ``$HOME`` climbs to ``$HOME`` and treats the *entire home
+     directory* as one governed project — pulling every unrelated repo into
+     the write-boundary policy.
+
+  2. Stray / orphan control planes. A one-off session started directly in a
+     parent directory (e.g. ``~/code``) leaves a ``~/code/.dynos`` behind. That
+     orphan then captures every sibling repository beneath it.
+
+This module is the single discriminator all ancestor walks use so those two
+cases are rejected consistently. It depends only on the standard library — it
+must never import another hooks module, because it is imported by the
+lowest-level policy code (``write_policy``) and a cycle there would break the
+pre-tool-use hook.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+from pathlib import Path
+
+
+@functools.lru_cache(maxsize=1)
+def dynos_home() -> Path:
+    """Resolve the framework home (``$DYNOS_HOME`` or ``~/.dynos``).
+
+    Cached for the lifetime of the (short-lived) hook process; the environment
+    does not change mid-invocation.
+    """
+    raw = os.environ.get("DYNOS_HOME")
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:
+            pass
+    return (Path.home() / ".dynos").resolve()
+
+
+@functools.lru_cache(maxsize=1)
+def _registered_project_roots() -> frozenset[str] | None:
+    """Resolved path strings of every registered project root.
+
+    Returns ``None`` (not an empty set) when the registry cannot be read, so
+    callers can distinguish "no projects registered" from "registry unknown"
+    and fall back to on-disk evidence instead of silently de-governing.
+    """
+    try:
+        raw = (dynos_home() / "registry.json").read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except Exception:
+        return None
+    roots: set[str] = set()
+    try:
+        for entry in data.get("projects", []) or []:
+            for rec in entry.get("paths", []) or []:
+                path = rec.get("path")
+                if not path:
+                    continue
+                try:
+                    roots.add(str(Path(path).resolve()))
+                except Exception:
+                    continue
+    except Exception:
+        return None
+    return frozenset(roots)
+
+
+# Sub-directories that only appear once a project has done real dynos work.
+# A stray orphan `.dynos` left by a one-off session (its contents are limited
+# to orchestrator-session.json, dashboard*, routing-context.json, automation/)
+# has none of these, so it stays rejected; a legitimate project that predates
+# its registry entry is recognised by them.
+_PROJECT_STATE_DIRS = frozenset({"investigations"})
+
+
+def _has_project_state(dynos_dir: Path) -> bool:
+    """True when the control plane carries on-disk evidence of a real project:
+    a ``task-*`` directory or another recognised project-state directory."""
+    try:
+        for child in dynos_dir.iterdir():
+            name = child.name
+            if name.startswith("task-") and child.is_dir():
+                return True
+            if name in _PROJECT_STATE_DIRS and child.is_dir():
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def is_project_dynos_dir(dynos_dir: Path) -> bool:
+    """Return True iff ``dynos_dir`` legitimately governs its parent directory.
+
+    A ``.dynos`` directory governs its parent only when it is a real project
+    control plane — NOT the framework home, and NOT a stray orphan that would
+    otherwise capture unrelated sibling repositories.
+
+    A directory qualifies when it is not the framework home AND either:
+      * its parent is a registered project root (the authoritative signal), or
+      * it carries on-disk task state (the fallback used when the registry is
+        unreadable or a legitimate project predates its registration).
+
+    An orphan such as ``~/code/.dynos`` — unregistered and taskless — is
+    rejected, so it no longer hijacks the repositories beneath it.
+    """
+    try:
+        if not dynos_dir.is_dir():
+            return False
+        resolved = dynos_dir.resolve()
+    except Exception:
+        return False
+    # Hard exclusion: the framework home is never a project control plane.
+    if resolved == dynos_home():
+        return False
+    registered = _registered_project_roots()
+    if registered is not None and str(resolved.parent) in registered:
+        return True
+    return _has_project_state(resolved)

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -22,6 +22,27 @@ import shlex
 import sys
 from pathlib import Path
 
+# Shared discriminator that rejects the framework home (~/.dynos) and stray
+# orphan .dynos dirs when resolving a project root from an ancestor walk. The
+# `.dynos` name is overloaded (framework home vs. per-project control plane);
+# a bare `.dynos`.is_dir() match would treat $HOME — or any orphan .dynos high
+# in the tree — as a project root and govern unrelated repos. If the shared
+# module cannot be imported, fall back to excluding just the framework home,
+# which is the critical half of the guard.
+try:
+    from lib_dynos_root import is_project_dynos_dir as _is_project_dynos_dir
+except Exception:  # pragma: no cover - defensive import fallback
+    def _is_project_dynos_dir(dynos_dir: Path) -> bool:
+        try:
+            if not dynos_dir.is_dir():
+                return False
+            home = Path(
+                os.environ.get("DYNOS_HOME") or (Path.home() / ".dynos")
+            ).expanduser().resolve()
+            return dynos_dir.resolve() != home
+        except Exception:
+            return False
+
 # Allowlist of valid executor role names that may appear in active-segment-role.
 # Privileged internal roles (ctl, receipt-writer, eventbus, scheduler, system)
 # are intentionally excluded to prevent role-file injection attacks.
@@ -161,7 +182,7 @@ def _task_dir_from_ancestor_path(cwd: Path) -> Path | None:
 def _project_root_from_ancestors(cwd: Path) -> Path | None:
     current = cwd.resolve()
     for ancestor in [current, *current.parents]:
-        if (ancestor / ".dynos").is_dir():
+        if _is_project_dynos_dir(ancestor / ".dynos"):
             return ancestor
     return None
 
@@ -217,7 +238,7 @@ def _find_task_dir_from_ancestors(cwd: Path) -> Path | None:
     current = cwd.resolve()
     for ancestor in [current, *current.parents]:
         dynos = ancestor / ".dynos"
-        if dynos.is_dir():
+        if _is_project_dynos_dir(dynos):
             active_tasks = _active_tasks_from_manifests(dynos)
             pointer_path = dynos / "active-task.json"
             if pointer_path.exists():
@@ -920,7 +941,7 @@ def main() -> int:
                 dynos_root = task_dir.parent
             else:
                 for ancestor in [cwd, *cwd.parents]:
-                    if (ancestor / ".dynos").is_dir():
+                    if _is_project_dynos_dir(ancestor / ".dynos"):
                         dynos_root = ancestor / ".dynos"
                         break
             if dynos_root is not None:

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -349,10 +349,31 @@ def _self_modification_denial(attempt: WriteAttempt, path: Path) -> WriteDecisio
 
 
 def _nearest_project_root_from_cwd(cwd: Path) -> Path | None:
-    """Return nearest ancestor containing .dynos, or None if not in a project."""
+    """Return nearest ancestor governed by a project .dynos, or None.
+
+    The `.dynos` name is overloaded (framework home vs. per-project control
+    plane), so a bare-name match would treat `$HOME` — or a stray orphan
+    `.dynos` high in the tree — as a project root and pull unrelated repos into
+    governance. `is_project_dynos_dir` is the shared discriminator that rejects
+    those cases; on import failure fall back to excluding the framework home,
+    which is the critical part of the guard.
+    """
     resolved = cwd.resolve()
+    try:
+        from lib_dynos_root import is_project_dynos_dir  # noqa: PLC0415
+    except Exception:
+        _home = Path(
+            os.environ.get("DYNOS_HOME") or (Path.home() / ".dynos")
+        ).expanduser().resolve()
+
+        def is_project_dynos_dir(dynos_dir: Path) -> bool:
+            try:
+                return dynos_dir.is_dir() and dynos_dir.resolve() != _home
+            except Exception:
+                return False
+
     for candidate in (resolved, *resolved.parents):
-        if (candidate / ".dynos").is_dir():
+        if is_project_dynos_dir(candidate / ".dynos"):
             return candidate
     return None
 
@@ -404,9 +425,21 @@ def _project_scope_roots(attempt: WriteAttempt) -> tuple[Path, ...]:
 
 def _is_inside_project_scope(attempt: WriteAttempt, path: Path) -> bool:
     roots = _project_scope_roots(attempt)
-    if not roots:
-        return True
-    return any(path == root or _is_under(path, root) for root in roots)
+    if roots:
+        return any(path == root or _is_under(path, root) for root in roots)
+    # No project root resolved from the active task or the hook's cwd. Rather
+    # than govern-when-unsure (which treated every non-dynos folder — and, via
+    # the overloaded `.dynos` home, all of $HOME — as in-scope and produced
+    # spurious write denials), decide from the TARGET path itself: govern only
+    # when the write lands inside a real project control plane. A write to a
+    # location with no governing project .dynos ancestor is simply not ours to
+    # police. The self-modification guard and hook-owned control-plane checks
+    # in decide_write run *before* this gate, so they still apply regardless.
+    try:
+        target_parent = path.parent
+    except Exception:
+        return False
+    return _nearest_project_root_from_cwd(target_parent) is not None
 
 
 # Task-root files the orchestrator authors directly: logs, escalation notes,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/tests/test_bash_destination_extraction.py
+++ b/tests/test_bash_destination_extraction.py
@@ -136,6 +136,9 @@ def test_denial_message_names_guardrail_role_path_and_docs(
 ) -> None:
     task_dir = tmp_path / ".dynos" / "task-20260611-001"
     task_dir.mkdir(parents=True)
+    # Non-terminal manifest so pre_tool_use keeps the DYNOS_TASK_DIR binding
+    # (a manifest-less/terminal task dir is ignored as stale).
+    (task_dir / "manifest.json").write_text(json.dumps({"stage": "EXECUTION"}))
     monkeypatch.setenv("DYNOS_ROLE", "planning")
     monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
     payload = {
@@ -158,6 +161,10 @@ def test_wrapper_required_denial_names_sanctioned_command(
 ) -> None:
     task_dir = tmp_path / ".dynos" / "task-20260611-002"
     task_dir.mkdir(parents=True)
+    # Non-terminal manifest so the task_dir binding is honoured; otherwise the
+    # write resolves as a cross-task control-plane write, not a wrapper-required
+    # one, and the sanctioned-command hint is never surfaced.
+    (task_dir / "manifest.json").write_text(json.dumps({"stage": "EXECUTION"}))
     monkeypatch.setenv("DYNOS_ROLE", "planning")
     monkeypatch.setenv("DYNOS_TASK_DIR", str(task_dir))
     payload = {

--- a/tests/test_dynos_root_scope.py
+++ b/tests/test_dynos_root_scope.py
@@ -1,0 +1,166 @@
+"""Regression tests for project-root discrimination in `.dynos` ancestor walks.
+
+The `.dynos` directory name is overloaded: it is both the framework home
+(`~/.dynos` / `$DYNOS_HOME`) and each project's control plane
+(`<repo>/.dynos`). A bare `.dynos`.is_dir() match in the ancestor walk treated
+the framework home — and any stray orphan `.dynos` high in the tree — as a
+project root, pulling every unrelated repo under `$HOME` into governance and
+producing spurious write denials.
+
+These tests pin the fix: `is_project_dynos_dir` rejects the framework home and
+unregistered/taskless orphans, and `decide_write` no longer governs writes to a
+folder that is not a real dynos project.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+import lib_dynos_root  # noqa: E402
+import write_policy  # noqa: E402
+from write_policy import WriteAttempt, decide_write  # noqa: E402
+
+
+@pytest.fixture()
+def dynos_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point DYNOS_HOME at an isolated tmp home with an empty registry."""
+    home = tmp_path / "dynos-home"
+    home.mkdir()
+    (home / "registry.json").write_text(
+        json.dumps({"projects": []}), encoding="utf-8"
+    )
+    monkeypatch.setenv("DYNOS_HOME", str(home))
+    # lru_cache on the home/registry helpers must not leak across tests.
+    lib_dynos_root.dynos_home.cache_clear()
+    lib_dynos_root._registered_project_roots.cache_clear()
+    return home
+
+
+def _register(home: Path, project_root: Path) -> None:
+    reg = {
+        "projects": [
+            {
+                "id": "test-id",
+                "paths": [{"path": str(project_root.resolve())}],
+                "status": "active",
+            }
+        ]
+    }
+    (home / "registry.json").write_text(json.dumps(reg), encoding="utf-8")
+    lib_dynos_root._registered_project_roots.cache_clear()
+
+
+def _mk_dynos(root: Path, *, tasks: int = 0) -> Path:
+    dynos = root / ".dynos"
+    dynos.mkdir(parents=True)
+    for i in range(tasks):
+        (dynos / f"task-{i:03d}").mkdir()
+    return dynos
+
+
+# --- is_project_dynos_dir ---------------------------------------------------
+
+def test_framework_home_is_not_a_project_root(dynos_home: Path) -> None:
+    """`$DYNOS_HOME` itself must never be treated as a project control plane,
+    even if it somehow contains task-shaped directories."""
+    (dynos_home / "task-000").mkdir()  # would trip the task fallback if reached
+    assert lib_dynos_root.is_project_dynos_dir(dynos_home) is False
+
+
+def test_orphan_dynos_is_rejected(dynos_home: Path, tmp_path: Path) -> None:
+    """An unregistered, taskless `.dynos` (e.g. one left at ~/code by a one-off
+    session) must not govern its parent."""
+    orphan = _mk_dynos(tmp_path / "code")  # unregistered, no tasks
+    assert lib_dynos_root.is_project_dynos_dir(orphan) is False
+
+
+def test_registered_project_is_accepted(dynos_home: Path, tmp_path: Path) -> None:
+    project = tmp_path / "code" / "real-project"
+    dynos = _mk_dynos(project)  # no tasks yet
+    _register(dynos_home, project)
+    assert lib_dynos_root.is_project_dynos_dir(dynos) is True
+
+
+def test_taskful_unregistered_project_is_accepted(
+    dynos_home: Path, tmp_path: Path
+) -> None:
+    """Fallback: a legit project predating registration (or during a registry
+    read failure) is recognised by its on-disk task state."""
+    dynos = _mk_dynos(tmp_path / "code" / "legacy-project", tasks=1)
+    assert lib_dynos_root.is_project_dynos_dir(dynos) is True
+
+
+# --- _nearest_project_root_from_cwd -----------------------------------------
+
+def test_nearest_root_ignores_home_and_orphan(
+    dynos_home: Path, tmp_path: Path
+) -> None:
+    """A repo whose only `.dynos` ancestors are the framework home and an
+    orphan must resolve to no project root."""
+    _mk_dynos(tmp_path / "code")  # orphan at the parent level
+    repo = tmp_path / "code" / "unrelated-repo"
+    repo.mkdir()
+    assert write_policy._nearest_project_root_from_cwd(repo) is None
+
+
+def test_nearest_root_finds_registered_project(
+    dynos_home: Path, tmp_path: Path
+) -> None:
+    project = tmp_path / "code" / "real-project"
+    _mk_dynos(project)
+    _register(dynos_home, project)
+    sub = project / "src"
+    sub.mkdir()
+    assert write_policy._nearest_project_root_from_cwd(sub) == project.resolve()
+
+
+# --- decide_write end to end ------------------------------------------------
+
+def test_write_to_non_dynos_folder_is_not_governed(
+    dynos_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported bug: an orchestrator/reviewer writing a report into a
+    non-dynos repo was denied because the folder was wrongly governed. It must
+    now be allowed as out-of-scope."""
+    _mk_dynos(tmp_path / "code")  # orphan parent, as in the field report
+    repo = tmp_path / "code" / "env-reviewer"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    attempt = WriteAttempt(
+        role="orchestrator",
+        task_dir=None,
+        path=repo / "REPORT.md",
+        operation="create",
+        source="agent",
+    )
+    decision = decide_write(attempt)
+    assert decision.allowed is True
+    assert "not governed" in decision.reason
+
+
+def test_write_inside_registered_project_still_governed(
+    dynos_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Governance must still bite inside a real project: the orchestrator may
+    not write repo files directly (existing write-boundary behaviour)."""
+    project = tmp_path / "code" / "real-project"
+    _mk_dynos(project)
+    _register(dynos_home, project)
+    monkeypatch.chdir(project)
+    attempt = WriteAttempt(
+        role="orchestrator",
+        task_dir=None,
+        path=project / "src" / "foo.py",
+        operation="create",
+        source="agent",
+    )
+    decision = decide_write(attempt)
+    assert decision.allowed is False
+    assert "not governed" not in decision.reason

--- a/tests/test_role_file_fallback.py
+++ b/tests/test_role_file_fallback.py
@@ -95,12 +95,21 @@ def _invoke_resolve_role(
 
 
 def _make_task_dir(tmp_path: Path, task_id: str = "task-20260423-RF1") -> tuple[Path, Path]:
-    """Create (root, task_dir) with minimal structure."""
+    """Create (root, task_dir) with minimal structure.
+
+    A non-terminal manifest.json is required: pre_tool_use ignores a
+    DYNOS_TASK_DIR whose manifest is missing or terminal (stale-binding
+    hardening), which would otherwise drop the task_dir and short-circuit role
+    resolution before the active-segment-role fallthrough under test.
+    """
     root = tmp_path / "project"
     root.mkdir(exist_ok=True)
     (root / ".dynos").mkdir(exist_ok=True)
     task_dir = root / ".dynos" / task_id
     task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "manifest.json").write_text(
+        json.dumps({"stage": "EXECUTION"}), encoding="utf-8"
+    )
     return root, task_dir
 
 


### PR DESCRIPTION
## Summary

The `.dynos` directory name is **overloaded** — it is both the framework home (`~/.dynos` / `$DYNOS_HOME`) and each project's control plane (`<repo>/.dynos`). Every ancestor walk that resolved a "project root" matched the bare name, so:

- `~/.dynos` made **all of `$HOME`** resolve as one giant governed project, and
- any **stray orphan `.dynos`** high in the tree (e.g. one left at `~/code` by a one-off session) captured every repo beneath it.

The result was spurious write-policy denials in folders that are not dynos projects — the guardrail firing in unrelated repos and being misattributed to the "self-modification defense."

## The fix

- **`hooks/lib_dynos_root.py`** (new, stdlib-only): a single discriminator `is_project_dynos_dir()` that rejects the framework home outright and requires a candidate `.dynos` to be a **registered project root** — or to carry on-disk project state (`task-*` or `investigations/`) — before it can govern its parent.
- **`hooks/write_policy.py`**: `_nearest_project_root_from_cwd` uses the discriminator; the out-of-scope write path now decides from the **target location** instead of governing-when-unsure (`if not roots: return True`).
- **`hooks/pre_tool_use.py`**: all three ancestor-walk sites (project-root, task-dir, investigator dossier lookup) use the discriminator, with a safe inline fallback if the shared module can't import.
- **`tests/test_dynos_root_scope.py`** (new, 8 tests): framework-home rejection, orphan rejection, registered/taskful acceptance, and the end-to-end reported bug.

Verified against the real environment: non-dynos folders under `$HOME` now resolve to no project root (no hijack); real registered projects still resolve correctly.

## Also: greened six pre-existing red tests on `main`

Confirmed pre-existing (fail on a clean baseline), all maintenance issues rather than product bugs:

- **Five stale fixtures** built task dirs without a `manifest.json` and were dropped by the 7.5.10 stale-binding hardening *before* role/scope resolution ran. Their helpers now write a non-terminal manifest, as a real task dir always has (`test_role_file_fallback`, `test_bash_destination_extraction`).
- **One genuine model-literal lint violation**: an escalation comment in `hooks/lib_core.py` named vendor model tiers directly; reworded to the cheap/mid/deep-tier vocabulary already used in the file.

## Release

Version bumped `7.5.10 → 7.5.11` across all four manifests; `CHANGELOG.md` updated.

## Testing

Full suite: **2896 passed, 9 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)