### PR TITLE
Segment continuation loop + resumable-ledger executor prompt (7.5.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.11",
+      "version": "7.5.12",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.11",
+  "version": "7.5.12",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.11",
+  "version": "7.5.12",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.12] - 2026-07-15
+### Added
+- Segment continuation loop so execution finishes the work instead of stalling
+  when an executor runs out of turns mid-segment. New `ctl next-continuation`
+  reports every incomplete segment (reusing the finish gate's own authority:
+  pending segments + evidence/`files_expected` verification) together with a
+  resume seed — role, model, `files_expected`, `criteria_ids`, and the exact
+  `incomplete_reasons` — so a continuation executor picks up the partial work on
+  disk rather than cold-restarting. The execute skill now loops on it until
+  `complete`; budget is never the stop condition. The only automatic halt is a
+  genuine stall — two consecutive continuations that move nothing (no cleared
+  reason, no evidence growth, no new `files_expected` on disk) — reported as
+  status `stalled` (exit 3) for escalation instead of spinning forever.
+  `continuation-state.json` (stall fingerprints/attempt counts) is ctl-owned and
+  denied to agent roles in the write policy. Adds `tests/test_next_continuation.py`.
+
+---
+
 ## [7.5.11] - 2026-07-15
 ### Fixed
 - Project-root detection no longer treats the framework home (`~/.dynos` /

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -5298,6 +5298,188 @@ def cmd_run_execution_verify_evidence(args: argparse.Namespace) -> int:
         return 1
 
 
+# Continuation loop (segment-completion-first). When an executor exits without
+# finishing its segment — the classic "ran out of turns mid-edit, never wrote
+# evidence" failure — the segment is not abandoned. next-continuation reports
+# the incomplete segments with enough context to re-spawn an executor that
+# resumes exactly where the dead one stopped, and it loops until the segment is
+# actually complete. Budget is deliberately NOT a stop condition; the only
+# automatic halt is genuine stall (two consecutive continuations that move
+# nothing), surfaced so the orchestrator can escalate instead of spinning.
+_CONTINUATION_STATE_FILE = "continuation-state.json"
+_CONTINUATION_STALL_LIMIT = 2  # consecutive no-progress continuations => stalled
+
+
+def _segment_incompleteness(task_dir: Path) -> tuple[dict[str, list[str]], dict]:
+    """Return ({seg_id: [reasons]}, batch_payload) for every incomplete segment.
+
+    Authority is identical to the finish gate: a segment is incomplete if it is
+    still pending (no completion receipt) OR it fails evidence verification
+    (missing/empty evidence, files_expected absent on disk, verify_commands not
+    passing). Reusing _compute_execution_batch_payload + _verify_execution_evidence
+    keeps "incomplete" defined in exactly one place.
+    """
+    batch_payload = _compute_execution_batch_payload(
+        task_dir, expected_stages=frozenset({"EXECUTION", "TEST_EXECUTION"})
+    )
+    incomplete: dict[str, list[str]] = {}
+    for seg_id in batch_payload.get("pending_segments", []):
+        incomplete.setdefault(str(seg_id), []).append(
+            "segment pending: no completion receipt (executor did not finish)"
+        )
+    cached_ids = set(batch_payload.get("cached_segments", []))
+    errors, _verified = _verify_execution_evidence(task_dir, cached_ids)
+    for err in errors:
+        seg_id, sep, reason = err.partition(":")
+        seg_id = seg_id.strip()
+        if seg_id:
+            incomplete.setdefault(seg_id, []).append(reason.strip() if sep else err)
+    return incomplete, batch_payload
+
+
+def _continuation_fingerprint(
+    task_dir: Path, root: Path, seg_id: str, reasons: list[str], files_expected: list[str]
+) -> str:
+    """Cheap progress fingerprint for a segment. It changes whenever real
+    progress is made — a reason clears, the evidence file grows, or a
+    files_expected entry newly appears on disk — so an unchanged fingerprint
+    across calls means the last continuation moved nothing, the signal we treat
+    as a stall. Counting on-disk files (not just evidence) matters: an executor
+    that created files but died before writing evidence IS making progress and
+    must not be flagged as stalled."""
+    import hashlib  # noqa: PLC0415
+
+    evidence_path = task_dir / "evidence" / f"{seg_id}.md"
+    try:
+        ev_size = evidence_path.stat().st_size if evidence_path.exists() else -1
+    except OSError:
+        ev_size = -1
+    file_bits = []
+    for entry in sorted(files_expected):
+        try:
+            exists = (root / entry).exists() or bool(next(iter(root.glob(entry)), None))
+        except (ValueError, NotImplementedError, OSError):
+            exists = (root / entry).exists()
+        file_bits.append(f"{entry}={int(exists)}")
+    material = (
+        "\n".join(sorted(reasons))
+        + f"|evidence_bytes={ev_size}"
+        + "|files=" + ",".join(file_bits)
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def compute_continuation_status(task_dir: Path) -> dict:
+    """Report incomplete segments + per-segment continuation seed, updating the
+    stall-tracking state file. Does NOT transition stages or spawn anything —
+    it is the deterministic input to the orchestrator's continuation loop."""
+    incomplete, batch_payload = _segment_incompleteness(task_dir)
+    graph_by_id = {str(seg.get("id")): seg for seg in _load_graph_segments(task_dir)}
+    routing_by_id = {
+        str(entry.get("segment_id")): entry
+        for entry in _load_routing_segments(task_dir)
+        if isinstance(entry.get("segment_id"), str)
+    }
+
+    state_path = task_dir / _CONTINUATION_STATE_FILE
+    prev_state = load_json(state_path) if state_path.exists() else {}
+    prev_segments = prev_state.get("segments", {}) if isinstance(prev_state, dict) else {}
+    new_segments: dict[str, dict] = {}
+
+    segments_out: list[dict] = []
+    stalled: list[str] = []
+    for seg_id, reasons in sorted(incomplete.items()):
+        graph_seg = graph_by_id.get(seg_id, {})
+        routing = routing_by_id.get(seg_id, {})
+        seg_files = [
+            f for f in (graph_seg.get("files_expected") or []) if isinstance(f, str) and f
+        ]
+        fingerprint = _continuation_fingerprint(
+            task_dir, _root_for_task_dir(task_dir), seg_id, reasons, seg_files
+        )
+        prev = prev_segments.get(seg_id, {}) if isinstance(prev_segments, dict) else {}
+        attempt = int(prev.get("attempt", 0)) + 1
+        if prev.get("fingerprint") == fingerprint:
+            stall_count = int(prev.get("stall_count", 0)) + 1
+        else:
+            stall_count = 0
+        new_segments[seg_id] = {
+            "fingerprint": fingerprint,
+            "attempt": attempt,
+            "stall_count": stall_count,
+        }
+        is_stalled = stall_count >= _CONTINUATION_STALL_LIMIT
+        if is_stalled:
+            stalled.append(seg_id)
+        evidence_path = task_dir / "evidence" / f"{seg_id}.md"
+        segments_out.append({
+            "segment_id": seg_id,
+            "role": routing.get("executor") or graph_seg.get("executor"),
+            "model": routing.get("model"),
+            "files_expected": seg_files,
+            # criteria_ids may be ints or strings depending on the planner;
+            # carry them verbatim so the orchestrator can resolve their text
+            # from spec.md the same way it does for a normal spawn.
+            "criteria_ids": list(graph_seg.get("criteria_ids") or []),
+            "depends_on": [
+                d for d in (graph_seg.get("depends_on") or []) if isinstance(d, str) and d
+            ],
+            "incomplete_reasons": reasons,
+            "evidence_path": str(evidence_path.relative_to(_root_for_task_dir(task_dir)))
+            if evidence_path.exists() else str(evidence_path),
+            "evidence_present": evidence_path.exists(),
+            "continuation_attempt": attempt,
+            "stall_count": stall_count,
+            "stalled": is_stalled,
+        })
+
+    write_json(state_path, {"segments": new_segments})
+
+    if not incomplete:
+        status = "complete"
+    elif stalled and len(stalled) == len(segments_out):
+        # Every remaining incomplete segment is stalled: no forward progress is
+        # possible, so this is the hard-error halt (never a budget-count halt).
+        status = "stalled"
+    else:
+        status = "continuation_needed"
+
+    completed = list(batch_payload.get("completed_segments", []))
+    completed += list(batch_payload.get("cached_segments", []))
+    return {
+        "status": status,
+        "task_dir": str(task_dir),
+        "incomplete_segments": segments_out,
+        "stalled_segments": stalled,
+        "complete_segments": sorted(completed),
+    }
+
+
+def cmd_next_continuation(args: argparse.Namespace) -> int:
+    """Emit the continuation plan for a task's incomplete execution segments.
+
+    Exit codes:
+        0 — status "complete": every segment is done, proceed to the finish gate.
+        0 — status "continuation_needed": at least one segment can still make
+            progress; the printed incomplete_segments are the continuation seeds.
+        3 — status "stalled": every incomplete segment moved nothing across the
+            last two continuations; the orchestrator must escalate, not re-spawn.
+        1 — internal error.
+    """
+    task_dir = Path(args.task_dir).resolve()
+    root = _root_for_task_dir(task_dir)
+    blocked = _refuse_if_rules_corrupt(root)
+    if blocked is not None:
+        return blocked
+    try:
+        result = compute_continuation_status(task_dir)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 3 if result["status"] == "stalled" else 0
+
+
 def cmd_run_verification_evidence(args: argparse.Namespace) -> int:
     """Execute plan-declared verify_commands and capture machine evidence (D6).
 
@@ -6906,6 +7088,14 @@ def register_execution_parsers(subparsers: argparse._SubParsersAction) -> None:
     )
     run_execution_verify_evidence_parser.add_argument("task_dir")
     run_execution_verify_evidence_parser.set_defaults(func=cmd_run_execution_verify_evidence)
+
+    next_continuation_parser = subparsers.add_parser(
+        "next-continuation",
+        help="Report incomplete execution segments + continuation seeds so a "
+             "stalled/timed-out executor's segment can be resumed to completion",
+    )
+    next_continuation_parser.add_argument("task_dir")
+    next_continuation_parser.set_defaults(func=cmd_next_continuation)
 
     run_verification_parser = subparsers.add_parser(
         "run-verification-evidence",

--- a/hooks/router.py
+++ b/hooks/router.py
@@ -1366,19 +1366,27 @@ def build_executor_prompt(
     # exact same budget that the executor-plan record committed to.
     tool_budget = plan_entry.get("tool_budget")
     if tool_budget is not None:
+        seg_id = str(segment.get("id", "") or "")
+        evidence_target = f"evidence/{seg_id}.md" if seg_id else "your evidence file"
+        expected_artifact = segment.get("expected_artifact") or plan_entry.get("expected_artifact")
+        ledger_target = expected_artifact or evidence_target
+        # The tool_budget is shown for scoping, but it is deliberately NOT a
+        # cutoff: finishing the segment is the priority. Instead of pacing the
+        # executor to stop at a budget checkpoint (which left segments abandoned
+        # mid-edit with no evidence), the block asks for a resumable progress
+        # ledger so a continuation executor can pick the work up where an
+        # interrupted one stopped. See `ctl next-continuation`.
         parts.append(
             f"\n\n## Tool-Use Budget\n"
-            f"Your tool-use budget for this spawn is **{tool_budget}** tool calls. "
-            f"Stop and emit evidence within 3 calls of that budget."
+            f"The ~{tool_budget}-tool-call figure for this spawn is an ESTIMATE for "
+            f"scoping — NOT a cap. Finishing the segment is the priority: do not stop "
+            f"early or leave work half-done to stay under it.\n"
+            f"Keep your work resumable in case you are interrupted before finishing. "
+            f"Write {ledger_target} EARLY and update it incrementally with a progress "
+            f"ledger (done / in-flight / next). Work not written to disk does not exist — "
+            f"if you stop, a continuation executor resumes from exactly what is on disk "
+            f"and from your ledger, so keep the remaining work recorded there."
         )
-        expected_artifact = segment.get("expected_artifact") or plan_entry.get("expected_artifact")
-        if expected_artifact:
-            checkpoint_call = math.ceil(tool_budget / 3)
-            parts.append(
-                f"Budget {tool_budget}. Your artifact at {expected_artifact} must hold real content "
-                f"and a progress ledger (done / in-flight / next) by tool call {checkpoint_call}; "
-                f"update it incrementally — work not on disk does not exist."
-            )
 
     return "\n".join(parts)
 

--- a/hooks/write_policy.py
+++ b/hooks/write_policy.py
@@ -91,6 +91,7 @@ _CONTROL_PLANE_EXACT = frozenset({
     "role-grants.json",
     "role-bindings.json",
     "tool-call-counters.json",
+    "continuation-state.json",
 })
 
 _WRAPPER_REQUIRED = {
@@ -655,6 +656,20 @@ def decide_write(attempt: WriteAttempt) -> WriteDecision:
             False,
             "tool-call-counters.json is hook-owned telemetry; only the "
             "hook subprocess may write it",
+            "deny",
+        )
+
+    if rel_posix == "continuation-state.json":
+        # continuation-state.json is ctl-owned state for the segment
+        # continuation loop (stall fingerprints + attempt counts). ctl writes
+        # it via direct file I/O in a subprocess, bypassing this policy. If an
+        # agent role could write it, an executor could forge a stall (forcing a
+        # premature escalation) or reset stall counts (spinning the loop
+        # forever). All agent roles are denied.
+        return WriteDecision(
+            False,
+            "continuation-state.json is ctl-owned continuation-loop state; "
+            "only the ctl subprocess may write it",
             "deny",
         )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.11",
+  "version": "7.5.12",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -319,13 +319,32 @@ After each batch (or cached resolution) completes, record events and verify:
 
 **Test execution** (Step 4): Record test runner events with `--phase execution --stage TEST_EXECUTION`.
 
-When `run-execution-batch-plan` reports no pending segments, advance through ctl:
+**Segment continuation loop (finish the work — budget is NOT a stop condition).**
+
+An executor can exit before finishing its segment — most often it ran out of turns mid-edit and never wrote `evidence/{seg-id}.md`, leaving partial edits applied on disk (e.g. `app.js` now references a module it never imported). Do NOT abandon the segment, and do NOT cold-restart it blind. When `run-execution-batch-plan` reports no pending segments, run the continuation loop to drive every incomplete segment to completion:
+
+```bash
+"$DYNOS" ctl next-continuation .dynos/task-{id}
+```
+
+Parse the JSON `status`:
+
+- **`complete`** — every segment is done. Proceed to `run-execution-finish` below.
+- **`continuation_needed`** — for each entry in `incomplete_segments` whose `stalled` is `false`, spawn ONE continuation executor of the entry's `role` (pass its `model` as the model parameter), built exactly like a normal executor spawn (the Step 3 spawn block: the segment object, the criteria text extracted from `spec.md` by `criteria_ids`, dependency evidence, and `build_prompt_context` for `files_expected`) PLUS this continuation preamble:
+  - "This segment was already partially executed; the prior edits are applied on disk. Do NOT redo completed work — finish ONLY what remains."
+  - the entry's `incomplete_reasons`, verbatim, as the remaining checklist.
+  - "Write `evidence/{seg-id}.md` before you run low on turns."
+
+  After each continuation executor returns, run `run-execution-segment-done` for that segment (the same authoritative completion gate the normal batch loop uses — it writes the receipt and verifies ownership + evidence; a segment is not "complete" until that receipt exists). Then **re-run `next-continuation` and repeat.** There is no spawn-count cap in this loop — keep going as long as segments make progress. Do NOT run `check-spawn-budget` for continuation spawns; the spawn-budget backstop is for audit thrash, not for finishing execution.
+- **`stalled`** (exit code 3) — every remaining incomplete segment moved nothing across two consecutive continuations; `stalled_segments` names them. This is the ONLY automatic halt. Write `escalation.md` with `stalled_segments` and their `incomplete_reasons`, append a `[CONTINUATION-STALLED]` line to `execution-log.md`, and stop: the orchestrator cannot make progress and a human must intervene. Do NOT keep re-spawning.
+
+Only once `next-continuation` reports `complete` do you advance the stage:
 
 ```bash
 "$DYNOS" ctl run-execution-finish .dynos/task-{id}
 ```
 
-This command refuses the transition if any segment is still pending, AND it runs the full evidence verification (non-empty `evidence/{seg-id}.md` per segment, every `files_expected` entry on disk) inside the stage gate before advancing to `TEST_EXECUTION`. If it reports `"status": "blocked"` with `failures`, address each listed failure and re-run. Do not manually decide that execution is complete.
+This command refuses the transition if any segment is still pending, AND it runs the full evidence verification (non-empty `evidence/{seg-id}.md` per segment, every `files_expected` entry on disk) inside the stage gate before advancing to `TEST_EXECUTION`. It should pass now that the continuation loop reported `complete`; if it still reports `"status": "blocked"`, re-run `next-continuation` (state changed under it) and resolve what it surfaces. Do not manually decide that execution is complete.
 
 ### Step 4 — Run tests
 

--- a/tests/test_next_continuation.py
+++ b/tests/test_next_continuation.py
@@ -1,0 +1,171 @@
+"""Tests for `ctl next-continuation` — the segment-completion continuation loop.
+
+When an executor exits without finishing its segment (the "ran out of turns
+mid-edit, never wrote evidence" failure), the segment must not be abandoned.
+next-continuation reports the incomplete segments with a resume seed and loops
+until the work is actually done; budget is never the stop condition. The only
+automatic halt is genuine stall (two consecutive continuations that move
+nothing), reported as status "stalled" with exit code 3.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+
+from test_ctl import _run_ctl, _setup_task_dir  # noqa: E402
+
+
+def _seed_execution(task_dir: Path) -> None:
+    """Bring a fresh task dir to EXECUTION with routing in place."""
+    from lib_receipts import receipt_executor_routing, receipt_plan_validated
+
+    manifest_path = task_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["stage"] = "EXECUTION"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    os.environ["DYNOS_ALLOW_TEST_OVERRIDE"] = "1"
+    try:
+        receipt_plan_validated(task_dir, validation_passed_override=True)
+    finally:
+        os.environ.pop("DYNOS_ALLOW_TEST_OVERRIDE", None)
+
+    receipt_executor_routing(task_dir, [
+        {"segment_id": "seg-1", "executor": "backend-executor", "model": "sonnet",
+         "route_mode": "generic", "agent_path": None},
+        {"segment_id": "seg-2", "executor": "testing-executor", "model": "sonnet",
+         "route_mode": "generic", "agent_path": None},
+    ])
+
+
+def _complete_segment(task_dir: Path, seg_id: str, executor: str, rel_file: str) -> None:
+    """Fully finish a segment: files_expected on disk, evidence, done-receipt."""
+    from lib_receipts import receipt_executor_done
+
+    root = task_dir.parent.parent
+    target = root / rel_file
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# produced by execution\n")
+
+    evidence_dir = task_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    evidence_path = evidence_dir / f"{seg_id}.md"
+    evidence_path.write_text(f"{seg_id} evidence\n")
+
+    sidecar_dir = task_dir / "receipts" / "_injected-prompts"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    digest = ("f" if seg_id == "seg-1" else "a") * 64
+    (sidecar_dir / f"{seg_id}.sha256").write_text(digest)
+    receipt_executor_done(
+        task_dir,
+        segment_id=seg_id,
+        executor_type=executor,
+        model_used="sonnet",
+        injected_prompt_sha256=digest,
+        agent_name=None,
+        evidence_path=str(evidence_path),
+        tokens_used=5,
+        diff_verified_files=[],
+        no_op_justified=False,
+    )
+
+
+def test_incomplete_segment_reported_with_resume_seed(tmp_path: Path) -> None:
+    """seg-1 finished, seg-2 never executed → seg-2 is reported as a
+    continuation with role/model/files/criteria and its incomplete reason."""
+    task_dir = _setup_task_dir(tmp_path)
+    _seed_execution(task_dir)
+    _complete_segment(task_dir, "seg-1", "backend-executor", "src/a.py")
+
+    result = _run_ctl("next-continuation", str(task_dir))
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+
+    assert payload["status"] == "continuation_needed"
+    assert payload["complete_segments"] == ["seg-1"]
+    segs = payload["incomplete_segments"]
+    assert [s["segment_id"] for s in segs] == ["seg-2"]
+    seg2 = segs[0]
+    assert seg2["role"] == "testing-executor"
+    assert seg2["model"] == "sonnet"
+    assert seg2["files_expected"] == ["tests/test_a.py"]
+    assert seg2["criteria_ids"] == [2]
+    assert seg2["depends_on"] == ["seg-1"]
+    assert seg2["evidence_present"] is False
+    assert seg2["incomplete_reasons"]  # non-empty
+    assert seg2["stall_count"] == 0
+    assert seg2["stalled"] is False
+
+
+def test_completing_the_segment_reports_complete(tmp_path: Path) -> None:
+    """Once the continuation finishes seg-2, the loop terminates (complete)."""
+    task_dir = _setup_task_dir(tmp_path)
+    _seed_execution(task_dir)
+    _complete_segment(task_dir, "seg-1", "backend-executor", "src/a.py")
+
+    first = json.loads(_run_ctl("next-continuation", str(task_dir)).stdout)
+    assert first["status"] == "continuation_needed"
+
+    _complete_segment(task_dir, "seg-2", "testing-executor", "tests/test_a.py")
+
+    result = _run_ctl("next-continuation", str(task_dir))
+    assert result.returncode == 0, result.stdout + result.stderr
+    done = json.loads(result.stdout)
+    assert done["status"] == "complete"
+    assert done["incomplete_segments"] == []
+    assert set(done["complete_segments"]) == {"seg-1", "seg-2"}
+
+
+def test_no_progress_across_calls_stalls_with_exit_3(tmp_path: Path) -> None:
+    """Repeated continuations that move nothing eventually report 'stalled'
+    (exit 3) instead of spinning forever — the only automatic halt."""
+    task_dir = _setup_task_dir(tmp_path)
+    _seed_execution(task_dir)
+    _complete_segment(task_dir, "seg-1", "backend-executor", "src/a.py")
+
+    # seg-2 stays untouched across calls: nothing changes between them.
+    r1 = _run_ctl("next-continuation", str(task_dir))
+    assert r1.returncode == 0
+    assert json.loads(r1.stdout)["incomplete_segments"][0]["stall_count"] == 0
+
+    r2 = _run_ctl("next-continuation", str(task_dir))
+    assert r2.returncode == 0
+    assert json.loads(r2.stdout)["incomplete_segments"][0]["stall_count"] == 1
+
+    r3 = _run_ctl("next-continuation", str(task_dir))
+    assert r3.returncode == 3, r3.stdout + r3.stderr
+    payload = json.loads(r3.stdout)
+    assert payload["status"] == "stalled"
+    assert payload["stalled_segments"] == ["seg-2"]
+
+
+def test_progress_resets_the_stall_counter(tmp_path: Path) -> None:
+    """A continuation that grows evidence (partial progress) resets the stall
+    counter, so a segment making headway is never wrongly halted."""
+    task_dir = _setup_task_dir(tmp_path)
+    _seed_execution(task_dir)
+    _complete_segment(task_dir, "seg-1", "backend-executor", "src/a.py")
+
+    _run_ctl("next-continuation", str(task_dir))              # stall 0
+    r2 = _run_ctl("next-continuation", str(task_dir))         # stall 1
+    assert json.loads(r2.stdout)["incomplete_segments"][0]["stall_count"] == 1
+
+    # Partial progress: the continuation created a files_expected file but died
+    # before writing evidence, so the segment is still incomplete (pending) —
+    # yet real work happened and the stall counter must reset.
+    root = task_dir.parent.parent
+    (root / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "tests" / "test_a.py").write_text("# partial work by continuation\n")
+
+    r3 = _run_ctl("next-continuation", str(task_dir))
+    assert r3.returncode == 0
+    seg2 = json.loads(r3.stdout)["incomplete_segments"][0]
+    assert seg2["segment_id"] == "seg-2"
+    assert seg2["stall_count"] == 0

--- a/tests/test_router_emits_tool_budget.py
+++ b/tests/test_router_emits_tool_budget.py
@@ -257,7 +257,8 @@ def test_build_executor_prompt_contains_numeric_budget_value(dynos_home):
 
 
 def test_build_executor_prompt_budget_self_pacing_instruction(dynos_home):
-    """The prompt must include the self-pacing instruction mentioning 3 calls."""
+    """The budget block must frame the figure as guidance (not a cap) and ask
+    for a resumable progress ledger rather than a stop-at-N-calls cutoff."""
     import router as router_mod
 
     plan_entry = {
@@ -276,9 +277,14 @@ def test_build_executor_prompt_budget_self_pacing_instruction(dynos_home):
     }
     segment = {"id": "s1", "executor": "backend-executor", "files_expected": []}
     prompt = router_mod.build_executor_prompt(dynos_home.root, segment, plan_entry, "x")
-    # Spec AC-7: "Stop and emit evidence within 3 calls of that budget."
-    assert "3" in prompt, "self-pacing instruction '3 calls' not found in prompt"
+    # PR2 (7.5.12): the budget is guidance, not a cutoff — the block reframes
+    # from "stop within 3 calls" to a resumable progress ledger so an
+    # interrupted segment can be continued rather than abandoned.
     assert "budget" in prompt.lower(), "word 'budget' not found in prompt"
+    lowered = prompt.lower()
+    assert "not a cap" in lowered, "budget must be framed as an estimate, not a cap"
+    assert "resumable" in lowered, "resumability guidance missing from budget block"
+    assert "progress ledger" in lowered, "progress-ledger instruction missing from budget block"
 
 
 def test_build_executor_prompt_reads_budget_from_plan_entry_not_recomputed(dynos_home):


### PR DESCRIPTION
## Why

Executors were dying mid-segment (ran out of turns while editing, never wrote evidence), leaving partial edits on disk (e.g. `app.js` referencing a module it never imported) and a blocked task that needed a human. The priority is **finishing the work; budget is not the constraint.** This PR makes execution drive every segment to completion instead of abandoning it.

## PR 1 — Segment continuation loop

- **`ctl next-continuation <task>`** reports every incomplete segment using the finish gate's *own* authority (`_compute_execution_batch_payload` pending + `_verify_execution_evidence`), so "incomplete" is defined in exactly one place. Each incomplete segment carries a **resume seed**: `role`, `model`, `files_expected`, `criteria_ids`, `depends_on`, and the exact `incomplete_reasons`.
- **The execute skill loops** on it: for each non-stalled incomplete segment, spawn a continuation built like a normal executor spawn + a preamble ("prior edits are applied; finish only what remains; here's the checklist"), run `run-execution-segment-done`, re-run `next-continuation`. **No spawn-count cap; `check-spawn-budget` is skipped** for continuations.
- **Only automatic halt is genuine stall**: two consecutive continuations that move nothing (no cleared reason, no evidence growth, no new `files_expected` on disk) → status `stalled`, exit 3 → escalate. The fingerprint counts on-disk files, so an executor that created files but died before evidence is seen as *progressing*, not stalled.
- **`continuation-state.json`** (stall fingerprints/attempts) is ctl-written via subprocess I/O and denied to agent roles in the write policy.

## PR 2 — Resumable-ledger executor prompt

- The `## Tool-Use Budget` block is reframed from a *stop-at-N-calls cutoff* into an **estimate-not-a-cap** plus a **resumable progress ledger** (done / in-flight / next) written early and updated incrementally — so a continuation resumes precisely rather than re-deriving. Budget stays advisory.

## Deferred: PR 3

Re-basing the spawn-budget backstop off clean-audit counting (`compute_spawn_budget_status`) is intentionally **not** in this PR. It redefines a learned metric (`wasted_spawns`) that feeds the policy-threshold engine, circuit breaker, and DORA/reward/learning KPIs — a subsystem re-base that needs its own design and test migration, not a batch commit.

## Testing

`tests/test_next_continuation.py` (4 tests: incomplete detection + resume seed, completion, stall→exit 3, progress resets stall). Updated the tool-budget prompt test for the reframed block. Full suite: **2900 passed, 9 skipped, 0 failed.** Version → `7.5.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)