### PR TITLE
Consolidate orphan changelog entries; document CI-managed versioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "dynos-work",
       "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-      "version": "7.5.15",
+      "version": "7.5.16",
       "source": "./",
       "author": {
         "name": "dynos.fit",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynos-work",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs — calibrates to your project over time.",
-  "version": "7.5.15",
+  "version": "7.5.16",
   "author": {
     "name": "dynos.fit",
     "url": "https://dynos.fit"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.15",
+  "version": "7.5.16",
   "description": "Autonomous Software Foundry. Human-directed, tool-grounded, self-improving. Plans, executes, audits, repairs, and calibrates to your project over time.",
   "author": {
     "name": "dynos.fit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,92 +11,59 @@ and this project adheres to **Semantic Versioning**.
 
 ---
 
-## [7.5.17] - 2026-07-27
-### Fixed
-- `pytest tests/ debug-module/tests/` in a single process no longer fails.
-  124 debug-module tests were erroring with
-  `ImportError: cannot import name ... from 'lib'`.
-- Cause was a top-level module name collision, not test pollution:
-  `hooks/lib.py` (a re-export facade) and `debug-module/lib/` (a package)
-  shared the name `lib`. Both roots land on `sys.path` during a combined
-  run, and Python caches by name rather than by path — so once any `tests/`
-  case imported `lib`, `sys.modules["lib"]` was pinned to the facade and
-  every debug-module `from lib import <step>` resolved against the wrong
-  module. Either suite alone was unaffected, which is why it went unnoticed.
-- debug-module's internal package is renamed `lib` -> `debuglib` (42
-  references across 15 files). `hooks/lib.py` is untouched: it is a
-  backwards-compat facade whose whole purpose is that `import lib` keeps
-  working, so it is the wrong side to rename.
-
-### Added
-- Guard test (`tests/test_import_root_collisions.py`) asserting no two
-  import roots (`hooks/`, `memory/`, `debug-module/`) expose the same
-  top-level module name. Five pre-existing `hooks` <-> `memory` collisions
-  (`agent_generator`, `lib_qlearn`, `postmortem`, `postmortem_analysis`,
-  `postmortem_improve`) are frozen in a documented allowlist — they are
-  latent rather than active, since `hooks/` wins the path order and nothing
-  needs the `memory/` copy under those names — so a sixth fails the build.
-
----
-
 ## [7.5.16] - 2026-07-27
 ### Fixed
-- dynos-work commands no longer fire without the user typing them.
-  `/dynos-work:<command>` is the only invocation route. Command names are
-  unchanged — `/dynos-work:resume`, `/dynos-work:status`, and so on.
-- Root cause was not the slash namespace (the plugin prefix already supplies
-  that) but the two surfaces that invoke a skill *without* a typed command:
-  - **Skill descriptions.** A description is a trigger signal, and these were
-    written as capability advertisements. `resume` said "Use after session
-    restart or context compression", so restarting a session could fire it;
-    `status` matched any question about status; `init` matched project-setup
-    requests; `maintain` advertised that it periodically scans and opens pull
-    requests. All 21 descriptions (and their 20 template mirrors) now state
-    what the command does and scope invocation to the explicit
-    `/dynos-work:<name>` form. `memory` and `execution` additionally keep
-    their legitimate pipeline-invoked route. The `founder` command template,
-    which has no `skills/` counterpart, is covered too.
-  - **Agent prompts.** The same leak existed one level down: an agent
-    description like "Implements API routes, services, business logic, and
-    auth" reads as a standing offer, so the model could spawn an executor or
-    auditor spontaneously outside any dynos-work task — a stray executor
-    writes code. All 37 agents in `agents/` and their 34 mirrors under
-    `cli/assets/templates/base/agents/` now name the `/dynos-work:<command>`
-    that spawns them and forbid direct spawning.
-  - **The SessionStart hook.** `hooks/session-start` injected
-    "Use dynos-work start for new tasks." into every session — a standing
-    instruction to enter the pipeline whenever a request looked task-shaped.
-    It now states that commands are user-invoked only and that the pipeline
-    must never be entered on the agent's own initiative.
+- `CHANGELOG.md` had entries for 7.5.16 and 7.5.17 that no manifest ever
+  carried. All three changes in PR #236 shipped as a single release, 7.5.15 —
+  the Release Hygiene workflow computes one version per PR from the base ref,
+  so hand-written per-change bumps were normalized away while their changelog
+  entries survived as orphans. The three entries are merged into 7.5.15.
 
-### Added
-- Guard test (`tests/test_explicit_invocation_only.py`, 160 cases) covering
-  every invocable surface: each skill and command template names its typed
-  command and declares itself never auto-triggered; each agent names the
-  command that spawns it and forbids direct spawning; no description on
-  either surface contains auto-trigger phrasing ("use after", "runs
-  automatically", "periodically", "proactively", "whenever"); template
-  mirrors have not drifted; skill names stay bare so the command is singly
-  namespaced; and the SessionStart hook does not reintroduce the standing
-  invocation order.
+### Changed
+- `CLAUDE.md` release hygiene no longer instructs contributors to hand-edit
+  version fields. `.github/workflows/release-hygiene.yml` runs
+  `scripts/bump_version.py` on every PR, which derives the next version from
+  the base ref, writes all four manifests, and pushes a
+  `chore: update release metadata` commit to the PR branch. Following the old
+  instruction produced redundant edits that CI overwrote, a push rejection on
+  the next `git push`, and — when a PR bundled several changes — one changelog
+  entry per change instead of one per release.
 
 ---
 
-## [7.5.15] - 2026-07-25
+## [7.5.15] - 2026-07-27
+
+Three independent changes, shipped together.
+
 ### Added
-- Frontier tier (`TIER_FRONTIER` → `fable`) as a fourth rung above `deep` in
-  `lib_models.TIER_TO_MODEL`, plus `TIER_RANK` as the single authority for
+- **Frontier tier.** `TIER_FRONTIER` → `fable` as a fourth rung above `deep`
+  in `lib_models.TIER_TO_MODEL`, plus `TIER_RANK` as the single authority for
   tier ordering. Codex maps it to `None` like every other tier.
-- Role tier ceilings (`lib_models.ROLE_TIER_CEILINGS`, `max_tier_for_role`,
-  `clamp_model_to_role_ceiling`). `router.resolve_model` is now a thin wrapper
-  that clamps the inner selector's result, so no selection path — explicit
-  policy override, epsilon-greedy exploration, UCB winner, benchmark
-  selection, learned history, or default — can put an executor role above
-  `deep`. A clamp emits `router_model_ceiling_clamp` and preserves the
-  pre-clamp pick on `uncapped_model`.
+- **Role tier ceilings** (`lib_models.ROLE_TIER_CEILINGS`,
+  `max_tier_for_role`, `clamp_model_to_role_ceiling`). `router.resolve_model`
+  is now a thin wrapper that clamps the inner selector's result, so no
+  selection path — explicit policy override, epsilon-greedy exploration, UCB
+  winner, benchmark selection, learned history, or default — can put an
+  executor role above `deep`. A clamp emits `router_model_ceiling_clamp` and
+  preserves the pre-clamp pick on `uncapped_model`.
 - Guard test (`tests/test_tier_ceiling_invariant.py`) driving the ceiling
   through the production `resolve_model` entry point rather than asserting on
   constants.
+- Guard test (`tests/test_explicit_invocation_only.py`, 160 cases) covering
+  every invocable surface: each skill and command template names its typed
+  command and declares itself never auto-triggered; each agent names the
+  command that spawns it and forbids direct spawning; no description contains
+  auto-trigger phrasing ("use after", "runs automatically", "periodically",
+  "proactively", "whenever"); template mirrors have not drifted; skill names
+  stay bare so the command is singly namespaced; and the SessionStart hook
+  does not reintroduce the standing invocation order.
+- Guard test (`tests/test_import_root_collisions.py`) asserting no two import
+  roots (`hooks/`, `memory/`, `debug-module/`) expose the same top-level
+  module name. Five pre-existing `hooks` <-> `memory` collisions
+  (`agent_generator`, `lib_qlearn`, `postmortem`, `postmortem_analysis`,
+  `postmortem_improve`) are frozen in a documented allowlist — latent rather
+  than active, since `hooks/` wins the path order and nothing needs the
+  `memory/` copy under those names — so a sixth fails the build.
 
 ### Changed
 - `planning` default tier moves `balanced` → `frontier`; `agents/planning.md`
@@ -115,6 +82,48 @@ and this project adheres to **Semantic Versioning**.
   preserved.
 - `tests/test_model_literal_guard.py` regex extended with `fable`; without it
   the new literal could leak outside `lib_models.py` unnoticed.
+- debug-module's internal package renamed `lib` -> `debuglib` (42 references
+  across 15 files). `hooks/lib.py` is untouched: it is a backwards-compat
+  facade whose whole purpose is that `import lib` keeps working, so it is the
+  wrong side to rename.
+
+### Fixed
+- **dynos-work commands no longer fire without the user typing them.**
+  `/dynos-work:<command>` is the only invocation route; command names are
+  unchanged. The root cause was not the slash namespace (the plugin prefix
+  already supplies that) but the three surfaces that invoke a command
+  *without* a typed one:
+  - **Skill descriptions.** A description is a trigger signal, and these were
+    written as capability advertisements. `resume` said "Use after session
+    restart or context compression", so restarting a session could fire it;
+    `status` matched any question about status; `init` matched project-setup
+    requests; `maintain` advertised that it periodically scans and opens pull
+    requests. All 21 descriptions (and their 20 template mirrors) now state
+    what the command does and scope invocation to the explicit
+    `/dynos-work:<name>` form. `memory` and `execution` keep their legitimate
+    pipeline-invoked route. The `founder` command template, which has no
+    `skills/` counterpart, is covered too.
+  - **Agent prompts.** The same leak one level down: a description like
+    "Implements API routes, services, business logic, and auth" reads as a
+    standing offer, so the model could spawn an executor or auditor
+    spontaneously outside any dynos-work task — a stray executor writes code.
+    All 37 agents in `agents/` and their 34 mirrors under
+    `cli/assets/templates/base/agents/` now name the `/dynos-work:<command>`
+    that spawns them and forbid direct spawning.
+  - **The SessionStart hook.** `hooks/session-start` injected "Use dynos-work
+    start for new tasks." into every session — a standing instruction to enter
+    the pipeline whenever a request looked task-shaped. It now states that
+    commands are user-invoked only and that the pipeline must never be entered
+    on the agent's own initiative.
+- **`pytest tests/ debug-module/tests/` in a single process.** 124
+  debug-module tests were erroring with `ImportError: cannot import name ...
+  from 'lib'`. The cause was a top-level module name collision, not test
+  pollution: `hooks/lib.py` (a re-export facade) and `debug-module/lib/` (a
+  package) shared the name `lib`. Both roots land on `sys.path` during a
+  combined run, and Python caches by name rather than by path — so once any
+  `tests/` case imported `lib`, `sys.modules["lib"]` was pinned to the facade
+  and every debug-module `from lib import <step>` resolved against the wrong
+  module. Either suite alone was unaffected, which is why it went unnoticed.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,26 @@ Guidance for Claude Code and other Claude-based agents working in this repositor
 
 ## Release Hygiene
 
-Every PR or code update that changes dynos-work must include a tiny version bump and a changelog entry.
+Every PR that changes dynos-work ships as exactly one release. **The version number is computed by CI — do not edit it by hand.**
 
-- Current release line: `7.5.1`.
-- Use patch-style nightly increments for ordinary updates: `7.5.1` -> `7.5.2` -> `7.5.3`, and so on.
-- Update every plugin/package version field together:
-  - `package.json`
-  - `.claude-plugin/plugin.json`
-  - `.claude-plugin/marketplace.json`
-  - `.codex-plugin/plugin.json`
-- Add a matching entry to `CHANGELOG.md` for the new version before opening the PR.
-- Keep the changelog entry small but concrete: summarize the behavior change, fix, or maintenance work that justifies the version bump.
+### What CI does
 
-Do not open or prepare a PR with code changes while leaving the version and changelog unchanged.
+`.github/workflows/release-hygiene.yml` runs on every PR open, synchronize, reopen, and label change. It calls `scripts/bump_version.py`, which:
+
+- reads the current version from the PR's **base ref** (not from your branch),
+- applies one bump — `patch` by default, or `major`/`minor`/`none` if the PR carries a `release:major` / `release:minor` / `release:none` label,
+- writes the result to all four manifests (`package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`),
+- adds a stub `CHANGELOG.md` section only if no entry for that version exists,
+- and pushes a `chore: update release metadata` commit to your branch.
+
+It is idempotent: re-running produces the same version, so a PR gets one version no matter how many commits it contains.
+
+### What you do
+
+- **Write the `CHANGELOG.md` entry.** CI's stub is a fallback, not a substitute — it only records the PR title. Describe the behavior change, fix, or maintenance work concretely.
+- **Leave the four manifest version fields alone.** Hand-editing them is overwritten by CI, and the bot's push to your branch will reject your next `git push` until you rebase.
+- **One entry per PR, not per change.** If a PR bundles several logical changes, they still ship under one version. Writing an entry per change produces orphan entries for versions no manifest ever carried.
+
+If you need to know the version your PR will land as, it is the base branch's version plus one patch (or whatever your `release:*` label selects). `scripts/bump_version.py` has no dry-run mode — it writes the manifests in place — so read the number off `git show origin/main:package.json` rather than running the script to find out.
+
+Do not open or prepare a PR with code changes while leaving `CHANGELOG.md` unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynos-work",
-  "version": "7.5.15",
+  "version": "7.5.16",
   "description": "Autonomous Software Foundry. Self-learning, human-directed. Standalone — no dependencies required.",
   "license": "MIT",
   "skills": "./skills/",


### PR DESCRIPTION
Two documentation fixes, both fallout from `CLAUDE.md` contradicting the release automation. No code changes; `3291` tests pass and `check_release_hygiene.py` returns ok.

## 1. Orphan changelog entries

`CHANGELOG.md` on `main` had entries for **7.5.16** and **7.5.17** that no manifest ever carried. All three changes in #236 shipped as a single release, **7.5.15**.

The Release Hygiene workflow computes one version per PR from the base ref, so the hand-written per-change bumps were normalized away — correctly — while their changelog entries survived. The three entries are merged into a single 7.5.15 entry, organized `Added` / `Changed` / `Fixed`, with all substance preserved and the three changes kept legible. Dated `2026-07-27`, the day it actually merged, rather than the day the first entry was drafted.

## 2. `CLAUDE.md` release hygiene was stale

The section instructed contributors to hand-edit all four manifest version fields before opening a PR. That instruction is what produced the orphan entries above, and it has a second cost: the workflow pushes a `chore: update release metadata` commit to the PR branch, so a contributor who follows it also hits a rejected `git push` and has to rebase.

It now describes what actually happens:

- **CI does** — derives the next version from the PR's base ref (not your branch), applies one bump (`patch` by default, or per a `release:major` / `release:minor` / `release:none` label), writes all four manifests, adds a stub changelog section only if none exists, and pushes to your branch. Idempotent, so one version per PR regardless of commit count.
- **You do** — write the changelog entry (CI's stub only records the PR title), leave the manifest versions alone, and write **one entry per PR, not per change**.

It also notes that `scripts/bump_version.py` has no dry-run mode — it writes the manifests in place — so the way to find out your target version is `git show origin/main:package.json`, not running the script.

## Note

**This PR deliberately does not touch any manifest version.** That is the behavior it documents; CI will set it. If the reviewer sees no version change in the diff, that is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
