### PR TITLE
Re-base spawn-budget backstop off clean-audit counting (7.5.13)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.12",
+      "version": "7.5.13",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.12",
+  "version": "7.5.13",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.12",
+  "version": "7.5.13",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
+## [7.5.13] - 2026-07-15
+### Changed
+- Re-based the spawn-budget backstop off clean-audit counting. "Wasted spawns"
+  previously meant *empty-findings audit reports* — a clean audit is a passing
+  dimension, so with a default threshold of 2 any healthy task whose dimensions
+  passed would trip a hard pause requiring a human `spawn-resume`. The signal is
+  now **repair non-convergence**: distinct findings the repair loop keeps
+  re-flagging (max `retry_count >= 2` in `repair-log.json`), computed once in
+  `lib_validate.count_nonconverging_repairs` and used by both the runtime pause
+  (`compute_spawn_budget_status`) and the retrospective. The obsolete
+  ensemble-dedup and exempt-auditor machinery that only existed to soften the
+  clean-audit count is removed. `circuit_breaker.WASTED_SPAWN_ABORT_THRESHOLD`
+  (9) is unchanged in value; it now counts non-converging repairs.
+- Cold-started the learned thresholds: retrospectives carry
+  `wasted_spawns_signal_version = 2`, `policy_engine` aggregates only current-
+  version observations (pre-migration clean-audit counts are skipped) and stamps
+  the policy `version: 2`, and `compute_spawn_budget_status` honors learned
+  per-task-class thresholds only under a v2+ policy — falling back to
+  `global_fallback` until the new signal re-learns. Design:
+  `docs/spawn-budget-convergence-design.md`.
+
+---
+
 ## [7.5.12] - 2026-07-15
 ### Added
 - Segment continuation loop so execution finishes the work instead of stalling

--- a/docs/spawn-budget-convergence-design.md
+++ b/docs/spawn-budget-convergence-design.md
@@ -1,0 +1,66 @@
+# Spawn-budget backstop: re-base off clean-audit counting (PR 3)
+
+## Problem
+
+The spawn-budget backstop pauses a task when its "wasted spawn" count crosses a
+learned threshold. "Wasted" was defined as an **audit report with empty
+findings** — a *clean* audit (`compute_spawn_budget_status` in `hooks/ctl.py`
+and the retrospective builder in `hooks/lib_validate.py` both used
+`len(findings) == 0`). That is inverted: a clean audit is a **passing
+dimension**, the goal — not waste. With a default threshold of 2, any healthy
+task whose two-plus audit dimensions pass cleanly marched toward a hard pause
+(`wasted_spawns_exceeded`) that halted the task and required a human
+`ctl spawn-resume`. Priority is finishing the work; the backstop must fire only
+on **genuine non-convergence**, never on clean passes.
+
+## New signal: repair non-convergence
+
+A repair *converges* when the fix sticks. `repair-log.json` already tracks a
+per-finding `retry_count`, and `retry_count >= 2` already triggers deep-tier
+escalation (build-repair-log). We reuse that as the backstop signal:
+
+    wasted_spawns := count of distinct findings whose max retry_count >= 2
+
+i.e. findings that were repaired and re-flagged repeatedly — the repair loop
+churning without resolving them. A task that never needed repair, or whose
+repairs stuck, scores 0. Implemented once as
+`lib_validate.count_nonconverging_repairs(task_dir)` and used by **both** the
+runtime pause decision and the retrospective, so the signal has a single
+definition.
+
+## What this removes
+
+The ensemble-cascade dedup and `exempt_auditors` logic in
+`compute_spawn_budget_status` existed **only** to soften the clean-audit count
+(dedup ensemble tiers so one auditor isn't counted N times; exempt auditors
+with long zero-finding streaks). Under the repair-convergence signal they are
+obsolete and are removed. `auditor_zero_finding_streaks` stays in the
+retrospective (other consumers use it) but no longer feeds a spawn-budget
+exemption.
+
+## Migration: cold-start the learned thresholds
+
+`policy_engine._build_spawn_budget_policy_data` learns per-task-class thresholds
+from the distribution of historical `wasted_spawns`. Those observations were
+clean-audit counts — incomparable to the new signal. Mixing them would poison
+the baseline. Cold-start cleanly by **tagging the signal version**:
+
+* Retrospectives now carry `wasted_spawns_signal_version = 2`.
+* `_build_spawn_budget_policy_data` aggregates **only** retrospectives at the
+  current signal version; pre-migration retrospectives (no tag / v1) are skipped
+  for spawn-budget learning. The emitted policy is stamped `version: 2`.
+* Until a task class accumulates >= 3 v2 observations, it has no learned entry
+  and the `global_fallback` threshold (2) governs. With the new signal, count 2
+  means two findings each stuck in repair — a reasonable pause point.
+
+`circuit_breaker.WASTED_SPAWN_ABORT_THRESHOLD` (9) is unchanged in value; it now
+means nine non-converging repairs — still a valid hard-abort runaway guard.
+
+## Blast radius
+
+`hooks/ctl.py` (runtime counter), `hooks/lib_validate.py` (retrospective +
+helper), `memory/policy_engine.py` (cold-start filter), `hooks/circuit_breaker.py`
+(docs), plus test migration for `test_spawn_budget_policy.py`,
+`test_circuit_breaker.py`, and any suite asserting the clean-audit semantics.
+`wasted_spawns` stays an int on the retrospective and dashboard, so downstream
+KPI/dashboard consumers keep working — only its meaning changes.

--- a/hooks/circuit_breaker.py
+++ b/hooks/circuit_breaker.py
@@ -3,7 +3,7 @@
 Encodes runtime conditions under which a task should be hard-aborted or
 downgraded. Live-enforceable (EXECUTION) conditions:
 
-    1. wasted_spawns_abort       (>= 9 wasted spawns; via ctl.py check-spawn-budget)
+    1. wasted_spawns_abort       (>= 9 non-converging repairs; via ctl.py check-spawn-budget)
     2. small_task_token_overrun  (>= 9_371_185 tokens on a small bugfix/feature task)
     3. bugfix_token_overrun      (>= 68_283_719 tokens on a bugfix)
     4. small_task_token_downgrade  (>= 7_496_948 but < 9_371_185)
@@ -592,8 +592,8 @@ def _evaluate_execution(
             "abort": True,
             "trigger": "wasted_spawns_abort",
             "reason": (
-                "wasted spawn count reached the hard-abort threshold; "
-                "the task is burning tokens with no useful output."
+                "non-converging-repair count reached the hard-abort threshold; "
+                "repairs keep re-flagging findings without resolving them."
             ),
             "limit": WASTED_SPAWN_ABORT_THRESHOLD,
             "actual": wasted,

--- a/hooks/ctl.py
+++ b/hooks/ctl.py
@@ -1870,34 +1870,6 @@ def cmd_apply_auto_approve_veto(args: argparse.Namespace) -> int:
     return 0
 
 
-def _collect_ensemble_auditors(plan: object) -> set:
-    """Permissively collect auditor names marked ensemble:true from audit-plan.json.
-
-    Handles two common shapes:
-      - plan["auditors"] as list of dicts with "name" and "ensemble" fields
-      - top-level dict keyed by auditor name with "ensemble" field
-
-    Returns a set of auditor name strings. If the plan has no recognised
-    shape, returns an empty set (no dedup applied).
-    """
-    result: set[str] = set()
-    if not isinstance(plan, dict):
-        return result
-    # Shape 1: plan["auditors"] as list of dicts
-    auds = plan.get("auditors")
-    if isinstance(auds, list):
-        for a in auds:
-            if isinstance(a, dict) and a.get("ensemble") is True:
-                name = a.get("name")
-                if isinstance(name, str):
-                    result.add(name)
-    # Shape 2: top-level dict keyed by auditor name
-    for k, v in plan.items():
-        if isinstance(v, dict) and v.get("ensemble") is True:
-            result.add(k)
-    return result
-
-
 def compute_spawn_budget_status(
     task_dir: Path,
     manifest: dict,
@@ -1909,14 +1881,21 @@ def compute_spawn_budget_status(
      contributing_auditors} payload WITHOUT writing receipts or
     mutating manifest.
 
-    Same counting/dedup logic as the CLI command (AC-8a..AC-8e, AC-9).
-    Used by hooks/circuit_breaker.py to avoid the per-call subprocess
-    fork (perf-001 / residual 0fe95494). The CLI command wraps this
-    function and adds the side-effect branch for status=='paused'.
+    ``count`` is the number of non-converging repairs (findings the repair loop
+    keeps re-flagging: max retry_count >= 2), NOT the old clean-audit count. A
+    clean audit is a passing dimension, never waste. ``exempt_count`` is always
+    0 and ``contributing_auditors`` always empty — the ensemble-dedup and
+    exempt-auditor machinery that softened the clean-audit count retired with
+    it (kept in the payload for backward compatibility). Per-task-class learned
+    thresholds are honored only under a v2+ policy (cold-start guard). See
+    docs/spawn-budget-convergence-design.md.
 
-    ``project_root`` defaults to ``Path.cwd()`` to match the CLI
-    behavior; pass an explicit value when calling from a context where
-    cwd may be wrong.
+    Used by hooks/circuit_breaker.py to avoid the per-call subprocess fork
+    (perf-001 / residual 0fe95494). The CLI command wraps this function and
+    adds the side-effect branch for status=='paused'.
+
+    ``project_root`` defaults to ``Path.cwd()`` to match the CLI behavior; pass
+    an explicit value when calling from a context where cwd may be wrong.
     """
     from lib_core import _persistent_project_dir  # noqa: PLC0415
 
@@ -1945,13 +1924,6 @@ def compute_spawn_budget_status(
     if isinstance(ptc, dict):
         per_task_class = ptc
 
-    exempt_auditors: set[str] = set()
-    ea = policy.get("exempt_auditors")
-    if isinstance(ea, list):
-        for name in ea:
-            if isinstance(name, str):
-                exempt_auditors.add(name)
-
     classification = manifest.get("classification") or {}
     if isinstance(classification, dict):
         task_type = classification.get("type") or classification.get("task_type")
@@ -1963,64 +1935,36 @@ def compute_spawn_budget_status(
     else:
         task_class = "unknown:unknown"
 
+    # Cold-start guard: honor the learned per-task-class threshold only when the
+    # on-disk policy was computed under the CURRENT wasted_spawns signal (repair
+    # non-convergence). A stale v1 policy carries thresholds trained on the old
+    # clean-audit count and must not gate the new signal, so fall back to
+    # global_fallback until memory regenerates a v2 policy.
+    # See docs/spawn-budget-convergence-design.md.
+    from lib_validate import (  # noqa: PLC0415
+        WASTED_SPAWNS_SIGNAL_VERSION,
+        count_nonconverging_repairs,
+    )
+
+    policy_version = policy.get("version")
+    learned_ok = (
+        isinstance(policy_version, int)
+        and policy_version >= WASTED_SPAWNS_SIGNAL_VERSION
+    )
     task_class_policy = per_task_class.get(task_class)
-    if isinstance(task_class_policy, dict) and isinstance(task_class_policy.get("threshold_count"), int):
+    if (
+        learned_ok
+        and isinstance(task_class_policy, dict)
+        and isinstance(task_class_policy.get("threshold_count"), int)
+    ):
         threshold: int = task_class_policy["threshold_count"]
     else:
         threshold = global_fallback_threshold
 
-    ensemble_set: set[str] = set()
-    audit_plan_path = task_dir / "audit-plan.json"
-    try:
-        plan_raw = load_json(audit_plan_path)
-        ensemble_set = _collect_ensemble_auditors(plan_raw)
-    except Exception:
-        ensemble_set = set()
-
-    reports_dir = task_dir / "audit-reports"
-    all_reports: list[tuple[str, list, bool, Path, float]] = []
-    if reports_dir.is_dir():
-        for report_path in reports_dir.glob("*.json"):
-            try:
-                data = load_json(report_path)
-            except Exception:
-                continue
-            if not isinstance(data, dict):
-                continue
-            auditor = data.get("auditor")
-            findings = data.get("findings")
-            if not isinstance(auditor, str) or not isinstance(findings, list):
-                continue
-            is_wasted = (findings == [])
-            try:
-                mtime = report_path.stat().st_mtime
-            except OSError:
-                mtime = 0.0
-            all_reports.append((auditor, findings, is_wasted, report_path, mtime))
-
-    ensemble_by_auditor: dict[str, list[tuple[str, list, bool, Path, float]]] = {}
-    surviving_reports: list[tuple[str, list, bool, Path, float]] = []
-    for entry in all_reports:
-        auditor = entry[0]
-        if auditor in ensemble_set:
-            ensemble_by_auditor.setdefault(auditor, []).append(entry)
-        else:
-            surviving_reports.append(entry)
-    for auditor, entries in ensemble_by_auditor.items():
-        best = max(entries, key=lambda e: (e[4], e[3].name))
-        surviving_reports.append(best)
-
-    count: int = 0
-    exempt_count: int = 0
-    contributing_auditors: set[str] = set()
-    for auditor, _findings, is_wasted, _path, _mtime in surviving_reports:
-        if not is_wasted:
-            continue
-        if auditor in exempt_auditors:
-            exempt_count += 1
-        else:
-            count += 1
-            contributing_auditors.add(auditor)
+    # wasted_spawns := repair non-convergence — findings the repair loop keeps
+    # re-flagging — NOT clean audits. The ensemble-dedup and exempt-auditor
+    # machinery that once softened the clean-audit count retired with it.
+    count = count_nonconverging_repairs(task_dir)
 
     if manifest.get("blocked_reason") == "wasted_spawns_exceeded":
         status = "already_paused"
@@ -2033,9 +1977,9 @@ def compute_spawn_budget_status(
         "status": status,
         "count": count,
         "threshold": threshold,
-        "exempt_count": exempt_count,
+        "exempt_count": 0,
         "task_class": task_class,
-        "contributing_auditors": sorted(contributing_auditors),
+        "contributing_auditors": [],
     }
 
 
@@ -2043,9 +1987,10 @@ def cmd_check_spawn_budget(args: argparse.Namespace) -> int:
     """Check whether the current task has exhausted its wasted-spawn budget.
 
     Reads spawn-budget-policy.json from the persistent project dir, counts
-    wasted (empty-findings) audit reports with ensemble-cascade dedup, and
-    either emits status "ok" / "paused" / "already_paused" to stdout as
-    single-line JSON (exit 0), or exits 1 when manifest.json is missing.
+    non-converging repairs (findings the repair loop keeps re-flagging, from
+    repair-log.json), and either emits status "ok" / "paused" / "already_paused"
+    to stdout as single-line JSON (exit 0), or exits 1 when manifest.json is
+    missing.
 
     stdout: {"status": "ok"|"paused"|"already_paused", "count": <int>,
              "threshold": <int>, "exempt_count": <int>, "task_class": "<str>"}

--- a/hooks/lib_validate.py
+++ b/hooks/lib_validate.py
@@ -1182,6 +1182,57 @@ def compute_pipeline_budget(task_dir: Path) -> dict:
     }
 
 
+# A repair "converges" when the fix sticks. A finding whose retry_count reaches
+# this bound has been repaired and re-flagged repeatedly — the repair loop is
+# churning without resolving it. This is the genuine "wasted spawn" signal that
+# replaced the old (inverted) clean-audit count. Kept in lockstep with the
+# retry_count>=2 deep-tier escalation trigger in ctl build-repair-log.
+REPAIR_NONCONVERGENCE_RETRIES = 2
+
+# Bump when the wasted_spawns SIGNAL changes meaning, so the learning engine
+# cold-starts (see memory/policy_engine._build_spawn_budget_policy_data) instead
+# of mixing incomparable observations across the definition change.
+WASTED_SPAWNS_SIGNAL_VERSION = 2
+
+
+def count_nonconverging_repairs(task_dir: Path) -> int:
+    """Count distinct findings whose repair is not converging.
+
+    Reads repair-log.json and returns the number of finding_ids whose maximum
+    retry_count across all batches is >= REPAIR_NONCONVERGENCE_RETRIES — findings
+    repaired repeatedly that keep coming back. This is the genuine no-progress
+    signal that replaced the inverted "clean audit == wasted" count. Returns 0
+    when the repair log is absent or unreadable: a task that never needed repair
+    has, by definition, no non-converging repairs.
+    """
+    repair_log_path = task_dir / "repair-log.json"
+    if not repair_log_path.exists():
+        return 0
+    try:
+        repair_log = load_json(repair_log_path)
+    except Exception:
+        return 0
+    if not isinstance(repair_log, dict):
+        return 0
+    max_retry: dict[str, int] = {}
+    for batch in repair_log.get("batches", []) or []:
+        if not isinstance(batch, dict):
+            continue
+        for task in batch.get("tasks", []) or []:
+            if not isinstance(task, dict):
+                continue
+            fid = task.get("finding_id")
+            if not isinstance(fid, str) or not fid:
+                continue
+            try:
+                rc = int(task.get("retry_count", 0) or 0)
+            except (TypeError, ValueError):
+                rc = 0
+            if rc > max_retry.get(fid, -1):
+                max_retry[fid] = rc
+    return sum(1 for rc in max_retry.values() if rc >= REPAIR_NONCONVERGENCE_RETRIES)
+
+
 def compute_reward(task_dir: Path) -> dict:
     """Deterministically compute reward scores from task artifacts.
 
@@ -1622,15 +1673,11 @@ def compute_reward(task_dir: Path) -> dict:
         except OSError:
             pass
 
-    wasted_spawns = 0
-    if reports_dir.exists():
-        for report_path in sorted(reports_dir.glob("*.json")):
-            try:
-                report = load_json(report_path)
-                if len(report.get("findings", [])) == 0:
-                    wasted_spawns += 1
-            except (json.JSONDecodeError, OSError):
-                continue
+    # wasted_spawns := repair non-convergence, NOT clean audits. A clean audit
+    # is a passing dimension (the goal), never waste; the genuine no-progress
+    # signal is a finding the repair loop keeps re-flagging. See
+    # docs/spawn-budget-convergence-design.md.
+    wasted_spawns = count_nonconverging_repairs(task_dir)
 
     # --- 7. Reward vector ---
     # quality_score — only blocking findings affect quality.
@@ -1698,6 +1745,7 @@ def compute_reward(task_dir: Path) -> dict:
         "repair_cycle_count": repair_cycle_count,
         "subagent_spawn_count": subagent_spawn_count,
         "wasted_spawns": wasted_spawns,
+        "wasted_spawns_signal_version": WASTED_SPAWNS_SIGNAL_VERSION,
         "auditor_zero_finding_streaks": auditor_zero_finding_streaks,
         "executor_zero_repair_streak": executor_zero_repair_streak,
         "token_usage_by_agent": token_usage_by_agent,

--- a/memory/policy_engine.py
+++ b/memory/policy_engine.py
@@ -713,6 +713,14 @@ def _migrate_model_overrides(root: Path, model_policy_data: dict[str, dict]) -> 
     return merged
 
 
+# Current wasted_spawns signal version. Keep in lockstep with
+# hooks/lib_validate.WASTED_SPAWNS_SIGNAL_VERSION. When the signal's meaning
+# changes, only retrospectives stamped with the current version are aggregated,
+# so the learned thresholds cold-start instead of mixing incomparable
+# observations. See docs/spawn-budget-convergence-design.md.
+_WASTED_SPAWNS_SIGNAL_VERSION = 2
+
+
 def _build_spawn_budget_policy_data(retrospectives: list[dict]) -> dict:
     """Compute spawn-budget policy data from task retrospectives.
 
@@ -773,6 +781,13 @@ def _build_spawn_budget_policy_data(retrospectives: list[dict]) -> dict:
     grouped: dict[str, list[float]] = {}
     for retro in retrospectives:
         if not isinstance(retro, dict):
+            continue
+        # Cold-start guard: only aggregate observations recorded under the
+        # current wasted_spawns signal. Pre-migration retrospectives (missing
+        # the tag, or an older version) counted clean audits — incomparable to
+        # the repair-non-convergence signal — and are skipped here so the
+        # learned thresholds re-learn cleanly.
+        if retro.get("wasted_spawns_signal_version") != _WASTED_SPAWNS_SIGNAL_VERSION:
             continue
         task_type = retro.get("task_type")
         risk_level = retro.get("risk_level")
@@ -858,7 +873,7 @@ def _build_spawn_budget_policy_data(retrospectives: list[dict]) -> dict:
                 exempt.add(auditor_name)
 
     return {
-        "version": 1,
+        "version": _WASTED_SPAWNS_SIGNAL_VERSION,
         "computed_at": now_iso(),
         "per_task_class": per_task_class,
         "global_fallback": {"threshold_count": 2},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.12",
+  "version": "7.5.13",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -185,7 +185,7 @@ Before issuing each parallel auditor batch (this includes the first batch AND ev
 
 Parse the JSON output. The command emits a single-line JSON object with keys `status`, `count`, `threshold`, `exempt_count`, and `task_class`. If `status` is `'paused'` or `'already_paused'`:
 
-1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the auditor count, the threshold, the `task_class`, and instruct the operator to run `"$DYNOS" ctl spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why spawns were wasted.
+1. Write `escalation.md` in the task directory containing the full JSON output and a human-readable explanation that the spawn budget was exceeded — name the non-converging-repair `count`, the threshold, the `task_class`, and instruct the operator to run `"$DYNOS" ctl spawn-resume .dynos/task-{id} --reason "<≥20-char rationale>"` after diagnosing why repairs are not converging.
 2. Append a line beginning with `[BUDGET-PAUSE]` to `execution-log.md` that records the timestamp, count, and threshold.
 3. Exit non-zero.
 

--- a/tests/test_spawn_budget_policy.py
+++ b/tests/test_spawn_budget_policy.py
@@ -36,8 +36,15 @@ def _retro(
     *,
     computed_at: str = "2026-05-01T00:00:00Z",
     streaks: dict | None = None,
+    signal_version: int | None = 2,
 ) -> dict:
-    """Build a minimal retrospective dict for policy-engine tests."""
+    """Build a minimal retrospective dict for policy-engine tests.
+
+    signal_version stamps wasted_spawns_signal_version so the retro is
+    aggregated under the current signal; pass None to simulate a pre-migration
+    (clean-audit-era) retrospective that must be skipped by the cold-start
+    filter.
+    """
     r: dict = {
         "task_id": task_id,
         "task_type": task_type,
@@ -45,9 +52,27 @@ def _retro(
         "wasted_spawns": wasted_spawns,
         "computed_at": computed_at,
     }
+    if signal_version is not None:
+        r["wasted_spawns_signal_version"] = signal_version
     if streaks is not None:
         r["auditor_zero_finding_streaks"] = streaks
     return r
+
+
+def _write_repair_log(
+    task_dir: Path, n_nonconverging: int, *, retry_count: int = 2, converging: int = 0
+) -> Path:
+    """Write repair-log.json with `n_nonconverging` findings stuck in repair
+    (retry_count >= 2) plus optional converging findings (retry_count 1) that
+    must NOT count. This is the new wasted_spawns signal source."""
+    tasks: list[dict] = [
+        {"finding_id": f"F-stuck-{i}", "retry_count": retry_count}
+        for i in range(n_nonconverging)
+    ]
+    tasks += [{"finding_id": f"F-ok-{i}", "retry_count": 1} for i in range(converging)]
+    p = task_dir / "repair-log.json"
+    p.write_text(json.dumps({"repair_cycle": 1, "batches": [{"tasks": tasks}]}, indent=2))
+    return p
 
 
 def _make_task_dir(
@@ -106,11 +131,17 @@ def _write_spawn_budget_policy(
     per_task_class: dict | None = None,
     exempt_auditors: list | None = None,
     global_fallback_threshold: int = 2,
+    version: int = 2,
 ) -> None:
-    """Write spawn-budget-policy.json into the persistent dir."""
+    """Write spawn-budget-policy.json into the persistent dir.
+
+    version defaults to the current signal version (2) so learned per-task-class
+    thresholds are honored; pass version=1 to simulate a stale pre-migration
+    policy that the cold-start guard must ignore.
+    """
     persistent_dir.mkdir(parents=True, exist_ok=True)
     policy = {
-        "version": 1,
+        "version": version,
         "computed_at": "2026-05-06T00:00:00Z",
         "per_task_class": per_task_class or {},
         "global_fallback": {"threshold_count": global_fallback_threshold},
@@ -228,8 +259,9 @@ def test_check_spawn_budget_ok_under_threshold_cold_start(
     monkeypatch.chdir(tmp_path)
     task_dir = _make_task_dir(tmp_path)
 
-    # Write one wasted audit report (count=1 < threshold=2)
-    _write_audit_report(task_dir, "code-quality-auditor", [])
+    # One non-converging repair (count=1 < threshold=2); a converging finding
+    # must not count.
+    _write_repair_log(task_dir, 1, converging=2)
 
     args = argparse.Namespace(task_dir=str(task_dir))
     rc = ctl.cmd_check_spawn_budget(args)
@@ -263,10 +295,8 @@ def test_check_spawn_budget_paused_above_learned_threshold(
     )
 
     task_dir = _make_task_dir(tmp_path)
-    # Write 3 wasted reports => count=3 >= threshold=3
-    _write_audit_report(task_dir, "code-quality-auditor", [], filename="r1.json")
-    _write_audit_report(task_dir, "dead-code-auditor", [], filename="r2.json")
-    _write_audit_report(task_dir, "db-schema-auditor", [], filename="r3.json")
+    # 3 non-converging repairs => count=3 >= threshold=3
+    _write_repair_log(task_dir, 3)
 
     args = argparse.Namespace(task_dir=str(task_dir))
     rc = ctl.cmd_check_spawn_budget(args)
@@ -312,11 +342,8 @@ def test_check_spawn_budget_uses_global_fallback_threshold(
     )
 
     task_dir = _make_task_dir(tmp_path)
-    # 4 wasted reports — between the broken-default 2 and the configured 5.
-    for i in range(4):
-        _write_audit_report(
-            task_dir, f"auditor-{i}", [], filename=f"r{i}.json"
-        )
+    # 4 non-converging repairs — between the broken-default 2 and the configured 5.
+    _write_repair_log(task_dir, 4)
 
     args = argparse.Namespace(task_dir=str(task_dir))
     rc = ctl.cmd_check_spawn_budget(args)
@@ -329,124 +356,71 @@ def test_check_spawn_budget_uses_global_fallback_threshold(
     assert payload["status"] == "ok"
 
 
-def test_ensemble_cascade_final_tier_only_counted(tmp_path, monkeypatch, capsys):
-    """For ensemble auditors, only the final (highest mtime) report is counted.
-    Earlier reports are deduplicated away."""
-    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
+def test_converging_repairs_are_not_wasted(tmp_path, monkeypatch, capsys):
+    """A finding whose repair converges (retry_count < 2) is NOT wasted, so a
+    task whose repairs stick never trips the backstop."""
+    _set_dynos_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
-
-    # Policy: threshold 2 for feature:medium (learned)
-    persistent = _persistent_for_cwd(dynos_home)
-    _write_spawn_budget_policy(
-        persistent,
-        per_task_class={
-            "feature:medium": {
-                "threshold_count": 2,
-                "waste_count_baseline": 1.0,
-                "waste_count_stddev": 0.0,
-                "n_observations": 3,
-            }
-        },
-    )
-
     task_dir = _make_task_dir(tmp_path)
+    _write_repair_log(task_dir, 0, converging=5)
 
-    # Write audit-plan.json marking "vision-auditor" as ensemble
-    (task_dir / "audit-plan.json").write_text(
-        json.dumps({"auditors": [{"name": "vision-auditor", "ensemble": True}]})
-    )
-
-    # Two wasted reports for the same ensemble auditor (simulating cascade tiers)
-    # The final tier (r2.json) has findings, so it is NOT wasted -> count stays 0
-    reports_dir = task_dir / "audit-reports"
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    import time
-
-    p1 = reports_dir / "vision-auditor-r1.json"
-    p1.write_text(json.dumps({"auditor": "vision-auditor", "findings": []}))
-    time.sleep(0.01)  # ensure different mtime
-    p2 = reports_dir / "vision-auditor-r2.json"
-    p2.write_text(json.dumps({"auditor": "vision-auditor", "findings": ["finding"]}))
-
-    # One non-ensemble wasted report
-    _write_audit_report(task_dir, "dead-code-auditor", [], filename="dead-code.json")
-
-    args = argparse.Namespace(task_dir=str(task_dir))
-    rc = ctl.cmd_check_spawn_budget(args)
-    out = capsys.readouterr().out.strip()
+    rc = ctl.cmd_check_spawn_budget(argparse.Namespace(task_dir=str(task_dir)))
+    payload = json.loads(capsys.readouterr().out.strip())
     assert rc == 0
-    payload = json.loads(out)
-    # Only dead-code-auditor counts as wasted (count=1); vision-auditor's final
-    # report has findings so is not wasted after dedup
-    assert payload["count"] == 1
-    assert payload["status"] == "ok"
-
-
-def test_ensemble_cascade_succeeded_not_wasted(tmp_path, monkeypatch, capsys):
-    """An ensemble auditor whose final (latest mtime) report has findings is NOT
-    counted as wasted, even if earlier cascade tiers were empty."""
-    dynos_home = _set_dynos_home(monkeypatch, tmp_path)
-    monkeypatch.chdir(tmp_path)
-    persistent = _persistent_for_cwd(dynos_home)
-    _write_spawn_budget_policy(persistent)
-
-    task_dir = _make_task_dir(tmp_path)
-    (task_dir / "audit-plan.json").write_text(
-        json.dumps({"auditors": [{"name": "spec-auditor", "ensemble": True}]})
-    )
-
-    reports_dir = task_dir / "audit-reports"
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    import time
-
-    p1 = reports_dir / "spec-auditor-tier1.json"
-    p1.write_text(json.dumps({"auditor": "spec-auditor", "findings": []}))
-    time.sleep(0.01)
-    p2 = reports_dir / "spec-auditor-tier2.json"
-    p2.write_text(json.dumps({"auditor": "spec-auditor", "findings": ["real-finding"]}))
-
-    args = argparse.Namespace(task_dir=str(task_dir))
-    rc = ctl.cmd_check_spawn_budget(args)
-    out = capsys.readouterr().out.strip()
-    assert rc == 0
-    payload = json.loads(out)
     assert payload["count"] == 0
     assert payload["status"] == "ok"
 
 
-def test_exempt_auditor_not_counted(tmp_path, monkeypatch, capsys):
-    """Auditors listed in policy exempt_auditors are NOT counted toward the budget."""
+def test_clean_audits_no_longer_pause(tmp_path, monkeypatch, capsys):
+    """Regression for the inverted trigger: clean audit reports (empty findings)
+    must NOT count toward the backstop anymore — only repair non-convergence."""
+    _set_dynos_home(monkeypatch, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    task_dir = _make_task_dir(tmp_path)
+    # Several passing (clean) audit dimensions + no non-converging repairs.
+    for i in range(4):
+        _write_audit_report(task_dir, f"auditor-{i}", [], filename=f"r{i}.json")
+
+    rc = ctl.cmd_check_spawn_budget(argparse.Namespace(task_dir=str(task_dir)))
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert rc == 0
+    assert payload["count"] == 0
+    assert payload["status"] == "ok"
+
+
+def test_cold_start_ignores_pre_migration_retrospectives():
+    """The learning engine skips retrospectives recorded under the old signal
+    (no wasted_spawns_signal_version tag) so thresholds re-learn cleanly."""
+    retros = [
+        _retro("t1", "feature", "medium", 9, signal_version=None),
+        _retro("t2", "feature", "medium", 9, signal_version=None),
+        _retro("t3", "feature", "medium", 9, signal_version=None),
+    ]
+    policy = _build_spawn_budget_policy_data(retros)
+    assert policy["version"] == 2
+    assert "feature:medium" not in policy["per_task_class"]
+
+
+def test_stale_v1_policy_thresholds_are_ignored(tmp_path, monkeypatch, capsys):
+    """A stale v1 policy (thresholds trained on clean audits) must not gate the
+    new signal: the cold-start guard falls back to global_fallback."""
     dynos_home = _set_dynos_home(monkeypatch, tmp_path)
     monkeypatch.chdir(tmp_path)
-
     persistent = _persistent_for_cwd(dynos_home)
     _write_spawn_budget_policy(
         persistent,
-        per_task_class={
-            "feature:medium": {
-                "threshold_count": 2,
-                "waste_count_baseline": 1.0,
-                "waste_count_stddev": 0.0,
-                "n_observations": 3,
-            }
-        },
-        exempt_auditors=["vision-auditor"],
+        version=1,  # stale
+        per_task_class={"feature:medium": {"threshold_count": 2}},
+        global_fallback_threshold=5,
     )
-
     task_dir = _make_task_dir(tmp_path)
+    _write_repair_log(task_dir, 3)  # 3 >= stale-2 would pause; < fallback-5 => ok
 
-    # Two wasted reports: one exempt, one not
-    _write_audit_report(task_dir, "vision-auditor", [], filename="exempt.json")
-    _write_audit_report(task_dir, "dead-code-auditor", [], filename="nonexempt.json")
-
-    args = argparse.Namespace(task_dir=str(task_dir))
-    rc = ctl.cmd_check_spawn_budget(args)
-    out = capsys.readouterr().out.strip()
+    rc = ctl.cmd_check_spawn_budget(argparse.Namespace(task_dir=str(task_dir)))
+    payload = json.loads(capsys.readouterr().out.strip())
     assert rc == 0
-    payload = json.loads(out)
-    # Only dead-code-auditor counts (1 < threshold 2)
-    assert payload["count"] == 1
-    assert payload["exempt_count"] == 1
+    assert payload["threshold"] == 5  # global fallback, not the stale v1 value
+    assert payload["count"] == 3
     assert payload["status"] == "ok"
 
 


### PR DESCRIPTION
## Why

The spawn-budget backstop counted **clean audits as "wasted spawns"** (`len(findings) == 0`). A clean audit is a *passing dimension* — the goal, not waste. With a default threshold of 2, any healthy task whose two-plus audit dimensions passed marched into a hard `wasted_spawns_exceeded` pause that halted the task and required a human `ctl spawn-resume`. This re-bases the backstop so it fires only on **genuine non-convergence**.

## The new signal: repair non-convergence

`repair-log.json` already tracks per-finding `retry_count`, and `retry_count >= 2` already triggers deep-tier escalation. We reuse it:

> `wasted_spawns` := count of distinct findings whose max `retry_count >= 2` — findings the repair loop keeps re-flagging without resolving.

Defined once in `lib_validate.count_nonconverging_repairs` and used by **both** the runtime pause (`compute_spawn_budget_status`) and the retrospective, so the signal has a single definition. A task that never needed repair, or whose repairs stuck, scores 0.

## Removed

The **ensemble-cascade dedup** and **exempt-auditor** logic in `compute_spawn_budget_status` (and the now-dead `_collect_ensemble_auditors`) existed only to soften the clean-audit count. They retire with it. `compute_spawn_budget_status` shed ~147 lines; `exempt_count`/`contributing_auditors` stay in the payload (0 / empty) for backward compatibility.

## Cold-start (the key migration decision)

The learned per-task-class thresholds were trained on the *distribution of clean-audit counts* — incomparable to the new signal. Mixing them would poison the baseline. Cold-start cleanly by **tagging the signal version**:

- Retrospectives carry `wasted_spawns_signal_version = 2`.
- `policy_engine._build_spawn_budget_policy_data` aggregates **only** current-version observations (pre-migration retrospectives are skipped) and stamps the policy `version: 2`.
- `compute_spawn_budget_status` honors learned per-task-class thresholds **only** under a v2+ policy; otherwise it falls back to `global_fallback` (2) until the new signal re-learns.

**⚠️ Behavioral note for deploy:** existing learned spawn-budget thresholds effectively reset on deploy (the policy regenerates as v2 from new retrospectives), governed by `global_fallback = 2` in the interim. Intended and documented — flagging so the "disappearing thresholds" aren't a surprise.

`circuit_breaker.WASTED_SPAWN_ABORT_THRESHOLD` (9) is unchanged in value; it now counts non-converging repairs. Its **separate** deep-tier-audit-empty-findings arm is deliberately untouched (distinct mechanism, out of scope; its 32 tests pass unchanged).

## Testing

Migrated `test_spawn_budget_policy.py` to repair-log fixtures: deleted 3 tests for the removed ensemble/exempt machinery, added 4 (convergence-not-counted, clean-audits-no-longer-pause regression, cold-start filter skips old retros, stale-v1-policy ignored). Full suite: **2901 passed, 9 skipped, 0 failed.** Version → `7.5.13`.

Design: `docs/spawn-budget-convergence-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)